### PR TITLE
Add a discussion template for script requests

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/request-script.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-script.yml
@@ -1,0 +1,35 @@
+title: "[Script request] "
+labels: ["enhancement"]
+body:
+- type: input
+  attributes:
+    label: Application Name
+    description: Enter the application name.
+    placeholder: "e.g., Home Assistant"
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Website
+    description: Official website or github page.
+    placeholder: "e.g., https://www.home-assistant.io/"
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Description
+    description: Explain what the application does and why it should be added to Proxmox VE Helper-Scripts.
+    placeholder: "e.g., Home Assistant is a popular open-source platform that brings all your smart home devices together in one place. Adding it to Proxmox VE Helper-Scripts would make setup and management on Proxmox easy, letting users quickly get a powerful, self-hosted smart home system up and running."
+  validations:
+    required: true
+- type: checkboxes
+  attributes:
+    label: Due Diligence
+    options:
+      - label: "I have searched existing [scripts](https://community-scripts.github.io/Proxmox/scripts) and found no duplicates."
+        required: true
+      - label: "I have searched existing [discussions](https://github.com/community-scripts/ProxmoxVE/discussions?discussions_q=) and found no duplicate requests."
+        required: true
+- type: markdown
+  attributes:
+    value: "Thanks for submitting your request! The team will review it and reach out if we need more information."

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 > [!NOTE]
-I am meticulous when it comes to merging code into the main branch, so please understand that I may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.
+We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.
 
 ## Description
 


### PR DESCRIPTION
> [!NOTE]
I am meticulous when it comes to merging code into the main branch, so please understand that I may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Fixes https://github.com/community-scripts/ProxmoxVE/discussions/6

Add template for script requests in discussions. **New discussion category "Request script" must be added by a repo owner first (see third screenshot).**

Default form:

![default_form](https://github.com/user-attachments/assets/6430d0b1-8209-4623-8772-8e4a57b6f6b5)

Opened discussion:

![request_script_open](https://github.com/user-attachments/assets/faafa87d-de63-45e7-84cb-d6d5f719c7cf)

Create new discussion category:

![request_script](https://github.com/user-attachments/assets/b6055869-a8eb-48da-8d3e-0ef8093b66a9)

## Type of change

Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)

