### PR TITLE
Inverted the check for tteck repo, so it exits on the correct condition

### DIFF
--- a/misc/update-repo.sh
+++ b/misc/update-repo.sh
@@ -37,7 +37,7 @@ function update_container() {
     if pct exec "$container" -- [ -e /usr/bin/update ]; then
       if pct exec "$container" -- grep -q "community-scripts/ProxmoxVE" /usr/bin/update; then
         echo -e "${RD}[No Change]${CL} /usr/bin/update is already up to date in ${BL}$container${CL}.\n"
-      elif pct exec "$container" -- grep -q "tteck" /usr/bin/update; then
+      elif pct exec "$container" -- grep -q -v "tteck" /usr/bin/update; then
         echo -e "${RD}[Warning]${CL} /usr/bin/update in ${BL}$container${CL} contains a different entry (${RD}tteck${CL}). No changes made.\n"
       else
         pct exec "$container" -- bash -c "sed -i 's/tteck\\/Proxmox/community-scripts\\/ProxmoxVE/g' /usr/bin/update"


### PR DESCRIPTION
## Description

The inverted grep is looking to see if the update script does NOT contain "tteck". Grep therefor needs the argument -v (invert match)

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [ ] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)

## Additional Information (optional)

Reported on discord. I ran the script and noticed the same problem on a proxmox server that had not been updated.

Fix tested on Proxmox 8.2.7. The script ran without error and updated.
