### PR TITLE
New YunoHost 12 Release

### DIFF
--- a/ct/yunohost.sh
+++ b/ct/yunohost.sh
@@ -23,7 +23,7 @@ var_disk="20"
 var_cpu="2"
 var_ram="2048"
 var_os="debian"
-var_version="11"
+var_version="12"
 variables
 color
 catch_errors


### PR DESCRIPTION
## Description
Updated debian 11 to 12 based on: https://yunohost.org/es/install/hardware:vps_debian#pre-requisites *
Still more RAM and storage to avoid reaching the limit quickly.

