### PR TITLE
Outdated: Add JSON Documents for Each Script

### DIFF
--- a/json/actualbudget.json
+++ b/json/actualbudget.json
@@ -1,0 +1,34 @@
+{
+    "name": "Actual Budget",
+    "slug": "actualbudget",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5006",
+    "documentation": "",
+    "website": "https://actualbudget.org/",
+    "logo": "https://raw.githubusercontent.com/actualbudget/actual/master/packages/desktop-client/public/maskable-512x512.png",
+    "description": "Actual Budget is a super fast and privacy-focused app for managing your finances. At its heart is the well proven and much loved Envelope Budgeting methodology.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/actualbudget.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/add-netbird-lxc.json
+++ b/json/add-netbird-lxc.json
@@ -1,0 +1,41 @@
+{
+    "name": "NetBird",
+    "slug": "add-netbird-lxc",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-19",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://docs.netbird.io/",
+    "website": "https://netbird.io/",
+    "logo": "https://avatars.githubusercontent.com/u/100464677?s=400&v=4",
+    "description": "NetBird combines a configuration-free peer-to-peer private network and a centralized access control system in a single platform, making it easy to create secure private networks for your organization or home.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/add-netbird-lxc.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "After the script finishes, reboot the LXC then run `netbird up` in the LXC console"
+        },
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/add-tailscale-lxc.json
+++ b/json/add-tailscale-lxc.json
@@ -1,0 +1,41 @@
+{
+    "name": "Tailscale",
+    "slug": "add-tailscale-lxc",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://tailscale.com/",
+    "logo": "https://avatars.githubusercontent.com/u/48932923?v=4&s=100",
+    "description": "Tailscale is a software-defined networking solution that enables secure communication between devices over the internet. It creates a virtual private network (VPN) that enables devices to communicate with each other as if they were on the same local network. Tailscale works even when the devices are separated by firewalls or subnets, and provides secure and encrypted communication between devices. With Tailscale, users can connect devices, servers, computers, and cloud instances to create a secure network, making it easier to manage and control access to resources. Tailscale is designed to be easy to set up and use, providing a streamlined solution for secure communication between devices over the internet.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/add-tailscale-lxc.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "After the script finishes, reboot the LXC then run `tailscale up` in the LXC console"
+        },
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/adguard.json
+++ b/json/adguard.json
@@ -1,0 +1,34 @@
+{
+    "name": "AdGuard Home",
+    "slug": "adguard",
+    "categories": [
+        "AdBlocker - DNS"
+    ],
+    "date_created": "2024-04-28",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started",
+    "website": "https://adguard.com/en/adguard-home/overview.html",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/adguard/icon.png",
+    "description": "AdGuard Home is an open-source, self-hosted network-wide ad blocker. It blocks advertisements, trackers, phishing and malware websites, and provides protection against online threats. AdGuard Home is a DNS-based solution, which means it blocks ads and malicious content at the network level, before it even reaches your device. It runs on your home network and can be easily configured and managed through a web-based interface. It provides detailed statistics and logs, allowing you to see which websites are being blocked, and why. AdGuard Home is designed to be fast, lightweight, and easy to use, making it an ideal solution for home users who want to block ads, protect their privacy, and improve the speed and security of their online experience.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/adguard.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/adventurelog.json
+++ b/json/adventurelog.json
@@ -1,0 +1,34 @@
+{
+    "name": "AdventureLog",
+    "slug": "adventurelog",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-26",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://adventurelog.app/",
+    "logo": "https://raw.githubusercontent.com/seanmorley15/AdventureLog/refs/heads/main/documentation/static/img/favicon.png",
+    "description": "Adventure Log is an app designed to track outdoor activities and personal achievements, allowing users to log their adventures with photos, notes, and location data. It focuses on enhancing outdoor experiences by preserving memories and sharing them with others.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/adventurelog.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "7",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/agentdvr.json
+++ b/json/agentdvr.json
@@ -1,0 +1,34 @@
+{
+    "name": "AgentDVR",
+    "slug": "agentdvr",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 1,
+    "interface_port": "8090",
+    "documentation": "",
+    "website": "https://www.ispyconnect.com/",
+    "logo": "https://ispycontent.azureedge.net/img/ispy2.png?raw=true",
+    "description": "AgentDVR a new video surveillance solution for the Internet Of Things.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/agentdvr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/all-templates.json
+++ b/json/all-templates.json
@@ -1,0 +1,38 @@
+{
+    "name": "All Templates",
+    "slug": "all-templates",
+    "categories": [
+        "TurnKey"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/proxmox.svg",
+    "description": "A script designed to allow for the creation of one of the many free LXC templates. Great for creating system LXCs.\r\nThe script creates a `*.creds` file in the Proxmox root directory with the password of the newly created LXC.\r\nPlease take note that if you plan to use this script for creating TurnKey LXCs, you'll need to modify the hostname after creation.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/all-templates.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Resource and network settings are adjustable post LXC creation."
+        }
+    ]
+}

--- a/json/alpine.json
+++ b/json/alpine.json
@@ -1,0 +1,34 @@
+{
+    "name": "Alpine",
+    "slug": "alpine",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.alpinelinux.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/alpinelinux.svg",
+    "description": "A security-oriented, lightweight Linux distribution based on musl and BusyBox.\r\nBy default, the root password is set to alpine. If you choose to use advanced settings, you will need to define a password, autologin is currently unavailable.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/alpine.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "0.1",
+                "os": "alpine",
+                "version": "3.19"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": "alpine"
+    },
+    "alerts": []
+}

--- a/json/apache-cassandra.json
+++ b/json/apache-cassandra.json
@@ -1,0 +1,38 @@
+{
+    "name": "Apache-Cassandra",
+    "slug": "apache-cassandra",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://cassandra.apache.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/apachecassandra.svg",
+    "description": "Apache-Cassandra is an open source NoSQL distributed database trusted by thousands of companies for scalability and high availability without compromising performance.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/apache-cassandra.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Apache-Cassandra Configuration: `nano /etc/cassandra/cassandra.yaml`"
+        }
+    ]
+}

--- a/json/apache-couchdb.json
+++ b/json/apache-couchdb.json
@@ -1,0 +1,38 @@
+{
+    "name": "Apache-CouchDB",
+    "slug": "apache-couchdb",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5984",
+    "documentation": "",
+    "website": "https://couchdb.apache.org/",
+    "logo": "https://couchdb.apache.org/image/couch@2x.png",
+    "description": "Apache-CouchDB Seamless multi-master sync, that scales from Big Data to Mobile, with an Intuitive HTTP/JSON API and designed for Reliability.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/apache-couchdb.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "4096",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Show Login Credentials: `cat CouchDB.creds`"
+        }
+    ]
+}

--- a/json/apt-cacher-ng.json
+++ b/json/apt-cacher-ng.json
@@ -1,0 +1,34 @@
+{
+    "name": "Apt-Cacher-NG",
+    "slug": "apt-cacher-ng",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3142",
+    "documentation": "",
+    "website": "https://www.unix-ag.uni-kl.de/~bloch/acng/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/linux.svg",
+    "description": "Apt-Cacher-NG is a caching proxy. Specialized for package files from Linux distributors, primarily for Debian (and Debian based) distributions.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/apt-cacher-ng.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/archivebox.json
+++ b/json/archivebox.json
@@ -1,0 +1,34 @@
+{
+    "name": "ArchiveBox",
+    "slug": "archivebox",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-19",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://archivebox.io/",
+    "logo": "https://raw.githubusercontent.com/ArchiveBox/ArchiveBox/refs/heads/dev/website/icon.png",
+    "description": "ArchiveBox is an open source tool that lets organizations & individuals archive both public & private web content while retaining control over their data. It can be used to save copies of bookmarks, preserve evidence for legal cases, backup photos from FB/Insta/Flickr or media from YT/Soundcloud/etc., save research papers, and more...",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/archivebox.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "archivebox",
+        "password": "helper-scripts.com"
+    },
+    "alerts": []
+}

--- a/json/aria2.json
+++ b/json/aria2.json
@@ -1,0 +1,38 @@
+{
+    "name": "Aria2",
+    "slug": "aria2",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "6880",
+    "documentation": "",
+    "website": "https://aria2.github.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/linux.svg",
+    "description": "Aria2 is a lightweight multi-protocol & multi-source, cross platform download utility operated in command-line. It supports HTTP/HTTPS, FTP, SFTP, BitTorrent and Metalink.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/aria2.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1028",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Within the LXC console, run `cat rpc.secret` to display the rpc-secret. Copy this token and paste it into the Aria2 RPC Secret Token box within the AriaNG Settings. Then, click the reload AriaNG button."
+        }
+    ]
+}

--- a/json/audiobookshelf.json
+++ b/json/audiobookshelf.json
@@ -1,0 +1,34 @@
+{
+    "name": "Audiobookshelf",
+    "slug": "audiobookshelf",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "13378",
+    "documentation": "",
+    "website": "https://www.audiobookshelf.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/audiobookshelf.svg",
+    "description": "Audiobookshelf is a Self-hosted audiobook and podcast server.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/audiobookshelf.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/autobrr.json
+++ b/json/autobrr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Autobrr",
+    "slug": "autobrr",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7474",
+    "documentation": "",
+    "website": "https://autobrr.com/",
+    "logo": "https://raw.githubusercontent.com/autobrr/autobrr/master/.github/images/logo.png",
+    "description": "Autobrr is a torrent downloading tool that automates the process of downloading torrents. It is designed to be modern and user-friendly, providing users with a convenient and efficient way to download torrent files. With Autobrr, you can schedule and manage your torrent downloads, and have the ability to automatically download torrents based on certain conditions, such as time of day or availability of seeds. This can save you time and effort, allowing you to focus on other tasks while your torrents are being downloaded in the background.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/autobrr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/bazarr.json
+++ b/json/bazarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Bazarr",
+    "slug": "bazarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "6767",
+    "documentation": "",
+    "website": "https://www.bazarr.media/",
+    "logo": "https://www.bazarr.media/assets/img/logo.png",
+    "description": "Bazarr is a companion application to Sonarr and Radarr that manages and downloads subtitles based on your requirements.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/bazarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/blocky.json
+++ b/json/blocky.json
@@ -1,0 +1,38 @@
+{
+    "name": "Blocky",
+    "slug": "blocky",
+    "categories": [
+        "AdBlocker - DNS"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "4000",
+    "documentation": "",
+    "website": "https://0xerr0r.github.io/blocky/",
+    "logo": "https://raw.githubusercontent.com/0xERR0R/blocky/main/docs/blocky.svg",
+    "description": "Blocky is a software tool designed for blocking unwanted ads and trackers on local networks. It functions as a DNS proxy and runs on the Go programming language. Blocky intercepts requests to advertisements and other unwanted content and blocks them before they reach the end user. This results in a cleaner, faster, and more secure online experience for users connected to the local network. Blocky is open-source, easy to configure and can be run on a variety of devices, making it a versatile solution for small to medium-sized local networks.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/blocky.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Blocky Configuration Path: `/opt/blocky/config.yml`"
+        }
+    ]
+}

--- a/json/bunkerweb.json
+++ b/json/bunkerweb.json
@@ -1,0 +1,34 @@
+{
+    "name": "BunkerWeb",
+    "slug": "bunkerweb",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.bunkerweb.io/",
+    "logo": "https://raw.githubusercontent.com/bunkerity/bunkerweb/v1.5.7/misc/logo.png",
+    "description": "BunkerWeb is a security-focused web server that enhances web application protection. It guards against common web vulnerabilities like SQL injection, XSS, and CSRF. It features simple setup and configuration using a YAML file, customizable security rules, and provides detailed logs for traffic monitoring and threat detection.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/bunkerweb.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/caddy.json
+++ b/json/caddy.json
@@ -1,0 +1,34 @@
+{
+    "name": "Caddy",
+    "slug": "caddy",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-11",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "https://caddyserver.com/docs/",
+    "website": "https://caddyserver.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/caddy.svg",
+    "description": "Caddy is a powerful, extensible platform to serve your sites, services, and apps, written in Go.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/caddy.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/calibre-web.json
+++ b/json/calibre-web.json
@@ -1,0 +1,38 @@
+{
+    "name": "Calibre-Web",
+    "slug": "calibre-web",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8083",
+    "documentation": "",
+    "website": "https://github.com/janeczku/calibre-web",
+    "logo": "https://sasquatters.com/media/2017/04/Calibre-web-banner-768x512.jpg",
+    "description": "Calibre-Web is a web app for browsing, reading and downloading eBooks stored in a Calibre database.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/calibre-web.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin123"
+    },
+    "alerts": [
+        {
+            "alert": "Add Calibre-Web Extras via `update`"
+        }
+    ]
+}

--- a/json/casaos.json
+++ b/json/casaos.json
@@ -1,0 +1,34 @@
+{
+    "name": "CasaOS",
+    "slug": "casaos",
+    "categories": [
+        "Docker - Kubernetes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://www.casaos.io/",
+    "logo": "https://wiki.casaos.io/_assets/casaos-no-text.svg",
+    "description": "CasaOS is a software that aims to make it easy for users to create a personal cloud system at home. It uses the Docker ecosystem to provide a simple, user-friendly experience for managing various applications and services.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/casaos.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/changedetection.json
+++ b/json/changedetection.json
@@ -1,0 +1,34 @@
+{
+    "name": "Change Detection",
+    "slug": "changedetection",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://changedetection.io/",
+    "logo": "https://github.com/dgtlmoon/changedetection.io/blob/master/changedetectionio/static/images/avatar-256x256.png?raw=true",
+    "description": "Change Detection is a service that allows you to monitor changes to web pages and receive notifications when changes occur. It can be used for a variety of purposes such as keeping track of online price changes, monitoring news websites for updates, or tracking changes to online forums.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/changedetection.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/channels.json
+++ b/json/channels.json
@@ -1,0 +1,34 @@
+{
+    "name": "Channels DVR Server",
+    "slug": "channels",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 1,
+    "interface_port": "8089",
+    "documentation": "",
+    "website": "https://getchannels.com/dvr-server/",
+    "logo": "https://getchannels.com/a/images/channels-logo.svg",
+    "description": "Channels DVR Server runs on your computer or NAS device at home. There's no cloud to worry about. Your tv shows and movies will always be available.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/channels.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/clean-lxcs.json
+++ b/json/clean-lxcs.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE LXC Cleaner",
+    "slug": "clean-lxcs",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/lxc.svg",
+    "description": "This script provides options to delete logs and cache, and repopulate apt lists for Ubuntu and Debian systems.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/clean-lxcs.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/cloudflared.json
+++ b/json/cloudflared.json
@@ -1,0 +1,34 @@
+{
+    "name": "Cloudflared",
+    "slug": "cloudflared",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.cloudflare.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/cloudflare.svg",
+    "description": "Cloudflared is a command-line tool that allows you to securely access resources on the Cloudflare network, such as websites and APIs, from your local computer. It works by creating a secure tunnel between your computer and the Cloudflare network, allowing you to access resources as if they were on your local network.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/cloudflared.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/cockpit.json
+++ b/json/cockpit.json
@@ -1,0 +1,38 @@
+{
+    "name": "Cockpit",
+    "slug": "cockpit",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-10-20",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "9090",
+    "documentation": "",
+    "website": "https://cockpit-project.org/",
+    "logo": "https://i0.wp.com/easycode.page/wp-content/uploads/2021/10/cockpit.png?fit=400%2C400&ssl=1",
+    "description": "Cockpit is a web-based graphical interface for managing Linux servers. It allows users to perform tasks like configuring networks, managing storage, and monitoring system performance directly through a web browser. It integrates with existing system tools, making it suitable for both beginners and experienced admins.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/cockpit.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Set a root password if using autologin. This will be the Cockpit password.`sudo passwd root`"
+        }
+    ]
+}

--- a/json/code-server.json
+++ b/json/code-server.json
@@ -1,0 +1,38 @@
+{
+    "name": "VS Code Server",
+    "slug": "code-server",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8680",
+    "documentation": "",
+    "website": "",
+    "logo": "https://user-images.githubusercontent.com/674621/71187801-14e60a80-2280-11ea-94c9-e56576f76baf.png",
+    "description": "VS Code Server is a service you can run on a remote development machine, like your desktop PC or a virtual machine (VM). It allows you to securely connect to that remote machine from anywhere through a vscode.dev URL, without the requirement of SSH.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/code-server.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within an existing LXC Console"
+        }
+    ]
+}

--- a/json/collabora-online.json
+++ b/json/collabora-online.json
@@ -1,0 +1,32 @@
+{
+    "name": "Collabora Online",
+    "slug": "collabora-online",
+    "categories": [],
+    "date_created": "2024-09-05",
+    "type": "LXC",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "9980",
+    "documentation": "",
+    "website": "https://www.collaboraonline.com/collabora-online/",
+    "logo": "https://wiki.calculate-linux.org/download_images/original/collabora-logo.png",
+    "description": "Collabora Online is a cloud-based office suite that enables real-time collaboration on documents, spreadsheets, and presentations. It supports multiple formats and integrates with platforms like Nextcloud and SharePoint",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "bash -c \"$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/collabora-online.sh)\"",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/collabora.json
+++ b/json/collabora.json
@@ -1,0 +1,32 @@
+{
+    "name": "Collabora Online",
+    "slug": "collabora-online",
+    "categories": [],
+    "date_created": "2024-09-05",
+    "type": "LXC",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "9980",
+    "documentation": "",
+    "website": "https://www.collaboraonline.com/collabora-online/",
+    "logo": "https://wiki.calculate-linux.org/download_images/original/collabora-logo.png",
+    "description": "Collabora Online is a cloud-based office suite that enables real-time collaboration on documents, spreadsheets, and presentations. It supports multiple formats and integrates with platforms like Nextcloud and SharePoint",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "bash -c \"$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/collabora-online.sh)\"",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/commafeed.json
+++ b/json/commafeed.json
@@ -1,0 +1,34 @@
+{
+    "name": "CommaFeed",
+    "slug": "commafeed",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8082",
+    "documentation": "",
+    "website": "https://www.commafeed.com/",
+    "logo": "https://raw.githubusercontent.com/Athou/commafeed/master/commafeed-client/public/app-icon-144.png",
+    "description": "CommaFeed is a Google Reader inspired self-hosted RSS reader.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/commafeed.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/cron-update-lxcs.json
+++ b/json/cron-update-lxcs.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Cron LXC Updater",
+    "slug": "cron-update-lxcs",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/lxc.svg",
+    "description": "This script will add/remove a crontab schedule that updates all LXCs every Sunday at midnight.\r\nTo exclude LXCs from updating, edit crontab (crontab -e) and add CTID as shown in the example below:",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/cron-update-lxcs.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/cronicle.json
+++ b/json/cronicle.json
@@ -1,0 +1,41 @@
+{
+    "name": "Cronicle Primary",
+    "slug": "cronicle",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3012",
+    "documentation": "",
+    "website": "https://github.com/jhuckaby/Cronicle",
+    "logo": "https://github.com/jhuckaby/Cronicle/blob/master/htdocs/images/logo-128.png?raw=true",
+    "description": "Cronicle is a task scheduling and management software that allows users to schedule and run tasks automatically on multiple servers. It has a web-based user interface that provides a convenient and centralized way to manage tasks and view their execution status. With Cronicle, users can schedule tasks to run at specific times, or on demand, and assign tasks to specific worker servers. The software provides real-time statistics and a live log viewer to help users monitor the progress of tasks. Cronicle is designed for use in large-scale environments, making it a valuable tool for automation and management of complex and time-sensitive tasks.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/cronicle.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Primary and Worker Private Keys Must Match."
+        },
+        {
+            "alert": "Configuration Path: `/opt/cronicle/conf/config.json`"
+        }
+    ]
+}

--- a/json/crowdsec.json
+++ b/json/crowdsec.json
@@ -1,0 +1,38 @@
+{
+    "name": "CrowdSec",
+    "slug": "crowdsec",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://crowdsec.net/",
+    "logo": "https://raw.githubusercontent.com/crowdsecurity/crowdsec-docs/main/crowdsec-docs/static/img/crowdsec_no_txt.png?raw=true",
+    "description": "CrowdSec is a free and open-source intrusion prevention system (IPS) designed to provide network security against malicious traffic. It is a collaborative IPS that analyzes behaviors and responses to attacks by sharing signals across a community of users. CrowdSec leverages the collective intelligence of its users to detect and respond to security threats in real-time. With CrowdSec, network administrators can set up protection against a wide range of threats, including malicious traffic, bots, and denial-of-service (DoS) attacks. The software is designed to be easy to use and integrate with existing security systems, making it a valuable tool for enhancing the security of any network.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/crowdsec.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within an existing LXC Console"
+        }
+    ]
+}

--- a/json/daemonsync.json
+++ b/json/daemonsync.json
@@ -1,0 +1,34 @@
+{
+    "name": "Daemon Sync Server",
+    "slug": "daemonsync",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8084",
+    "documentation": "",
+    "website": "",
+    "logo": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimg.informer.com%2Ficons_mac%2Fpng%2F128%2F350%2F350335.png&f=1&nofb=1",
+    "description": "Sync files from app to server, share photos & videos, back up your data and stay secure inside local network.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/daemonsync.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/dashy.json
+++ b/json/dashy.json
@@ -1,0 +1,34 @@
+{
+    "name": "Dashy",
+    "slug": "dashy",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "4000",
+    "documentation": "",
+    "website": "https://dashy.to/",
+    "logo": "https://github.com/Lissy93/dashy/raw/master/public/web-icons/dashy-logo.png",
+    "description": "Dashy is a solution that helps you organize your self-hosted services by centralizing access to them through a single interface.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/dashy.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/debian-vm.json
+++ b/json/debian-vm.json
@@ -1,0 +1,34 @@
+{
+    "name": "Debian 12",
+    "slug": "debian-vm",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.debian.org/",
+    "logo": "https://seeklogo.com/images/D/debian-logo-C136FDAF9E-seeklogo.com.png",
+    "description": "Debian Linux is a distribution that emphasizes free software. It supports many hardware platforms",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/debian-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "2G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/debian.json
+++ b/json/debian.json
@@ -1,0 +1,34 @@
+{
+    "name": "Debian",
+    "slug": "debian",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.debian.org/",
+    "logo": "https://seeklogo.com/images/D/debian-logo-C136FDAF9E-seeklogo.com.png",
+    "description": "Debian Linux is a distribution that emphasizes free software. It supports many hardware platforms.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/debian.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/deconz.json
+++ b/json/deconz.json
@@ -1,0 +1,34 @@
+{
+    "name": "deCONZ",
+    "slug": "deconz",
+    "categories": [
+        "Zigbee - Zwave"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 1,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://www.phoscon.de/en/conbee2/software#deconz",
+    "logo": "https://phoscon.de/img/phoscon-logo128x.svg",
+    "description": "deCONZ is a software for managing and controlling Zigbee-based smart home devices. It allows for setting up, configuring and visualizing the status of connected devices, as well as for triggering actions and automations. It works as a bridge between the Zigbee network and other home automation systems and can be used as a standalone solution or integrated into existing setups.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/deconz.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/deluge.json
+++ b/json/deluge.json
@@ -1,0 +1,34 @@
+{
+    "name": "Deluge",
+    "slug": "deluge",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8112",
+    "documentation": "",
+    "website": "https://www.deluge-torrent.org/",
+    "logo": "https://dev.deluge-torrent.org/chrome/common/deluge_logo.png",
+    "description": "Deluge is a free, open-source, lightweight BitTorrent client. It supports various platforms including Windows, Linux, and macOS, and offers features such as peer exchange, DHT, and magnet links.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/deluge.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": "deluge"
+    },
+    "alerts": []
+}

--- a/json/docker.json
+++ b/json/docker.json
@@ -1,0 +1,44 @@
+{
+    "name": "Docker",
+    "slug": "docker",
+    "categories": [
+        "Docker - Kubernetes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.docker.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/docker.svg",
+    "description": "Docker is an open-source project for automating the deployment of applications as portable, self-sufficient containers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/docker.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        },
+        {
+            "alert": "Run Compose V2 by replacing the hyphen (-) with a space, using `docker compose`, instead of `docker-compose`."
+        },
+        {
+            "alert": "Options to Install Portainer and/or Docker Compose V2"
+        }
+    ]
+}

--- a/json/dockge.json
+++ b/json/dockge.json
@@ -1,0 +1,41 @@
+{
+    "name": "Dockge",
+    "slug": "dockge",
+    "categories": [
+        "Docker - Kubernetes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5001",
+    "documentation": "",
+    "website": "https://github.com/louislam/dockge",
+    "logo": "https://raw.githubusercontent.com/louislam/dockge/master/frontend/public/icon.svg",
+    "description": "Dockge is a fancy, easy-to-use and reactive self-hosted docker compose.yaml stack-oriented manager.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/dockge.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "18",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Options to add Immich and/or Home Assistant"
+        },
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        }
+    ]
+}

--- a/json/emby.json
+++ b/json/emby.json
@@ -1,0 +1,38 @@
+{
+    "name": "Emby Media Server",
+    "slug": "emby",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8096",
+    "documentation": "",
+    "website": "https://emby.media/",
+    "logo": "https://github.com/home-assistant/brands/blob/master/core_integrations/emby/icon.png?raw=true",
+    "description": "Emby brings together your personal videos, music, photos, and live television.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/emby.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "With Privileged/Unprivileged Hardware Acceleration Support"
+        }
+    ]
+}

--- a/json/emqx.json
+++ b/json/emqx.json
@@ -1,0 +1,34 @@
+{
+    "name": "EMQX",
+    "slug": "emqx",
+    "categories": [
+        "MQTT"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "18083",
+    "documentation": "",
+    "website": "https://www.emqx.io/",
+    "logo": "https://github.com/hassio-addons/repository/blob/master/emqx/icon.png?raw=true",
+    "description": "EMQX is an open-source MQTT broker that features a high-performance, real-time message processing engine. It is designed to handle large-scale IoT deployments, providing fast and reliable message delivery for connected devices. EMQX is known for its scalability, reliability, and low latency, making it a popular choice for IoT and M2M applications. It also offers a wide range of features and plugins for enhanced security, monitoring, and management.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/emqx.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "public"
+    },
+    "alerts": []
+}

--- a/json/ersatztv.json
+++ b/json/ersatztv.json
@@ -1,0 +1,34 @@
+{
+    "name": "ErsatzTV",
+    "slug": "ersatztv",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8409",
+    "documentation": "",
+    "website": "https://ersatztv.org/",
+    "logo": "https://raw.githubusercontent.com/ErsatzTV/ErsatzTV/main/artwork/ersatztv-logo.svg",
+    "description": "ErsatzTV is software for configuring and streaming custom live channels using your media library.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/ersatztv.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "5",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/esphome.json
+++ b/json/esphome.json
@@ -1,0 +1,34 @@
+{
+    "name": "ESPHome",
+    "slug": "esphome",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "6052",
+    "documentation": "",
+    "website": "https://esphome.io/",
+    "logo": "https://esphome.io/_static/favicon.ico",
+    "description": "ESPHome is a platform for controlling ESP8266/ESP32-based devices using configuration files and integrating them with Home Automation systems. It provides a simple and flexible way to set up and manage the functionality of these devices, including defining and automating actions, monitoring sensors, and connecting to networks and other services. ESPHome is designed to be user-friendly and easy to use, and supports a wide range of features and integrations, making it a popular choice for home automation projects and IoT applications.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/esphome.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/evcc.json
+++ b/json/evcc.json
@@ -1,0 +1,38 @@
+{
+    "name": "evcc",
+    "slug": "evcc",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-15",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "7070",
+    "documentation": "https://evcc.io/#devices",
+    "website": "https://evcc.io/en/",
+    "logo": "https://docs.evcc.io/en/img/logo.svg",
+    "description": "EVCC is an open-source tool that manages EV charging, prioritizing solar energy use to reduce costs and optimize charging times. It supports various EVs and chargers, adjusting power automatically based on real-time data.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/evcc.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "entering `evcc configure` in the LXC terminal will guide you through the creation of a configuration file for evcc."
+        }
+    ]
+}

--- a/json/fenrus.json
+++ b/json/fenrus.json
@@ -1,0 +1,34 @@
+{
+    "name": "Fenrus",
+    "slug": "fenrus",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-05",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://github.com/revenz/Fenrus",
+    "logo": "https://raw.githubusercontent.com/revenz/Fenrus/master/wwwroot/fenrus.svg",
+    "description": "A personal home page for quick access to all your personal apps/sites.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/fenrus.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/fhem.json
+++ b/json/fhem.json
@@ -1,0 +1,34 @@
+{
+    "name": "FHEM",
+    "slug": "fhem",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8083",
+    "documentation": "",
+    "website": "https://fhem.de/",
+    "logo": "https://avatars.githubusercontent.com/u/45183393?s=100&v=4",
+    "description": "FHEM stands for \"Freundliche Hausautomation und Energie-Messung,\" which translates to \"Friendly Home Automation and Energy Measurement\" in English. The software can interface with a wide range of devices, including lighting systems, thermostats, weather stations, and media devices, among others.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/fhem.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/filebrowser.json
+++ b/json/filebrowser.json
@@ -1,0 +1,38 @@
+{
+    "name": "File Browser",
+    "slug": "filebrowser",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://filebrowser.org/features",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/filebrowser.png?raw=true",
+    "description": "File Browser offers a user-friendly web interface for managing files within a designated directory. It allows you to perform various actions such as uploading, deleting, previewing, renaming, and editing files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/filebrowser.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "changeme"
+    },
+    "alerts": [
+        {
+            "alert": "Execute within an existing LXC Console"
+        }
+    ]
+}

--- a/json/flaresolverr.json
+++ b/json/flaresolverr.json
@@ -1,0 +1,34 @@
+{
+    "name": "FlareSolverr",
+    "slug": "flaresolverr",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8191",
+    "documentation": "",
+    "website": "https://github.com/FlareSolverr/FlareSolverr",
+    "logo": "https://raw.githubusercontent.com/FlareSolverr/FlareSolverr/master/resources/flaresolverr_logo.svg",
+    "description": "FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/flaresolverr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/flowiseai.json
+++ b/json/flowiseai.json
@@ -1,0 +1,34 @@
+{
+    "name": "FlowiseAI",
+    "slug": "flowiseai",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://flowiseai.com/",
+    "logo": "https://flowiseai.com/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Flogo-color-high.e60de2f8.png&w=256&q=75",
+    "description": "FlowiseAI is an open source low-code tool for developers to build customized LLM orchestration flow & AI agents",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/flowiseai.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/forgejo.json
+++ b/json/forgejo.json
@@ -1,0 +1,34 @@
+{
+    "name": "Forgejo",
+    "slug": "forgejo",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://forgejo.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/forgejo.svg",
+    "description": "Forgejo is an open-source, self-hosted Git service that allows individuals and teams to manage their code repositories.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/forgejo.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/frigate.json
+++ b/json/frigate.json
@@ -1,0 +1,41 @@
+{
+    "name": "Frigate",
+    "slug": "frigate",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 1,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://frigate.video/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/frigate.svg",
+    "description": "Frigate is an open source NVR built around real-time AI object detection. All processing is performed locally on your own hardware, and your camera feeds never leave your home.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/frigate.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "20",
+                "os": "debian",
+                "version": "11"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Discussions (explore more advanced methods): `https://github.com/tteck/Proxmox/discussions/2711`"
+        },
+        {
+            "alert": "go2rtc Interface port:`1984`"
+        }
+    ]
+}

--- a/json/fstrim.json
+++ b/json/fstrim.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE LXC Filesystem Trim",
+    "slug": "fstrim",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://github.com/tteck/Proxmox/discussions/2505#discussion-6226037",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/lxc.svg",
+    "description": "This maintains SSD performance by managing unused blocks. Thin-provisioned storage systems also require management to prevent unnecessary storage use. VMs automate fstrim, while LXC containers need manual or automated fstrim processes for optimal performance.\r\nThis is designed to work with SSDs on ext4 filesystems only.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/fstrim.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/gitea.json
+++ b/json/gitea.json
@@ -1,0 +1,34 @@
+{
+    "name": "Gitea",
+    "slug": "gitea",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-07-26",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://gitea.com",
+    "logo": "https://gitea.com/gitea/design/raw/branch/main/logo/logo.svg",
+    "description": "Gitea is a self-hosted Git service. It provides a lightweight and easy-to-install solution for managing Git repositories. Users can collaborate on code, track issues, and manage project tasks. Gitea includes features like pull requests, code reviews, wiki, and project management tools. It is suitable for small to medium-sized teams seeking control over their Git hosting.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/gitea.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/glances.json
+++ b/json/glances.json
@@ -1,0 +1,38 @@
+{
+    "name": "Glances",
+    "slug": "glances",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "61208",
+    "documentation": "",
+    "website": "https://nicolargo.github.io/glances/",
+    "logo": "https://raw.githubusercontent.com/nicolargo/glances/develop/docs/_static/Glances%20Logo.svg",
+    "description": "Glances is an open-source system cross-platform monitoring tool. It allows real-time monitoring of various aspects of your system such as CPU, memory, disk, network usage etc.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/glances.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within an existing LXC Console"
+        }
+    ]
+}

--- a/json/go2rtc.json
+++ b/json/go2rtc.json
@@ -1,0 +1,34 @@
+{
+    "name": "go2rtc",
+    "slug": "go2rtc",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "1984",
+    "documentation": "",
+    "website": "https://github.com/AlexxIT/go2rtc",
+    "logo": "https://github.com/AlexxIT/go2rtc/blob/master/assets/logo.png?raw=true",
+    "description": "go2rtc is the ultimate camera streaming application with support RTSP, WebRTC, HomeKit, FFmpeg, RTMP, etc.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/go2rtc.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/gokapi.json
+++ b/json/gokapi.json
@@ -1,0 +1,34 @@
+{
+    "name": "Gokapi",
+    "slug": "gokapi",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "53842",
+    "documentation": "",
+    "website": "https://github.com/Forceu/Gokapi",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/linux.svg",
+    "description": "Gokapi is a lightweight server to share files, which expire after a set amount of downloads or days.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/gokapi.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/gotify.json
+++ b/json/gotify.json
@@ -1,0 +1,41 @@
+{
+    "name": "Gotify",
+    "slug": "gotify",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://gotify.net/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/gotify.svg",
+    "description": "Gotify is a simple server for sending and receiving messages",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/gotify.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": [
+        {
+            "alert": "password: `admin`"
+        },
+        {
+            "alert": "username: `admin`"
+        }
+    ]
+}

--- a/json/grafana.json
+++ b/json/grafana.json
@@ -1,0 +1,34 @@
+{
+    "name": "Grafana",
+    "slug": "grafana",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://grafana.com/",
+    "logo": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fdocs.checkmk.com%2Flatest%2Fimages%2Fgrafana_logo.png&f=1&nofb=1",
+    "description": "Grafana is a data visualization and monitoring platform that enables users to query, visualize, alert on and understand metrics, logs, and other data sources. It integrates with various data sources, including Prometheus, InfluxDB, Elasticsearch, and many others, to present a unified view of the data and enable users to create insightful and interactive dashboards.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/grafana.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/grocy.json
+++ b/json/grocy.json
@@ -1,0 +1,34 @@
+{
+    "name": "grocy",
+    "slug": "grocy",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://grocy.info/",
+    "logo": "https://grocy.info/img/grocy_logo.svg",
+    "description": "grocy is a web-based self-hosted groceries & household management solution for your home. It helps you keep track of your groceries and household items, manage your shopping list, and keep track of your pantry, recipes, meal plans, and more.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/grocy.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/haos-vm.json
+++ b/json/haos-vm.json
@@ -1,0 +1,38 @@
+{
+    "name": "Home Assistant OS",
+    "slug": "haos-vm",
+    "categories": [
+        "Home Assistant"
+    ],
+    "date_created": "2024-04-29",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8123",
+    "documentation": "https://www.home-assistant.io/docs/",
+    "website": "https://www.home-assistant.io/",
+    "logo": "https://avatars.githubusercontent.com/u/13844975?s=200&v=4",
+    "description": "This script automates the process of creating a Virtual Machine (VM) using the official KVM (qcow2) disk image provided by the Home Assistant Team. It involves finding, downloading, and extracting the image, defining user-defined settings, importing and attaching the disk, setting the boot order, and starting the VM. It supports various storage types, and does not involve any hidden installations. After the script completes, click on the VM, then on the Summary tab to find the VM IP.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/haos-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "4096",
+                "hdd": "32G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "The disk must have a minimum size of 32GB and its size cannot be changed during the creation of the VM."
+        }
+    ]
+}

--- a/json/headscale.json
+++ b/json/headscale.json
@@ -1,0 +1,38 @@
+{
+    "name": "Headscale",
+    "slug": "headscale",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-13",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://headscale.net/",
+    "website": "https://github.com/juanfont/headscale",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/headscale.svg",
+    "description": "An open source, self-hosted implementation of the Tailscale control server",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/headscale.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration settings: `/etc/headscale/config.yaml`"
+        }
+    ]
+}

--- a/json/heimdall-dashboard.json
+++ b/json/heimdall-dashboard.json
@@ -1,0 +1,34 @@
+{
+    "name": "Heimdall Dashboard",
+    "slug": "heimdall-dashboard",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7990",
+    "documentation": "",
+    "website": "https://heimdall.site/",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/heimdall.png?raw=true",
+    "description": "Heimdall Dashboard is a self-hosted, web-based dashboard for managing and monitoring the health of applications and servers. It allows you to keep track of the status of your systems from a single, centralized location, and receive notifications when things go wrong. With Heimdall Dashboard, you have full control over your data and can customize it to meet your specific needs. Self-hosting the dashboard gives you the flexibility to run it on your own infrastructure, making it a suitable solution for organizations that prioritize data security and privacy.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/heimdall-dashboard.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/hivemq.json
+++ b/json/hivemq.json
@@ -1,0 +1,34 @@
+{
+    "name": "HiveMQ CE",
+    "slug": "hivemq",
+    "categories": [
+        "MQTT"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "1883",
+    "documentation": "",
+    "website": "https://www.hivemq.com/",
+    "logo": "https://hivemq.com/img/svg/hivemq-bee.svg",
+    "description": "HiveMQ CE is a Java-based open source MQTT broker that fully supports MQTT 3.x and MQTT 5.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/hivemq.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/homarr.json
+++ b/json/homarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Homarr",
+    "slug": "homarr",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://homarr.dev/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/homarr.svg",
+    "description": "Homarr is a sleek, modern dashboard that puts all of your apps and services at your fingertips.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/homeassistant-core.json
+++ b/json/homeassistant-core.json
@@ -1,0 +1,44 @@
+{
+    "name": "Home Assistant Core",
+    "slug": "homeassistant-core",
+    "categories": [
+        "Home Assistant"
+    ],
+    "date_created": "2024-04-29",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8123",
+    "documentation": "https://www.home-assistant.io/docs/",
+    "website": "https://www.home-assistant.io/",
+    "logo": "https://avatars.githubusercontent.com/u/13844975?s=200&v=4",
+    "description": "A standalone installation of Home Assistant Core refers to a setup where the Home Assistant Core software is installed directly on a device or operating system, without the use of Docker containers. This provides a simpler, but less flexible and scalable solution, as the software is tightly coupled with the underlying system.\r\n\r\n\ud83d\udec8 If the LXC is created Privileged, the script will automatically set up USB passthrough.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homeassistant-core.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "24.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "config path: `/root/.homeassistant`"
+        },
+        {
+            "alert": "Requires `6.8.4-3-pve` or newer kernel"
+        },
+        {
+            "alert": "Use Ubuntu 24.04 ONLY"
+        }
+    ]
+}

--- a/json/homeassistant.json
+++ b/json/homeassistant.json
@@ -1,0 +1,41 @@
+{
+    "name": "Home Assistant Container",
+    "slug": "homeassistant",
+    "categories": [
+        "Home Assistant"
+    ],
+    "date_created": "2024-04-29",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8123",
+    "documentation": "https://www.home-assistant.io/docs/",
+    "website": "https://www.home-assistant.io/",
+    "logo": "https://avatars.githubusercontent.com/u/13844975?s=200&v=4",
+    "description": "A standalone container-based installation of Home Assistant Core means that the software is installed inside a Docker container, separate from the host operating system. This allows for flexibility and scalability, as well as improved security, as the container can be easily moved or isolated from other processes on the host.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homeassistant.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "16",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        },
+        {
+            "alert": "config path: `/var/lib/docker/volumes/hass_config/_data`"
+        }
+    ]
+}

--- a/json/homebox.json
+++ b/json/homebox.json
@@ -1,0 +1,34 @@
+{
+    "name": "HomeBox",
+    "slug": "homebox",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-09-16",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7745",
+    "documentation": "",
+    "website": "https://homebox.software/en/",
+    "logo": "https://homebox.software/lilbox.svg",
+    "description": "HomeBox is a simple, home-focused inventory management software. It allows users to organize and track household items by adding, updating, or deleting them. Features include optional details like warranty info, CSV import/export, custom labels, locations, and multi-tenant support for sharing with others. It\u2019s designed to be fast, easy to use, and portable.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homebox.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/homebridge.json
+++ b/json/homebridge.json
@@ -1,0 +1,34 @@
+{
+    "name": "Homebridge",
+    "slug": "homebridge",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8581",
+    "documentation": "",
+    "website": "https://homebridge.io/",
+    "logo": "https://raw.githubusercontent.com/homebridge/branding/master/logos/homebridge-color-round-stylized.png",
+    "description": "Homebridge is a popular open-source software platform that enables you to integrate smart home devices and services that do not natively support Apple's HomeKit protocol into the HomeKit ecosystem. This allows you to control and automate these devices using Siri, the Home app, or other HomeKit-enabled apps, making it easy to bring together a variety of different devices into a unified smart home system. With Homebridge, you can expand the capabilities of your smart home, unlocking new possibilities for automating and controlling your devices and systems.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homebridge.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/homepage.json
+++ b/json/homepage.json
@@ -1,0 +1,38 @@
+{
+    "name": "Homepage",
+    "slug": "homepage",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "https://gethomepage.dev/latest/configs/",
+    "website": "https://github.com/benphelps/homepage",
+    "logo": "https://avatars.githubusercontent.com/u/122929872?v=4",
+    "description": "Homepage is a self-hosted dashboard solution for centralizing and organizing data and information.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homepage.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "3",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration (bookmarks.yaml, services.yaml, widgets.yaml) path: `/opt/homepage/config/`"
+        }
+    ]
+}

--- a/json/homer.json
+++ b/json/homer.json
@@ -1,0 +1,38 @@
+{
+    "name": "Homer",
+    "slug": "homer",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8010",
+    "documentation": "",
+    "website": "https://github.com/bastienwirtz/homer#---------homer",
+    "logo": "https://raw.githubusercontent.com/bastienwirtz/homer/main/public/assets/icons/logo.svg",
+    "description": "Homer is a simple and lightweight static homepage generator that allows you to create and manage a home page for your server. It uses a YAML configuration file to define the layout and content of your homepage, making it easy to set up and customize. The generated homepage is static, meaning it does not require any server-side processing, making it fast and efficient to serve. Homer is designed to be a flexible and low-maintenance solution for organizing and accessing your services and information from a single, centralized location.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/homer.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration Path: `/opt/homer/assets/config.yml`"
+        }
+    ]
+}

--- a/json/host-backup.json
+++ b/json/host-backup.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Host Backup",
+    "slug": "host-backup",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/bash-dark.svg",
+    "description": "This script serves as a versatile backup utility, enabling users to specify both the backup path and the directory they want to work in. This flexibility empowers users to select the specific files and directories they wish to back up, making it compatible with a wide range of hosts, not limited to Proxmox.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/host-backup.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/hyperhdr.json
+++ b/json/hyperhdr.json
@@ -1,0 +1,34 @@
+{
+    "name": "HyperHDR",
+    "slug": "hyperhdr",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 1,
+    "interface_port": "8090",
+    "documentation": "",
+    "website": "https://github.com/awawa-dev/HyperHDR",
+    "logo": "https://raw.githubusercontent.com/awawa-dev/HyperHDR/master/resources/icons/hyperhdr-icon-256px.png",
+    "description": "HyperHDR is a highly optimized open source ambient lighting implementation based on modern digital video and audio stream analysis.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/hyperhdr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/hyperion.json
+++ b/json/hyperion.json
@@ -1,0 +1,34 @@
+{
+    "name": "Hyperion",
+    "slug": "hyperion",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8090",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/hyperion-project/hyperion.ng/raw/master/doc/logo_dark.png?raw=true",
+    "description": "Hyperion is an opensource Ambient Lighting implementation. It supports many LED devices and video grabbers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/hyperion.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/influxdb.json
+++ b/json/influxdb.json
@@ -1,0 +1,34 @@
+{
+    "name": "InfluxDB",
+    "slug": "influxdb",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8086",
+    "documentation": "",
+    "website": "https://www.influxdata.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/influx.svg",
+    "description": "InfluxDB is designed to handle high write and query loads, and is optimized for storing and analyzing time-stamped data, such as metrics, events, and logs. InfluxDB supports SQL-like query language and has a built-in HTTP API for data ingestion and retrieval. It's commonly used for IoT and industrial applications where time-series data is involved.\r\n\r\nTelegraf is a server agent that collects, processes, and aggregates metrics and events data from different sources, such as systems, databases, and APIs, and outputs the data to various outputs, such as InfluxDB, Prometheus, Elasticsearch, and many others.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/influxdb.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/iobroker.json
+++ b/json/iobroker.json
@@ -1,0 +1,34 @@
+{
+    "name": "ioBroker",
+    "slug": "iobroker",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8081",
+    "documentation": "",
+    "website": "https://www.iobroker.net/#en/intro",
+    "logo": "https://raw.githubusercontent.com/ioBroker/ioBroker/master/img/logos/ioBroker_Logo_256px.png",
+    "description": "ioBroker is an open-source platform for building and managing smart home automation systems. It provides a centralized control and management interface for connected devices, sensors, and other IoT devices. ioBroker integrates with a wide range of popular smart home systems, devices, and services, making it easy to automate tasks and processes, monitor and control devices, and collect and analyze data from a variety of sources. With its flexible architecture and easy-to-use interface, ioBroker is designed to make it simple for users to build and customize their own smart home automation systems, regardless of their technical background or experience.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/iobroker.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/iventoy.json
+++ b/json/iventoy.json
@@ -1,0 +1,38 @@
+{
+    "name": "iVentoy",
+    "slug": "iventoy",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-16",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "26000",
+    "documentation": "",
+    "website": "https://www.iventoy.com/",
+    "logo": "https://www.iventoy.com/static/img/iventoy.png",
+    "description": "iVentoy is an upgraded PXE server that allows simultaneous OS booting and installation on multiple machines via network. It is user-friendly, requiring only the placement of ISO files in a designated folder and selecting PXE boot on the client machine. iVentoy supports x86 Legacy BIOS, IA32 UEFI, x86_64 UEFI, and ARM64 UEFI modes. It is compatible with over 110 OS types, including Windows, WinPE, Linux, and VMware.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/iventoy.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Container must be privileged."
+        }
+    ]
+}

--- a/json/jackett.json
+++ b/json/jackett.json
@@ -1,0 +1,34 @@
+{
+    "name": "Jackett",
+    "slug": "jackett",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "9117",
+    "documentation": "",
+    "website": "https://github.com/Jackett/Jackett",
+    "logo": "https://raw.githubusercontent.com/Jackett/Jackett/master/src/Jackett.Common/Content/jacket_medium.png",
+    "description": "Jackett supports a wide range of trackers, including popular ones like The Pirate Bay, RARBG, and Torrentz2, as well as many private trackers. It can be integrated with several BitTorrent clients, including qBittorrent, Deluge, and uTorrent, among others.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/jackett.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/jellyfin.json
+++ b/json/jellyfin.json
@@ -1,0 +1,41 @@
+{
+    "name": "Jellyfin Media Server",
+    "slug": "jellyfin",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8096",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/home-assistant/brands/blob/master/core_integrations/jellyfin/icon.png?raw=true",
+    "description": "",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/jellyfin.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "With Privileged/Unprivileged Hardware Acceleration Support"
+        },
+        {
+            "alert": "FFmpeg path: /usr/lib/jellyfin-ffmpeg/ffmpeg"
+        }
+    ]
+}

--- a/json/jellyseerr.json
+++ b/json/jellyseerr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Jellyseerr",
+    "slug": "jellyseerr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5055",
+    "documentation": "",
+    "website": "https://github.com/Fallenbagel/jellyseerr",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/jellyseerr.svg",
+    "description": "Jellyseerr is a free and open source software application for managing requests for your media library. It is a a fork of Overseerr built to bring support for Jellyfin & Emby media servers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/jellyseerr.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/kavita.json
+++ b/json/kavita.json
@@ -1,0 +1,34 @@
+{
+    "name": "Kavita",
+    "slug": "kavita",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://www.kavitareader.com/",
+    "logo": "https://raw.githubusercontent.com/Kareadita/Kavita/develop/Logo/kavita.svg",
+    "description": "Kavita is a fast, feature rich, cross platform reading server. Built with a focus for manga, and the goal of being a full solution for all your reading needs.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/kavita.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/kernel-clean.json
+++ b/json/kernel-clean.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Kernel Clean",
+    "slug": "kernel-clean",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/proxmoxve/icon.png",
+    "description": "Cleaning unused kernel images is beneficial for reducing the length of the GRUB menu and freeing up disk space. By removing old, unused kernels, the system is able to conserve disk space and streamline the boot process.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/kernel-clean.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/kernel-pin.json
+++ b/json/kernel-pin.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Kernel Pin",
+    "slug": "kernel-pin",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-05-08",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/proxmoxve/icon.png",
+    "description": "Kernel Pin is an essential tool for effortlessly managing kernel pinning and unpinning.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/kernel-pin.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/keycloak.json
+++ b/json/keycloak.json
@@ -1,0 +1,38 @@
+{
+    "name": "Keycloak",
+    "slug": "keycloak",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://www.keycloak.org/",
+    "logo": "https://www.keycloak.org/resources/images/logo.svg",
+    "description": "Keycloak is an open-source identity and access management solution that provides centralized authentication and authorization for modern applications and services. It enables organizations to secure their applications and services with a single sign-on (SSO) solution, reducing the need for users to remember multiple login credentials. Keycloak supports various authentication protocols, including SAML, OAuth, and OpenID Connect, and integrates with a wide range of applications and services. With Keycloak, administrators can manage user identities, define security policies, and monitor access to their applications and services. The software is designed to be scalable, flexible, and easy to use, making it a valuable tool for enhancing the security and usability of modern applications and services.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/keycloak.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "First start can take a few minutes"
+        }
+    ]
+}

--- a/json/kubo.json
+++ b/json/kubo.json
@@ -1,0 +1,34 @@
+{
+    "name": "Kubo",
+    "slug": "kubo",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-06-27",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://github.com/ipfs/kubo",
+    "logo": "https://user-images.githubusercontent.com/157609/250148884-d6d12db8-fdcf-4be3-8546-2550b69845d8.png",
+    "description": "Kubo, developed by IPFS, is a decentralized file storage and sharing protocol. It implements the IPFS protocol, allowing users to manage files across a distributed network, ensuring data integrity and availability. Kubo supports file versioning, pinning, provides APIs and CLI tools for developers, and allows customizable node configurations for enhanced privacy and control.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/kubo.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "4096",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/lazylibrarian.json
+++ b/json/lazylibrarian.json
@@ -1,0 +1,34 @@
+{
+    "name": "LazyLibrarian",
+    "slug": "lazylibrarian",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5299",
+    "documentation": "",
+    "website": "https://gitlab.com/LazyLibrarian/LazyLibrarian",
+    "logo": "https://gitlab.com/uploads/-/system/project/avatar/9317860/ll.png",
+    "description": "LazyLibrarian is a SickBeard, CouchPotato, Headphones-like application for ebooks, audiobooks and magazines.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/lazylibrarian.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/lidarr.json
+++ b/json/lidarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Lidarr",
+    "slug": "lidarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8686",
+    "documentation": "",
+    "website": "https://lidarr.audio/",
+    "logo": "https://raw.githubusercontent.com/Lidarr/Lidarr/develop/Logo/256.png",
+    "description": "Lidarr is a music management tool designed for Usenet and BitTorrent users. It allows users to manage and organize their music collection with ease. Lidarr integrates with popular Usenet and BitTorrent clients, such as Sonarr and Radarr, to automate the downloading and organizing of music files. The software provides a web-based interface for managing and organizing music, making it easy to search and find songs, albums, and artists. Lidarr also supports metadata management, including album art, artist information, and lyrics, making it easy for users to keep their music collection organized and up-to-date. The software is designed to be easy to use and provides a simple and intuitive interface for managing and organizing music collections, making it a valuable tool for music lovers who want to keep their collection organized and up-to-date. With Lidarr, users can enjoy their music collection from anywhere, making it a powerful tool for managing and sharing music files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/lidarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/linkwarden.json
+++ b/json/linkwarden.json
@@ -1,0 +1,38 @@
+{
+    "name": "Linkwarden",
+    "slug": "linkwarden",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://linkwarden.app/",
+    "logo": "https://raw.githubusercontent.com/linkwarden/linkwarden/main/assets/logo.png",
+    "description": "Linkwarden is a fully self-hostable, open-source collaborative bookmark manager to collect, organize and archive webpages.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/linkwarden.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Show Database/Adminer Credentials: `cat linkwarden.creds`"
+        }
+    ]
+}

--- a/json/lldap.json
+++ b/json/lldap.json
@@ -1,0 +1,34 @@
+{
+    "name": "lldap",
+    "slug": "lldap",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-08-06",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "17170",
+    "documentation": "",
+    "website": "https://github.com/lldap/lldap",
+    "logo": "https://avatars.githubusercontent.com/u/129409591?s=64&v=4",
+    "description": "LLDAP is a lightweight LDAP server designed for simplicity and ease of use. It provides secure user authentication and authorization management through LDAP over TLS. Ideal for small to medium-sized environments, It aims to streamline identity management tasks with a minimalistic and straightforward setup.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/lldap.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "password"
+    },
+    "alerts": []
+}

--- a/json/mafl.json
+++ b/json/mafl.json
@@ -1,0 +1,38 @@
+{
+    "name": "Mafl",
+    "slug": "mafl",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://mafl.hywax.space/",
+    "logo": "https://raw.githubusercontent.com/hywax/mafl/main/docs/public/logotype.svg",
+    "description": "Mafl is an intuitive service for organizing your homepage. Customize Mafl to your individual needs and work even more efficiently!",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mafl.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration Path: `/opt/mafl/data/config.yml`\r\n"
+        }
+    ]
+}

--- a/json/magicmirror.json
+++ b/json/magicmirror.json
@@ -1,0 +1,38 @@
+{
+    "name": "MagicMirror Server",
+    "slug": "magicmirror",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "https://docs.magicmirror.builders/configuration/introduction.html#configuring-your-magicmirror",
+    "website": "https://docs.magicmirror.builders/",
+    "logo": "https://github.com/MichMich/MagicMirror/raw/master/.github/header.png",
+    "description": "MagicMirror\u00b2 is a smart mirror software that allows you to build your own personal smart mirror. It uses modular components that you can customize to display information such as the weather, news, calendar, to-do list, and more. The platform is open source, allowing for community contributions and customization.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/magicmirror.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "3",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration Path: `/opt/magicmirror/config/config.js`"
+        }
+    ]
+}

--- a/json/mariadb.json
+++ b/json/mariadb.json
@@ -1,0 +1,34 @@
+{
+    "name": "Mariadb",
+    "slug": "mariadb",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3306",
+    "documentation": "",
+    "website": "https://mariadb.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/mariadb.svg",
+    "description": "MariaDB is a fork of the popular MySQL database management system that is developed and maintained by the open-source community. It is also commercially supported, offering enterprise-level features and support for organizations that require them. MariaDB aims to maintain high compatibility with MySQL, ensuring a drop-in replacement capability.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mariadb.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/matterbridge.json
+++ b/json/matterbridge.json
@@ -1,0 +1,38 @@
+{
+    "name": "Matterbridge",
+    "slug": "matterbridge",
+    "categories": [
+        "Zigbee - Zwave"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8283",
+    "documentation": "",
+    "website": "https://github.com/Luligu/matterbridge",
+    "logo": "https://raw.githubusercontent.com/Luligu/matterbridge/main/frontend/public/matterbridge%20624x624.png",
+    "description": "Matterbridge allows you to have all your Matter devices up and running in a couple of minutes without having to deal with the pairing process of each single device.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/matterbridge.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        }
+    ]
+}

--- a/json/mediamtx.json
+++ b/json/mediamtx.json
@@ -1,0 +1,34 @@
+{
+    "name": "MediaMTX",
+    "slug": "mediamtx",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://github.com/bluenviron/mediamtx/blob/main/README.md",
+    "website": "https://github.com/bluenviron/mediamtx",
+    "logo": "https://raw.githubusercontent.com/bluenviron/mediamtx/main/logo.png",
+    "description": "MediaMTX is a ready-to-use SRT / WebRTC / RTSP / RTMP / LL-HLS media server and media proxy that allows you to read, publish, proxy, record and playback video and audio streams.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mediamtx.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/medusa.json
+++ b/json/medusa.json
@@ -1,0 +1,34 @@
+{
+    "name": "Medusa",
+    "slug": "medusa",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8081",
+    "documentation": "",
+    "website": "https://pymedusa.com/",
+    "logo": "https://cdn.jsdelivr.net/gh/pymedusa/medusa.github.io@4360d494/images/logo/new-logo.png",
+    "description": "Medusa is an automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic: automatic torrent/nzb searching, downloading, and processing at the qualities you want.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/medusa.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/memos.json
+++ b/json/memos.json
@@ -1,0 +1,34 @@
+{
+    "name": "Memos",
+    "slug": "memos",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-10-31",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "9030",
+    "documentation": "",
+    "website": "https://www.usememos.com/",
+    "logo": "https://camo.githubusercontent.com/aa5a8cac358e3448ef7bad80fc178699841913ec438ed0ddfe18f867f931d7ee/68747470733a2f2f7777772e7573656d656d6f732e636f6d2f6c6f676f2d726f756e6465642e706e67",
+    "description": "Memos is an open-source, self-hosted platform designed for fast, privacy-focused note-taking. Users can create, organize, and format notes with Markdown, which are securely stored in a local database. It\u2019s lightweight and customizable, built for quick access and adaptability to individual or team needs.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/memos.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "7",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/meshcentral.json
+++ b/json/meshcentral.json
@@ -1,0 +1,34 @@
+{
+    "name": "MeshCentral",
+    "slug": "meshcentral",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://meshcentral.com/",
+    "logo": "https://github.com/Ylianst/MeshCentral/blob/master/public/favicon-303x303.png?raw=true",
+    "description": "MeshCentral is a web-based computer management platform that provides remote control and management capabilities for computers. It allows administrators to manage and control computers over a local network or the internet through a single, centralized web-based interface. With MeshCentral, users can monitor the status of computers, perform remote administration tasks, and control the power state of machines. The software supports various operating systems and provides real-time updates and alerts to keep administrators informed of the status of their systems. MeshCentral is designed to provide an easy-to-use, scalable, and secure solution for remote computer management, making it a valuable tool for IT administrators, helpdesk support, and remote workers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/meshcentral.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/metube.json
+++ b/json/metube.json
@@ -1,0 +1,34 @@
+{
+    "name": "MeTube",
+    "slug": "metube",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8081",
+    "documentation": "",
+    "website": "https://github.com/alexta69/metube",
+    "logo": "https://raw.githubusercontent.com/alexta69/metube/master/ui/src/assets/icons/android-chrome-192x192.png",
+    "description": "MeTube allows you to download videos from YouTube and dozens of other sites.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/metube.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/microcode.json
+++ b/json/microcode.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Processor Microcode",
+    "slug": "microcode",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/processor.png?raw=true",
+    "description": "Processor Microcode is a layer of low-level software that runs on the processor and provides patches or updates to its firmware. Microcode updates can fix hardware bugs, improve performance, and enhance security features of the processor.\r\n\r\nIt's important to note that the availability of firmware update mechanisms, such as Intel's Management Engine (ME) or AMD's Platform Security Processor (PSP), may vary depending on the processor and its specific implementation. Therefore, it's recommended to consult the documentation for your processor to confirm whether firmware updates can be applied through the operating system.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/microcode.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/mikrotik-routeros.json
+++ b/json/mikrotik-routeros.json
@@ -1,0 +1,34 @@
+{
+    "name": "Mikrotik RouterOS CHR",
+    "slug": "mikrotik-routeros",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://help.mikrotik.com/docs/display/ROS/Cloud+Hosted+Router%2C+CHR",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/mikrotik.svg",
+    "description": "Mikrotik RouterOS CHR is a Linux-based operating system that transforms a computer into a router. It provides a wide range of features for network routing, firewall, bandwidth management, wireless access point, backhaul link, hotspot gateway, VPN server, and many others. RouterOS is a versatile solution that supports various network configurations, including those with multiple WAN links, hotspots, and VPNs. It is highly customizable, allowing administrators to configure and manage their networks according to their specific requirements. With RouterOS, network administrators can monitor and control the performance and security of their networks, ensuring reliable and secure communication for their users. The software is designed to be easy to use and provides a wide range of tools for network management, making it a valuable solution for small and large networks alike.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/mikrotik-routeros.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "512",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "none"
+    },
+    "alerts": []
+}

--- a/json/mongodb.json
+++ b/json/mongodb.json
@@ -1,0 +1,34 @@
+{
+    "name": "MongoDB",
+    "slug": "mongodb",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-18",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.mongodb.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/mongodb-spring-green.svg",
+    "description": "MongoDB is a NoSQL database that uses a document-oriented data model, storing data in JSON-like documents with dynamic schemas. This design offers flexibility and scalability, making it ideal for handling large volumes of data. MongoDB supports indexing, replication, and load balancing, ensuring high performance and availability, and can distribute data across multiple servers, making it well-suited for big data applications.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mongodb.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/monitor-all.json
+++ b/json/monitor-all.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Monitor-All",
+    "slug": "monitor-all",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/monitor.png?raw=true",
+    "description": "This script will add Monitor-All to Proxmox VE, which will monitor the status of all your instances, both containers and virtual machines, excluding templates and user-defined ones, and automatically restart or reset them if they become unresponsive. This is particularly useful if you're experiencing problems with Home Assistant becoming non-responsive every few days/weeks. Monitor-All also maintains a log of the entire process, which can be helpful for troubleshooting and monitoring purposes.\r\n\r\n\ud83d\udec8 Virtual machines without the QEMU guest agent installed must be excluded.\r\n\ud83d\udec8 Prior to generating any new CT/VM not found in this repository, it's necessary to halt Proxmox VE Monitor-All by running systemctl stop ping-instances.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/monitor-all.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/motioneye.json
+++ b/json/motioneye.json
@@ -1,0 +1,34 @@
+{
+    "name": "MotionEye NVR",
+    "slug": "motioneye",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8765",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/home-assistant/brands/blob/master/core_integrations/motioneye/icon.png?raw=true",
+    "description": "MotionEye is an open-source, self-hosted network video recording (NVR) software designed to manage and monitor IP cameras. It runs on various platforms such as Linux, Raspberry Pi, and Docker, and offers features such as real-time video streaming, motion detection, and customizable camera views.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/motioneye.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "none"
+    },
+    "alerts": []
+}

--- a/json/mqtt.json
+++ b/json/mqtt.json
@@ -1,0 +1,34 @@
+{
+    "name": "MQTT",
+    "slug": "mqtt",
+    "categories": [
+        "MQTT"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://mosquitto.org/documentation/",
+    "website": "https://mosquitto.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/eclipsemosquitto.svg",
+    "description": "Eclipse Mosquitto is an open-source message broker that implements the MQTT (Message Queuing Telemetry Transport) protocol. It is a lightweight and simple-to-use message broker that allows IoT devices and applications to communicate with each other by exchanging messages in real-time. Mosquitto is widely used in IoT applications, due to its low resource requirements and its compatibility with a wide range of devices and platforms",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mqtt.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/myspeed.json
+++ b/json/myspeed.json
@@ -1,0 +1,34 @@
+{
+    "name": "MySpeed",
+    "slug": "myspeed",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-06-14",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5216",
+    "documentation": "",
+    "website": "https://myspeed.dev/",
+    "logo": "https://raw.githubusercontent.com/gnmyt/myspeed/development/web/public/assets/img/logo.png",
+    "description": "MySpeed is a speed test analysis tool that records and displays internet speed metrics for up to 30 days. It offers automated tests using Cron expressions and supports multiple speed test servers (Ookla, LibreSpeed, Cloudflare). MySpeed provides detailed statistics, health check notifications via email or messaging apps, and integrates with Prometheus and Grafana for advanced monitoring.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/myspeed.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/mysql.json
+++ b/json/mysql.json
@@ -1,0 +1,38 @@
+{
+    "name": "MySQL",
+    "slug": "mysql",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-10-10",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://1000logos.net/wp-content/uploads/2020/08/MySQL-Logo.png",
+    "description": "MySQL is an open-source relational database management system (RDBMS) that uses SQL for managing and manipulating data. It is known for its scalability, reliability, and high performance, making it suitable for small to large-scale applications. Key features include support for ACID transactions, data replication for high availability, and compatibility with various programming languages like Python, PHP, and Java.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/mysql.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Database credentials: `cat mysql.creds`"
+        }
+    ]
+}

--- a/json/n8n.json
+++ b/json/n8n.json
@@ -1,0 +1,34 @@
+{
+    "name": "n8n",
+    "slug": "n8n",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5678",
+    "documentation": "",
+    "website": "https://n8n.io/",
+    "logo": "https://docs.n8n.io/_images/n8n-docs-icon.svg",
+    "description": "n8n is a workflow automation tool that enables users to automate various tasks and processes by connecting various data sources, systems, and services. It provides a visual interface for building workflows, allowing users to easily define and automate complex sequences of actions, such as data processing, conditional branching, and API calls. n8n supports a wide range of integrations, making it a versatile tool for automating a variety of use cases, from simple data processing workflows to complex business processes. With its extendable architecture, n8n is designed to be easily customizable and can be adapted to meet the specific needs of different users and industries.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/n8n.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/navidrome.json
+++ b/json/navidrome.json
@@ -1,0 +1,38 @@
+{
+    "name": "Navidrome",
+    "slug": "navidrome",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "4533",
+    "documentation": "",
+    "website": "https://www.navidrome.org/",
+    "logo": "https://raw.githubusercontent.com/navidrome/navidrome/master/resources/logo-192x192.png?raw=true",
+    "description": "Navidrome is a music server solution that makes your music collection accessible from anywhere. It provides a modern web-based user interface and compatibility with a range of third-party mobile apps for both iOS and Android devices. With Navidrome, users can access their music collection from anywhere, whether at home or on the go. The software supports a variety of music formats, making it easy for users to play their favorite songs and albums. Navidrome provides a simple and user-friendly interface for managing and organizing music collections, making it a valuable tool for music lovers who want to access their music from anywhere. The software is designed to be easy to set up and use, making it a popular choice for those who want to host their own music server and enjoy their music collection from anywhere.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/navidrome.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "To change Navidrome music folder path, `nano /var/lib/navidrome/navidrome.toml`"
+        }
+    ]
+}

--- a/json/neo4j.json
+++ b/json/neo4j.json
@@ -1,0 +1,34 @@
+{
+    "name": "Neoj",
+    "slug": "neo4j",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-10-20",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "7474",
+    "documentation": "",
+    "website": "https://neo4j.com/product/neo4j-graph-database/",
+    "logo": "https://avatars.githubusercontent.com/u/201120?s=200&v=4",
+    "description": "Neo4j is a graph database designed to manage complex data relationships. It uses nodes, relationships, and properties to store and analyze connected data, making it ideal for applications like recommendation engines, fraud detection, and network analysis. Its structure allows for fast querying and deep data insights through native graph storage.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/neo4j.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "neo4j",
+        "password": "neo4j"
+    },
+    "alerts": []
+}

--- a/json/netdata.json
+++ b/json/netdata.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Netdata",
+    "slug": "netdata",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.netdata.cloud/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/netdata.svg",
+    "description": "Netdata is an open-source, real-time performance monitoring tool designed to provide insights into the performance and health of systems and applications. It is often used by system administrators, DevOps professionals, and developers to monitor and troubleshoot issues on servers and other devices.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/netdata.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/nextcloudpi.json
+++ b/json/nextcloudpi.json
@@ -1,0 +1,34 @@
+{
+    "name": "Nextcloud",
+    "slug": "nextcloudpi",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "433",
+    "documentation": "",
+    "website": "https://www.turnkeylinux.org/nextcloud",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/nextcloud.svg",
+    "description": "NextCloudPi is a popular self-hosted solution for file collaboration and data storage. It is built on the NextCloud software, which is an open-source platform for data management.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/nextcloudpi.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/nginxproxymanager.json
+++ b/json/nginxproxymanager.json
@@ -1,0 +1,38 @@
+{
+    "name": "Nginx Proxy Manager",
+    "slug": "nginxproxymanager",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "81",
+    "documentation": "",
+    "website": "https://nginxproxymanager.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/nginxproxymanager.svg",
+    "description": "Nginx Proxy Manager is a tool that provides a web-based interface to manage Nginx reverse proxies. It enables users to easily and securely expose their services to the internet by providing features such as HTTPS encryption, domain mapping, and access control. It eliminates the need for manual configuration of Nginx reverse proxies, making it easy for users to quickly and securely expose their services to the public.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/nginxproxymanager.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin@example.com",
+        "password": "changeme"
+    },
+    "alerts": [
+        {
+            "alert": "Since there are hundreds of Certbot instances, it's necessary to install the specific Certbot of your preference."
+        }
+    ]
+}

--- a/json/nocodb.json
+++ b/json/nocodb.json
@@ -1,0 +1,34 @@
+{
+    "name": "NocoDB",
+    "slug": "nocodb",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://www.nocodb.com/",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/nocodb.png?raw=true",
+    "description": "NocoDB is a document-oriented database management system. It uses the NoSQL (Not Only SQL) data model, which allows for more flexible and scalable data storage than traditional relational databases. NoCoDB stores data in JSON format, making it easier to manage and query complex data structures, and supports a range of data types, including strings, numbers, arrays, and objects. The software provides a web-based interface for managing and querying data, and includes features such as real-time data synchronization, auto-indexing, and full-text search. NoCoDB is designed to be scalable, and can be used for a range of applications, from small projects to large enterprise systems. The software is free and open-source, and is designed to be easy to use and integrate with other applications.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/nocodb.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/node-red.json
+++ b/json/node-red.json
@@ -1,0 +1,38 @@
+{
+    "name": "Node-Red",
+    "slug": "node-red",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "1880",
+    "documentation": "",
+    "website": "https://nodered.org/",
+    "logo": "https://github.com/home-assistant/brands/blob/master/custom_integrations/nodered/icon.png?raw=true",
+    "description": "Node-RED is a visual programming tool that allows developers and non-developers alike to easily wire together hardware devices, APIs, and online services to create custom applications. It provides a visual interface for building workflows, making it easy to create and modify complex integrations without having to write any code. Node-RED is used in a wide range of applications, from simple automations to complex integrations, and is known for its simplicity, versatility, and ease of use.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/node-red.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "To install themes, type `update` in the LXC console."
+        }
+    ]
+}

--- a/json/notifiarr.json
+++ b/json/notifiarr.json
@@ -1,0 +1,38 @@
+{
+    "name": "Notifiarr",
+    "slug": "notifiarr",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5454",
+    "documentation": "",
+    "website": "https://notifiarr.com/",
+    "logo": "https://notifiarr.com/images/logo/notifiarr.png?raw=true",
+    "description": "Notifiarr is a purpose built system to bring many applications together to manage and customize notifications via Discord. You can monitor many aspects of your network(s), be notified of downtime, be notified of health issues, etc",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/notifiarr.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Manually edit `/etc/notifiarr/notifiarr.conf`to enter the API key from Notifiarr.com, and create a password for the UI."
+        }
+    ]
+}

--- a/json/ntfy.json
+++ b/json/ntfy.json
@@ -1,0 +1,34 @@
+{
+    "name": "ntfy",
+    "slug": "ntfy",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://ntfy.sh/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/ntfy.svg",
+    "description": "ntfy (pronounced notify) is a simple HTTP-based pub-sub notification service. It allows you to send notifications to your phone or desktop via scripts from any computer, and/or using a REST API. It's infinitely flexible, and 100% free software.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/ntfy.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/nzbget.json
+++ b/json/nzbget.json
@@ -1,0 +1,34 @@
+{
+    "name": "NZBGet",
+    "slug": "nzbget",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-31",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "6789",
+    "documentation": "",
+    "website": "https://nzbget.net/",
+    "logo": "https://avatars.githubusercontent.com/u/3368377?s=200&v=4",
+    "description": "NZBGet is a Usenet downloader focused on efficiency and performance, designed to handle NZB files for downloading content from Usenet. It automates downloading, checking, repairing, and extracting files, optimizing resources to run well on lower-powered devices.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/nzbget.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "nzbget",
+        "password": "tegbzn6789"
+    },
+    "alerts": []
+}

--- a/json/octoprint.json
+++ b/json/octoprint.json
@@ -1,0 +1,34 @@
+{
+    "name": "OctoPrint",
+    "slug": "octoprint",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 1,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://octoprint.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/octoprint.svg",
+    "description": "OctoPrint is a free and open-source web-based 3D printer control software that allows you to remotely control and monitor your 3D printer from a web interface. It was designed to be compatible with a wide range of 3D printers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/octoprint.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/olivetin.json
+++ b/json/olivetin.json
@@ -1,0 +1,38 @@
+{
+    "name": "OliveTin",
+    "slug": "olivetin",
+    "categories": [
+        "Dashboards"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "1337",
+    "documentation": "",
+    "website": "https://www.olivetin.app/",
+    "logo": "https://www.olivetin.app/resources/images/logo.png",
+    "description": "OliveTin provides a secure and straightforward way to execute pre-determined shell commands through a web-based interface.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/olivetin.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Configuration Path: `/etc/OliveTin/config.yaml`"
+        }
+    ]
+}

--- a/json/omada.json
+++ b/json/omada.json
@@ -1,0 +1,34 @@
+{
+    "name": "Omada Controller",
+    "slug": "omada",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8043",
+    "documentation": "",
+    "website": "https://www.tp-link.com/us/support/download/omada-software-controller/",
+    "logo": "https://www.enterpriseitpro.net/wp-content/uploads/2020/12/logo-omada.png",
+    "description": "Omada Controller is a software application used to manage TP-Link's Omada EAP (Enterprise Access Point) devices. It allows administrators to centrally manage a large number of EAPs, monitor network performance, and control user access to the network. The software provides an intuitive interface for network configuration, firmware upgrades, and network monitoring. By using the Omada Controller, administrators can streamline the management process, reduce manual intervention, and improve the overall security and reliability of the network.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/omada.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/ombi.json
+++ b/json/ombi.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ombi",
+    "slug": "ombi",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "https://ombi.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/ombi.svg",
+    "description": "Ombi is a self-hosted web application designed to empower shared Plex, Emby or Jellyfin users with automated content request capabilities. By integrating with various TV Show and Movie DVR tools, Ombi ensures a smooth and comprehensive experience for your users, allowing them to effortlessly request content on their own.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/ombi.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/omv.json
+++ b/json/omv.json
@@ -1,0 +1,34 @@
+{
+    "name": "OpenMediaVault",
+    "slug": "omv",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://www.openmediavault.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/openmediavault.svg",
+    "description": "OpenMediaVault is a next-generation network-attached storage (NAS) solution based on Debian Linux. It provides a web-based interface for managing and storing digital data, making it easy to use and set up. OpenMediaVault supports various storage protocols, including SMB/CIFS, NFS, and FTP, and provides a wide range of features for data management, such as user and group management, disk quotas, and data backup and recovery. The software is designed to be flexible and scalable, making it a valuable solution for both personal and enterprise use. OpenMediaVault provides a stable and reliable platform for managing and storing digital data, making it a popular choice for those who want to host their own data and ensure its security and privacy. With OpenMediaVault, users can access their data from anywhere and easily share it with others, making it a valuable tool for collaboration and data management.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/omv.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "openmediavault"
+    },
+    "alerts": []
+}

--- a/json/openhab.json
+++ b/json/openhab.json
@@ -1,0 +1,34 @@
+{
+    "name": "openHAB",
+    "slug": "openhab",
+    "categories": [
+        "Automation"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://www.openhab.org/",
+    "logo": "https://www.coxprod.org/domotique/wp-content/uploads/2019/01/openhab-logo-square.png",
+    "description": "openHAB is a popular open-source home automation platform that provides a vendor and technology agnostic solution for integrating and automating various smart home devices and services. It supports a wide range of devices and protocols, making it easy to bring together different systems and devices into a unified smart home ecosystem. With its user-friendly interface and powerful automation capabilities, openHAB makes it easy to create custom automations and monitor and control your smart home devices and systems, all from a single interface.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/openhab.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/openobserve.json
+++ b/json/openobserve.json
@@ -1,0 +1,38 @@
+{
+    "name": "OpenObserve",
+    "slug": "openobserve",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5080",
+    "documentation": "",
+    "website": "https://openobserve.ai/",
+    "logo": "https://raw.githubusercontent.com/tteck/Proxmox/main/misc/images/openobsecure.png",
+    "description": "OpenObserve is a simple yet sophisticated log search, infrastructure monitoring, and APM solution.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/openobserve.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "3",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Show Login Credentials: `cat /opt/openobserve/data/.env`"
+        }
+    ]
+}

--- a/json/openwebui.json
+++ b/json/openwebui.json
@@ -1,0 +1,34 @@
+{
+    "name": "Open WebUI",
+    "slug": "openwebui",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-24",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://openwebui.com/",
+    "logo": "https://raw.githubusercontent.com/open-webui/open-webui/refs/heads/main/static/favicon.png",
+    "description": "OpenWebUI is a self-hosted, web-based interface that allows you to run AI models entirely offline. It integrates with various LLM runners, such as OpenAI and Ollama, and supports features like markdown and LaTeX rendering, model management, and voice/video calls. It also offers multilingual support and the ability to generate images using APIs like DALL-E or ComfyUI",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/openwebui.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "16",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/openwrt.json
+++ b/json/openwrt.json
@@ -1,0 +1,34 @@
+{
+    "name": "OpenWrt",
+    "slug": "openwrt",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://openwrt.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/openwrt.svg",
+    "description": "OpenWrtis a powerful open-source firmware that can transform a wide range of networking devices into highly customizable and feature-rich routers, providing users with greater control and flexibility over their network infrastructure.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/openwrt.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "256",
+                "hdd": "512M",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/overseerr.json
+++ b/json/overseerr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Overseerr",
+    "slug": "overseerr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5055",
+    "documentation": "",
+    "website": "https://overseerr.dev/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/overseerr.svg",
+    "description": "Overseerr is a request management and media discovery tool built to work with your existing Plex ecosystem.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/overseerr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/owncast.json
+++ b/json/owncast.json
@@ -1,0 +1,34 @@
+{
+    "name": "Owncast",
+    "slug": "owncast",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://owncast.online/",
+    "logo": "https://raw.githubusercontent.com/owncast/owncast/develop/web/public/img/favicon/android-icon-144x144.png",
+    "description": "Owncast is a free and open source live video and web chat server for use with existing popular broadcasting software.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/owncast.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "abc123"
+    },
+    "alerts": []
+}

--- a/json/owncloud-vm.json
+++ b/json/owncloud-vm.json
@@ -1,0 +1,34 @@
+{
+    "name": "ownCloud",
+    "slug": "owncloud-vm",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://www.turnkeylinux.org/owncloud",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/owncloud.svg",
+    "description": "TurnKey ownCloud is an open-source file sharing server and collaboration platform that can store your personal content, like documents and pictures, in a centralized location.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/owncloud-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "12G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/pairdrop.json
+++ b/json/pairdrop.json
@@ -1,0 +1,34 @@
+{
+    "name": "PairDrop",
+    "slug": "pairdrop",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://github.com/schlagmichdoch/PairDrop",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/pairdrop.svg",
+    "description": "PairDrop: Local file sharing in your browser.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pairdrop.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/paperless-ngx.json
+++ b/json/paperless-ngx.json
@@ -1,0 +1,38 @@
+{
+    "name": "Paperless-ngx",
+    "slug": "paperless-ngx",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8000",
+    "documentation": "",
+    "website": "https://docs.paperless-ngx.com/",
+    "logo": "https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/resources/logo/web/svg/square.svg",
+    "description": "Paperless-ngx is a software tool designed for digitizing and organizing paper documents. It provides a web-based interface for scanning, uploading, and organizing paper documents, making it easier to manage, search, and access important information. Paperless-ngx uses the OCR (Optical Character Recognition) technology to extract text from scanned images and makes it searchable, thus increasing the efficiency of document management.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/paperless-ngx.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Show Login Credentials, type `update` in the LXC console"
+        }
+    ]
+}

--- a/json/pbs.json
+++ b/json/pbs.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox Backup Server",
+    "slug": "pbs",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8007",
+    "documentation": "",
+    "website": "https://www.proxmox.com/en/proxmox-backup-server/overview",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/proxmoxve/icon.png",
+    "description": "Proxmox Backup Server is an enterprise backup solution, for backing up and restoring VMs, containers, and physical hosts. By supporting incremental, fully deduplicated backups, Proxmox Backup Server significantly reduces network load and saves valuable storage space.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pbs.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Set a root password if using autologin. This will be the PBS password."
+        }
+    ]
+}

--- a/json/peanut.json
+++ b/json/peanut.json
@@ -1,0 +1,34 @@
+{
+    "name": "PeaNUT",
+    "slug": "peanut",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-06-14",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://github.com/Brandawg93/PeaNUT/",
+    "logo": "https://raw.githubusercontent.com/Brandawg93/PeaNUT/main/src/app/icon.svg",
+    "description": "PeaNUT is a small dashboard for Network UPS Tools (NUT). It provides a web interface to monitor and manage UPS devices. PeaNUT allows users to view device status, retrieve information, and manage UPS parameters through its API. It's customizable for different UPS devices and supports integration with the Homepage dashboard.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/peanut.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/petio.json
+++ b/json/petio.json
@@ -1,0 +1,34 @@
+{
+    "name": "Petio",
+    "slug": "petio",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7777",
+    "documentation": "",
+    "website": "https://petio.tv/",
+    "logo": "https://raw.githubusercontent.com/petio-team/petio/master/frontend/public/p-seamless.png",
+    "description": "Petio is a third party companion app available to Plex server owners to allow their users to request, review and discover content.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/petio.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "ubuntu",
+                "version": "20.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/photoprism.json
+++ b/json/photoprism.json
@@ -1,0 +1,38 @@
+{
+    "name": "PhotoPrism",
+    "slug": "photoprism",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "2342",
+    "documentation": "",
+    "website": "https://photoprism.app/",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/photoprism.png?raw=true",
+    "description": "PhotoPrism is an AI-Powered Photos App for the Decentralized Web. It makes use of the latest technologies to tag and find pictures automatically without getting in your way.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/photoprism.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "changeme"
+    },
+    "alerts": [
+        {
+            "alert": "Please note that Ubuntu 22.04 and Debian 12 are supported, while older Linux distributions may not be compatible."
+        }
+    ]
+}

--- a/json/pialert.json
+++ b/json/pialert.json
@@ -1,0 +1,34 @@
+{
+    "name": "Pi.Alert",
+    "slug": "pialert",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://github.com/leiweibau/Pi.Alert/",
+    "logo": "https://raw.githubusercontent.com/leiweibau/Pi.Alert/main/front/img/favicons/glass_black_white.png",
+    "description": "Pi.Alert is a WIFI / LAN intruder detector. Checks the devices connected and alert you with unknown devices. It also warns of the disconnection of \"always connected\" devices.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pialert.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "3",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/pihole.json
+++ b/json/pihole.json
@@ -1,0 +1,41 @@
+{
+    "name": "Pi-Hole",
+    "slug": "pihole",
+    "categories": [
+        "AdBlocker - DNS"
+    ],
+    "date_created": "2024-04-28",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "81",
+    "documentation": "https://docs.pi-hole.net/",
+    "website": "https://pi-hole.net/",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/pi_hole/icon%402x.png",
+    "description": "Pi-hole is a free, open-source network-level advertisement and Internet tracker blocking application. It runs on a Raspberry Pi or other Linux-based systems and acts as a DNS sinkhole, blocking unwanted traffic before it reaches a user's device. Pi-hole can also function as a DHCP server, providing IP addresses and other network configuration information to devices on a network. The software is highly configurable and supports a wide range of customizations, such as allowing or blocking specific domains, setting up blocklists and whitelists, and customizing the appearance of the web-based interface. The main purpose of Pi-hole is to protect users' privacy and security by blocking unwanted and potentially malicious content, such as ads, trackers, and malware. It is designed to be easy to set up and use, and can be configured through a web-based interface or through a terminal-based command-line interface.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pihole.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "To set your password, log in to the container, and type the following:  `pihole -a -p`"
+        },
+        {
+            "alert": "With an option to add Unbound"
+        }
+    ]
+}

--- a/json/pimox-haos-vm.json
+++ b/json/pimox-haos-vm.json
@@ -1,0 +1,34 @@
+{
+    "name": "PiMox HAOS",
+    "slug": "pimox-haos-vm",
+    "categories": [
+        "Home Assistant"
+    ],
+    "date_created": "2024-04-29",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8123",
+    "documentation": "",
+    "website": "https://github.com/jiangcuo/Proxmox-Port",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/pimox.png?raw=true",
+    "description": "The script automates the manual process of finding, downloading and extracting the aarch64 (qcow2) disk image provided by the Home Assistant Team, creating a VM with user defined settings, importing and attaching the disk, setting the boot order and starting the VM.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/pimox-haos-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "4096",
+                "hdd": "32G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/pingvin.json
+++ b/json/pingvin.json
@@ -1,0 +1,34 @@
+{
+    "name": "Pingvin Share",
+    "slug": "pingvin",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://github.com/stonith404/pingvin-share",
+    "logo": "https://github.com/stonith404/pingvin-share/blob/main/frontend/public/img/logo.png?raw=true",
+    "description": "Pingvin Share is self-hosted file sharing platform and an alternative for WeTransfer.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pingvin.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/plex.json
+++ b/json/plex.json
@@ -1,0 +1,38 @@
+{
+    "name": "Plex Media Server",
+    "slug": "plex",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "32400",
+    "documentation": "",
+    "website": "https://www.plex.tv/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/plex-white.svg",
+    "description": "Plex personal media server magically scans and organizes your files, sorting your media intuitively and beautifully.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/plex.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "With Privileged/Unprivileged Hardware Acceleration Support"
+        }
+    ]
+}

--- a/json/pocketbase.json
+++ b/json/pocketbase.json
@@ -1,0 +1,34 @@
+{
+    "name": "Pocketbase",
+    "slug": "pocketbase",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-07",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://pocketbase.io/docs/",
+    "website": "https://pocketbase.io/",
+    "logo": "https://pocketbase.io/images/logo.svg",
+    "description": "PocketBase is an open source backend consisting of embedded database (SQLite) with realtime subscriptions, built-in auth management, convenient dashboard UI and simple REST-ish API.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/pocketbase.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/podman-homeassistant.json
+++ b/json/podman-homeassistant.json
@@ -1,0 +1,41 @@
+{
+    "name": "Podman Home Assistant Container",
+    "slug": "podman-homeassistant",
+    "categories": [
+        "Home Assistant"
+    ],
+    "date_created": "2024-04-29",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8123",
+    "documentation": "https://www.home-assistant.io/docs/",
+    "website": "https://www.home-assistant.io/",
+    "logo": "https://avatars.githubusercontent.com/u/13844975?s=200&v=4",
+    "description": "A standalone Podman container-based installation of Home Assistant Core means that the Home Assistant Core software is installed inside a container managed by Podman, separate from the host operating system. This provides a flexible and scalable solution for running the software, as the container can be easily moved between host systems or isolated from other processes for security. Podman is a popular open-source tool for managing containers that is similar to Docker, but designed for use on Linux systems without a daemon.\r\n\r\n\ud83d\udec8 If the LXC is created Privileged, the script will automatically set up USB passthrough.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/podman-homeassistant.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "16",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Doesn't work with ZFS"
+        },
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        }
+    ]
+}

--- a/json/podman.json
+++ b/json/podman.json
@@ -1,0 +1,38 @@
+{
+    "name": "Podman",
+    "slug": "podman",
+    "categories": [
+        "Docker - Kubernetes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://podman.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/podman.svg",
+    "description": "Podman is an open-source, daemonless, and portable container engine that allows users to manage containers on Linux systems without the need for a daemon or system service to be running in the background. It provides an API and a command-line interface that can be used to create, run, and manage containers and their associated networks, volumes, and images. It is built on top of the Open Container Initiative (OCI) runtime specification, making it compatible with other OCI-compliant container engines.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/podman.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Doesn't work with ZFS"
+        }
+    ]
+}

--- a/json/post-pbs-install.json
+++ b/json/post-pbs-install.json
@@ -1,0 +1,41 @@
+{
+    "name": "Proxmox Backup Server Post Install",
+    "slug": "post-pbs-install",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/proxmoxve/icon.png",
+    "description": "The script will give options to Disable the Enterprise Repo, Add/Correct PBS Sources, Enable the No-Subscription Repo, Add Test Repo, Disable Subscription Nag, Update Proxmox Backup Server and Reboot PBS.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/post-pbs-install.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Proxmox Backup Server ONLY"
+        },
+        {
+            "alert": "Execute within the Proxmox Backup Server Shell"
+        }
+    ]
+}

--- a/json/post-pve-install.json
+++ b/json/post-pve-install.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE Post Install",
+    "slug": "post-pve-install",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-28",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/home-assistant/brands/master/core_integrations/proxmoxve/icon.png",
+    "description": "This script provides options for managing Proxmox VE repositories, including disabling the Enterprise Repo, adding or correcting PVE sources, enabling the No-Subscription Repo, adding the test Repo, disabling the subscription nag, updating Proxmox VE, and rebooting the system.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/post-pve-install.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/postgresql.json
+++ b/json/postgresql.json
@@ -1,0 +1,34 @@
+{
+    "name": "PostgreSQL",
+    "slug": "postgresql",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5432",
+    "documentation": "",
+    "website": "https://www.postgresql.org/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/postgresql.svg",
+    "description": "PostgreSQL (often referred to as Postgres) is an open-source relational database management system that is known for its extensibility and strict adherence to SQL standards. It is a free and powerful database solution, suitable for a wide range of applications, from small projects to large enterprise systems. PostgreSQL is widely used for its reliability, feature-richness, and robustness.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/postgresql.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/prometheus.json
+++ b/json/prometheus.json
@@ -1,0 +1,34 @@
+{
+    "name": "Prometheus",
+    "slug": "prometheus",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "9090",
+    "documentation": "",
+    "website": "https://prometheus.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/prometheus.svg",
+    "description": "Prometheus is widely used to monitor the performance and health of various infrastructure components and applications, and trigger alerts based on predefined rules. It has a multi-dimensional data model and supports various data sources and exporters, making it an extremely flexible and scalable monitoring solution.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/prometheus.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/prowlarr.json
+++ b/json/prowlarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Prowlarr",
+    "slug": "prowlarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "9696",
+    "documentation": "",
+    "website": "https://github.com/Prowlarr/Prowlarr",
+    "logo": "https://raw.githubusercontent.com/Prowlarr/Prowlarr/develop/Logo/256.png",
+    "description": "Prowlarr is a software tool designed to integrate with various PVR (Personal Video Recorder) apps. It is built on a popular *arr .net/ReactJS base stack and serves as an indexer manager and proxy. Prowlarr makes it easy to manage and organize TV show and movie collections, by integrating with popular PVR apps and automating the downloading and organizing of media files. The software provides a web-based interface for managing and organizing TV shows and movies, making it easy to search and find content. Prowlarr also supports metadata management, including show and movie information, making it easy for users to keep their media collection organized and up-to-date. The software is designed to be easy to use and provides a simple and intuitive interface for managing and organizing media collections, making it a valuable tool for media enthusiasts who want to keep their collection organized and up-to-date. With Prowlarr, users can enjoy their media collection from anywhere, making it a powerful tool for managing and sharing media files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/prowlarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/qbittorrent.json
+++ b/json/qbittorrent.json
@@ -1,0 +1,34 @@
+{
+    "name": "qBittorrent",
+    "slug": "qbittorrent",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8090",
+    "documentation": "",
+    "website": "https://www.qbittorrent.org/",
+    "logo": "https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/src/icons/qbittorrent.ico",
+    "description": "qBittorrent offers a user-friendly interface that allows users to search for and download torrent files easily. It also supports magnet links, which allow users to start downloading files without the need for a torrent file.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/qbittorrent.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "changeme"
+    },
+    "alerts": []
+}

--- a/json/rabbitmq.json
+++ b/json/rabbitmq.json
@@ -1,0 +1,34 @@
+{
+    "name": "RabbitMQ",
+    "slug": "rabbitmq",
+    "categories": [
+        "MQTT"
+    ],
+    "date_created": "2024-06-27",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "15672",
+    "documentation": "",
+    "website": "https://www.rabbitmq.com/",
+    "logo": "https://raw.githubusercontent.com/rabbitmq/rabbitmq-website/main/static/img/rabbitmq-logo.svg",
+    "description": "RabbitMQ is a robust messaging broker widely used for message queuing, streaming, and decoupling services. It supports multiple messaging protocols, ensures reliable message delivery, and offers features like routing, clustering, and federation. RabbitMQ is suitable for various use cases, including microservices communication, real-time data processing, and IoT applications.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/rabbitmq.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/radarr.json
+++ b/json/radarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Radarr",
+    "slug": "radarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "7878",
+    "documentation": "",
+    "website": "https://radarr.video/",
+    "logo": "https://raw.githubusercontent.com/Radarr/Radarr/develop/Logo/256.png",
+    "description": "Radarr is a movie management tool designed for Usenet and BitTorrent users. It allows users to manage and organize their movie collection with ease. Radarr integrates with popular Usenet and BitTorrent clients, such as Sonarr and Lidarr, to automate the downloading and organizing of movie files. The software provides a web-based interface for managing and organizing movies, making it easy to search and find titles, genres, and release dates. Radarr also supports metadata management, including movie posters and information, making it easy for users to keep their movie collection organized and up-to-date. The software is designed to be easy to use and provides a simple and intuitive interface for managing and organizing movie collections, making it a valuable tool for movie enthusiasts who want to keep their collection organized and up-to-date. With Radarr, users can enjoy their movie collection from anywhere, making it a powerful tool for managing and sharing movie files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/radarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/rdtclient.json
+++ b/json/rdtclient.json
@@ -1,0 +1,34 @@
+{
+    "name": "Real-Debrid Torrent Client",
+    "slug": "rdtclient",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "6500",
+    "documentation": "",
+    "website": "https://github.com/rogerfar/rdt-client",
+    "logo": "https://fcdn.real-debrid.com/0820/images/logo.png",
+    "description": "RDTClient is a web interface to manage your torrents on Real-Debrid, AllDebrid or Premiumize.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/rdtclient.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/readarr.json
+++ b/json/readarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Readarr",
+    "slug": "readarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8787",
+    "documentation": "",
+    "website": "https://readarr.com/",
+    "logo": "https://raw.githubusercontent.com/Readarr/Readarr/develop/Logo/256.png",
+    "description": "Readarr is an eBook and audiobook management tool designed for Usenet and BitTorrent users. It allows users to manage and organize their eBook and audiobook collection with ease. Readarr integrates with popular Usenet and BitTorrent clients, such as Sonarr and Lidarr, to automate the downloading and organizing of eBook and audiobook files. The software provides a web-based interface for managing and organizing eBooks and audiobooks, making it easy to search and find titles, authors, and genres. Readarr also supports metadata management, including cover art and information, making it easy for users to keep their eBook and audiobook collection organized and up-to-date. The software is designed to be easy to use and provides a simple and intuitive interface for managing and organizing eBook and audiobook collections, making it a valuable tool for book and audiobook enthusiasts who want to keep their collection organized and up-to-date. With Readarr, users can enjoy their eBook and audiobook collection from anywhere, making it a powerful tool for managing and sharing book and audiobook files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/readarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/readeck.json
+++ b/json/readeck.json
@@ -1,0 +1,34 @@
+{
+    "name": "Readeck",
+    "slug": "readeck",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8000",
+    "documentation": "",
+    "website": "https://readeck.org/",
+    "logo": "https://codeberg.org/readeck/readeck/raw/branch/main/web/media/logo-square.svg",
+    "description": "Readeck helps you keep all that web content you\u2019ll want to revisit in an hour, tomorrow, or in 20 years.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/readeck.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/redis.json
+++ b/json/redis.json
@@ -1,0 +1,38 @@
+{
+    "name": "Redis ",
+    "slug": "redis",
+    "categories": [
+        "Database"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://redis.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/redis.svg",
+    "description": "Redis is an open-source, in-memory data store used by millions of developers as a cache, vector database, document database, streaming engine, and message broker.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/redis.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Redis Configuration: `nano /etc/redis/redis.conf`"
+        }
+    ]
+}

--- a/json/rtsptoweb.json
+++ b/json/rtsptoweb.json
@@ -1,0 +1,34 @@
+{
+    "name": "RTSPtoWeb",
+    "slug": "rtsptoweb",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8083",
+    "documentation": "",
+    "website": "https://github.com/deepch/RTSPtoWeb",
+    "logo": "https://brands.home-assistant.io/_/rtsp_to_webrtc/logo.png?raw=true",
+    "description": "RTSPtoWeb converts your RTSP streams to formats consumable in a web browser like MSE (Media Source Extensions), WebRTC, or HLS. It's fully native Golang without the use of FFmpeg or GStreamer",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/rtsptoweb.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/runtipi.json
+++ b/json/runtipi.json
@@ -1,0 +1,34 @@
+{
+    "name": "Runtipi",
+    "slug": "runtipi",
+    "categories": [
+        "Docker - Kubernetes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://runtipi.io/",
+    "logo": "https://runtipi.io/_next/static/media/tipi.c0b9b68e.png",
+    "description": "Runtipi lets you install all your favorite self-hosted apps without the hassle of configuring and managing each service. One-click installs and updates for more than 180 popular apps.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/runtipi.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/sabnzbd.json
+++ b/json/sabnzbd.json
@@ -1,0 +1,34 @@
+{
+    "name": "SABnzbd",
+    "slug": "sabnzbd",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7777",
+    "documentation": "",
+    "website": "https://sabnzbd.org/",
+    "logo": "https://raw.githubusercontent.com/sabnzbd/sabnzbd/develop/icons/logo-arrow.svg",
+    "description": "SABnzbd is a free, open-source software program for downloading binary files from Usenet newsgroups. It is designed to be easy to use, and provides a number of features to simplify the downloading process, such as automatic error detection and repair, download scheduling, and integration with other applications. SABnzbd is a binary newsreader, which means it is specifically designed for downloading binary files, such as images, music, and video, from Usenet newsgroups. With its user-friendly interface and powerful features, SABnzbd makes it easy to manage your Usenet downloads and keep your download queue organized.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/sabnzbd.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/scaling-governor.json
+++ b/json/scaling-governor.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE CPU Scaling Governor",
+    "slug": "scaling-governor",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "https://www.kernel.org/doc/html/latest/admin-guide/pm/cpufreq.html?#generic-scaling-governors",
+    "website": "",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/cpu.png?raw=true",
+    "description": "The CPU scaling governor determines how the CPU frequency is adjusted based on the workload, with the goal of either conserving power or improving performance. By scaling the frequency up or down, the operating system can optimize the CPU usage and conserve energy when possible. Generic Scaling Governors",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/scaling-governor.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/scrutiny.json
+++ b/json/scrutiny.json
@@ -1,0 +1,32 @@
+{
+    "name": "Scrutiny",
+    "slug": "scrutiny",
+    "categories": [],
+    "date_created": "2024-06-26",
+    "type": "LXC",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://github.com/AnalogJ/scrutiny?tab=readme-ov-file",
+    "logo": "https://github.com/AnalogJ/scrutiny/raw/master/webapp/frontend/src/assets/images/logo/scrutiny-logo-dark.png",
+    "description": "Scrutiny is a web-based tool for monitoring hard drive health using S.M.A.R.T metrics. It integrates with smartd to detect all connected hard drives, track their historical S.M.A.R.T data, and set customized thresholds based on real-world failure rates. It offers a web UI for easy monitoring and can send failure notifications via various services. Scrutiny aims to predict drive failures and ensure data safety through proactive monitoring and alerting.",
+    "install_methods": [
+        {
+            "type": "default",
+            "installer": "bash -c \"$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/scrutiny.sh)\"",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/scrypted.json
+++ b/json/scrypted.json
@@ -1,0 +1,38 @@
+{
+    "name": "Scrypted",
+    "slug": "scrypted",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "10443",
+    "documentation": "",
+    "website": "https://www.scrypted.app/",
+    "logo": "https://www.scrypted.app/images/web_hi_res_512.png?raw=true",
+    "description": "Scrypted focuses on providing a seamless experience for managing and utilizing cameras in a smart home setup. It offers features like camera management, event triggering, video and image storage, and integration with other smart home devices and services. Scrypted is designed to make it easy to set up and use cameras in a home automation system, providing a simple and user-friendly interface for monitoring and automating camera-related tasks.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/scrypted.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "If the LXC is created Privileged, the script will automatically set up USB passthrough."
+        }
+    ]
+}

--- a/json/sftpgo.json
+++ b/json/sftpgo.json
@@ -1,0 +1,34 @@
+{
+    "name": "SFTPGo",
+    "slug": "sftpgo",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://github.com/drakkan/sftpgo",
+    "logo": "https://raw.githubusercontent.com/drakkan/sftpgo/main/img/logo.png",
+    "description": "SFTPGo is a fully featured and highly configurable SFTP server with optional HTTP/S, FTP/S and WebDAV support. Several storage backends are supported: local filesystem, encrypted local filesystem, S3 (compatible) Object Storage, Google Cloud Storage, Azure Blob Storage, SFTP.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/sftpgo.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/shinobi.json
+++ b/json/shinobi.json
@@ -1,0 +1,34 @@
+{
+    "name": "Shinobi NVR",
+    "slug": "shinobi",
+    "categories": [
+        "NVR - DVR"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://shinobi.video/",
+    "logo": "https://gitlab.com/uploads/-/system/project/avatar/6947723/mstile-150x150.png?raw=true",
+    "description": "Shinobi is an open-source, self-hosted network video recording (NVR) software. It allows you to manage and monitor security cameras and record video footage. Shinobi can be run on various platforms including Linux, macOS, and Raspberry Pi, and offers features such as real-time streaming, motion detection, and email notifications.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/shinobi.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin@shinobi.video",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/smokeping.json
+++ b/json/smokeping.json
@@ -1,0 +1,34 @@
+{
+    "name": "SmokePing",
+    "slug": "smokeping",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://oss.oetiker.ch/smokeping/",
+    "logo": "https://images.g2crowd.com/uploads/product/image/large_detail/large_detail_5ca8465f5b01fc1048c47aba6f79b6c6/smokeping.png",
+    "description": "SmokePing is a deluxe latency measurement tool. It can measure, store and display latency, latency distribution and packet loss.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/smokeping.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/sonarr.json
+++ b/json/sonarr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Sonarr",
+    "slug": "sonarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8989",
+    "documentation": "",
+    "website": "https://sonarr.tv/",
+    "logo": "https://raw.githubusercontent.com/Sonarr/Sonarr/develop/Logo/256.png",
+    "description": "Sonarr is a personal video recorder (PVR) software designed for Usenet and BitTorrent users. It allows users to manage and organize their TV show collection with ease. Sonarr integrates with popular Usenet and BitTorrent clients, such as NZBget and Transmission, to automate the downloading and organizing of TV show files. The software provides a web-based interface for managing and organizing TV shows, making it easy to search and find titles, seasons, and episodes. Sonarr also supports metadata management, including TV show posters and information, making it easy for users to keep their TV show collection organized and up-to-date. The software is designed to be easy to use and provides a simple and intuitive interface for managing and organizing TV show collections, making it a valuable tool for TV show enthusiasts who want to keep their collection organized and up-to-date. With Sonarr, users can enjoy their TV show collection from anywhere, making it a powerful tool for managing and sharing TV show files.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/sonarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/spoolman.json
+++ b/json/spoolman.json
@@ -1,0 +1,34 @@
+{
+    "name": "Spoolman",
+    "slug": "spoolman",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-06-13",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "7912",
+    "documentation": "",
+    "website": "https://github.com/Donkie/Spoolman",
+    "logo": "https://raw.githubusercontent.com/Donkie/Spoolman/master/client/public/favicon.svg",
+    "description": "Spoolman is a self-hosted web service designed to help you efficiently manage your 3D printer filament spools and monitor their usage.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/spoolman.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/stirling-pdf.json
+++ b/json/stirling-pdf.json
@@ -1,0 +1,34 @@
+{
+    "name": "Stirling-PDF",
+    "slug": "stirling-pdf",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://github.com/Stirling-Tools/Stirling-PDF",
+    "logo": "https://raw.githubusercontent.com/Stirling-Tools/Stirling-PDF/main/docs/stirling-pdf.png",
+    "description": "Stirling-PDF is a powerful locally hosted web based PDF manipulation tool that allows you to perform various operations on PDF files, such as splitting merging, converting, reorganizing, adding images, rotating, compressing, and more.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/stirling-pdf.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/syncthing.json
+++ b/json/syncthing.json
@@ -1,0 +1,34 @@
+{
+    "name": "Syncthing",
+    "slug": "syncthing",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8384",
+    "documentation": "",
+    "website": "https://syncthing.net/",
+    "logo": "https://raw.githubusercontent.com/syncthing/syncthing/6afaa9f20c8eb9c7af5abbe2f2d90fa2571aa7ad/assets/logo-only.svg",
+    "description": "Syncthing is an open-source file syncing tool that allows users to keep their files in sync across multiple devices by using peer-to-peer synchronization. It doesn't rely on any central server, so all data transfers are directly between devices.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/syncthing.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/tandoor.json
+++ b/json/tandoor.json
@@ -1,0 +1,34 @@
+{
+    "name": "Tandoor Recipes",
+    "slug": "tandoor",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8002",
+    "documentation": "",
+    "website": "https://tandoor.dev/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/tandoor.svg",
+    "description": "Tandoor Recipes is an application for managing recipes, planning meals, building shopping lists and much much more!",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/tandoor.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "10",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/tasmoadmin.json
+++ b/json/tasmoadmin.json
@@ -1,0 +1,34 @@
+{
+    "name": "TasmoAdmin",
+    "slug": "tasmoadmin",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "9999",
+    "documentation": "",
+    "website": "https://github.com/TasmoAdmin/TasmoAdmin#readme",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/tasmota.svg",
+    "description": "TasmoAdmin is an administrative platform for devices flashed with Tasmota.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/tasmoadmin.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/tautulli.json
+++ b/json/tautulli.json
@@ -1,0 +1,34 @@
+{
+    "name": "Tautulli",
+    "slug": "tautulli",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8181",
+    "documentation": "",
+    "website": "https://tautulli.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/tautulli.svg",
+    "description": "Tautulli allows you to monitor and track your Plex Media Server usage, such as viewing statistics and analysis of your media library. It can be used to monitor user activity, get notifications about new media added to your library, and even generate reports on your media usage.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/tautulli.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/tdarr.json
+++ b/json/tdarr.json
@@ -1,0 +1,38 @@
+{
+    "name": "Tdarr",
+    "slug": "tdarr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8265",
+    "documentation": "",
+    "website": "https://tdarr.io/",
+    "logo": "https://home.tdarr.io/static/media/logo3-min.246d6df44c7f16ddebaf.png",
+    "description": "Tdarr is a media transcoding application designed to automate the transcode and remux management of a media library. It uses conditional-based processing to determine the required encoding and remux operations for each file in the library. The software integrates with popular media management tools, such as Sonarr and Radarr, to ensure that newly added media files are automatically processed and optimized for the user's desired playback device. Tdarr provides a web-based interface for monitoring and managing the transcoding process, and also supports real-time logging and reporting. The software is designed to be flexible and configurable, with a wide range of encoding and remux options available to users. Tdarr is an ideal solution for media enthusiasts who want to optimize their library for seamless playback on a variety of devices, while also streamlining the management and maintenance of their media library.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/tdarr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "With Privileged/Unprivileged Hardware Acceleration Support"
+        }
+    ]
+}

--- a/json/technitiumdns.json
+++ b/json/technitiumdns.json
@@ -1,0 +1,34 @@
+{
+    "name": "Technitium DNS",
+    "slug": "technitiumdns",
+    "categories": [
+        "AdBlocker - DNS"
+    ],
+    "date_created": "2024-04-28",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5380",
+    "documentation": "",
+    "website": "https://technitium.com/dns/",
+    "logo": "https://technitium.com/img/logo.png",
+    "description": "Technitium DNS Server is a free, open-source and privacy-focused DNS (Domain Name System) server software for Windows, Linux, and macOS. It is designed to provide a secure, fast, and reliable DNS resolution service to its users. The server can be configured through a web-based interface, and it supports a variety of advanced features, such as automatic IP updates, IPv6 support, caching of DNS queries, and the ability to block unwanted domains. It is also designed to be highly secure, with built-in measures to prevent common types of DNS attacks and data leaks. Technitium DNS Server is aimed at providing an alternative to traditional DNS servers, which often have privacy and security concerns associated with them, and it is ideal for users who are looking for a more secure and private DNS resolution service.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/technitiumdns.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/threadfin.json
+++ b/json/threadfin.json
@@ -1,0 +1,34 @@
+{
+    "name": "Threadfin",
+    "slug": "threadfin",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://github.com/Threadfin/Threadfin",
+    "logo": "https://raw.githubusercontent.com/Threadfin/Threadfin/main/html/img/threadfin.png",
+    "description": "Threadfin is a M3U proxy for Kernel, Plex, Jellyfin, or Emby, based on xTeVe.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/threadfin.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/tianji.json
+++ b/json/tianji.json
@@ -1,0 +1,34 @@
+{
+    "name": "Tianji",
+    "slug": "tianji",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-09-14",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "12345",
+    "documentation": "",
+    "website": "https://tianji.msgbyte.com/",
+    "logo": "https://tianji.msgbyte.com/img/logo.svg",
+    "description": "Tianji is an open-source tool for website analytics, uptime monitoring, and server status tracking, all in one. It\u2019s lightweight, privacy-focused, and helps teams monitor web traffic, server health, and gather user interaction data",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/tianji.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "4096",
+                "hdd": "12",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": []
+}

--- a/json/traccar.json
+++ b/json/traccar.json
@@ -1,0 +1,34 @@
+{
+    "name": "Traccar",
+    "slug": "traccar",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8082",
+    "documentation": "",
+    "website": "https://www.traccar.org/",
+    "logo": "https://avatars.githubusercontent.com/u/37892282?s=100&v=4",
+    "description": "Traccar is an open source GPS tracking system. It supports more than 200 GPS protocols and more than 2000 models of GPS tracking devices.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/traccar.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/traefik.json
+++ b/json/traefik.json
@@ -1,0 +1,34 @@
+{
+    "name": "Traefik",
+    "slug": "traefik",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-20",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://traefik.io/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/traefik-gopher.svg",
+    "description": "Traefik (pronounced traffic) is an open-source edge router and reverse proxy that simplifies managing microservices. It automatically discovers services, dynamically updates routing rules without downtime, provides load balancing, handles SSL termination, and supports various middleware for added functionality. Ideal for cloud-native environments, it integrates seamlessly with platforms like Docker and Kubernetes.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/traefik.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/transmission.json
+++ b/json/transmission.json
@@ -1,0 +1,34 @@
+{
+    "name": "Transmission",
+    "slug": "transmission",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "9091",
+    "documentation": "",
+    "website": "https://transmissionbt.com/",
+    "logo": "https://raw.githubusercontent.com/transmission/transmission/main/web/assets/img/logo.png",
+    "description": "Transmission is a free, open-source BitTorrent client known for its fast download speeds and ease of use. It supports various platforms such as Windows, Linux, and macOS and has features like web interface, peer exchange, and encrypted transfers.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/transmission.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "transmission",
+        "password": "transmission"
+    },
+    "alerts": []
+}

--- a/json/trilium.json
+++ b/json/trilium.json
@@ -1,0 +1,34 @@
+{
+    "name": "Trilium",
+    "slug": "trilium",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8080",
+    "documentation": "",
+    "website": "https://github.com/zadam/trilium#trilium-notes",
+    "logo": "https://raw.githubusercontent.com/zadam/trilium/master/images/app-icons/png/128x128.png?raw=true",
+    "description": "Trilium is an open-source note-taking and personal knowledge management application. It allows users to organize and manage their notes, ideas, and information in a single place, using a hierarchical tree-like structure. Trilium offers a range of features, including rich text formatting, links, images, and attachments, making it easy to create and structure notes. The software is designed to be flexible and customizable, with a range of customization options and plugins available, including themes, export options, and more. Trilium is a self-hosted solution, and can be run on a local machine or a cloud-based server, providing users with full control over their notes and information.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/trilium.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/turnkey.json
+++ b/json/turnkey.json
@@ -1,0 +1,41 @@
+{
+    "name": "TurnKey",
+    "slug": "turnkey",
+    "categories": [
+        "TurnKey"
+    ],
+    "date_created": "2024-05-02",
+    "type": "turnkey",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.turnkeylinux.org/",
+    "logo": "https://blog.desdelinux.net/wp-content/uploads/2017/01/TurnKey-Linux.png",
+    "description": "TurnKey LXC Appliances is an open-source project that provides a collection of free, ready-to-use virtual appliances and installation images for various software applications and services. These appliances are pre-configured and come with all the necessary software and settings to simplify deployment and management. The goal of TurnKey Linux is to make it easier for users to set up and run popular software applications without the need for extensive manual configuration.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "turnkey/turnkey.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "The script creates a `*.creds` file in the Proxmox root directory with the password of the newly created TurnKey LXC Appliance."
+        },
+        {
+            "alert": "Retrieve Password: `cat turnkey-name.creds`"
+        }
+    ]
+}

--- a/json/ubuntu.json
+++ b/json/ubuntu.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ubuntu",
+    "slug": "ubuntu",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://ubuntu.com/",
+    "logo": "https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png",
+    "description": "Ubuntu is a distribution based on Debian, designed to have regular releases and a consistent user experience.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/ubuntu.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "ubuntu",
+                "version": "22.04"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/ubuntu2204-vm.json
+++ b/json/ubuntu2204-vm.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ubuntu 22.04",
+    "slug": "ubuntu2204-vm",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://ubuntu.com/",
+    "logo": "https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png",
+    "description": "Ubuntu is a distribution based on Debian, designed to have regular releases and a consistent user experience.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/ubuntu2204-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "2G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/ubuntu2404-vm.json
+++ b/json/ubuntu2404-vm.json
@@ -1,0 +1,34 @@
+{
+    "name": "Ubuntu 24.04",
+    "slug": "ubuntu2404-vm",
+    "categories": [
+        "Operating System"
+    ],
+    "date_created": "2024-05-02",
+    "type": "vm",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://ubuntu.com/",
+    "logo": "https://assets.ubuntu.com/v1/29985a98-ubuntu-logo32.png",
+    "description": "Ubuntu is a distribution based on Debian, designed to have regular releases and a consistent user experience.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "vm/ubuntu2404-vm.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "2G",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/umami.json
+++ b/json/umami.json
@@ -1,0 +1,38 @@
+{
+    "name": "Umami",
+    "slug": "umami",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-09",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://umami.is/",
+    "logo": "https://raw.githubusercontent.com/umami-software/umami/master/public/android-chrome-512x512.png",
+    "description": "Umami makes it easy to collect, analyze, and understand your web data while maintaining visitor privacy and data ownership.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/umami.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "12",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "umami"
+    },
+    "alerts": [
+        {
+            "alert": "To view the database credentials : `cat umami.creds`"
+        }
+    ]
+}

--- a/json/unifi.json
+++ b/json/unifi.json
@@ -1,0 +1,38 @@
+{
+    "name": "UniFi Network Server",
+    "slug": "unifi",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8443",
+    "documentation": "",
+    "website": "https://www.ui.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/ubiquiti.svg",
+    "description": "UniFi Network Server is a software that helps manage and monitor UniFi networks (Wi-Fi, Ethernet, etc.) by providing an intuitive user interface and advanced features. It allows network administrators to configure, monitor, and upgrade network devices, as well as view network statistics, client devices, and historical events. The aim of the application is to make the management of UniFi networks easier and more efficient.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/unifi.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "8",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "CPU with AVX Instruction Set required"
+        }
+    ]
+}

--- a/json/unmanic.json
+++ b/json/unmanic.json
@@ -1,0 +1,34 @@
+{
+    "name": "Unmanic",
+    "slug": "unmanic",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 1,
+    "interface_port": "8888",
+    "documentation": "",
+    "website": "https://docs.unmanic.app/",
+    "logo": "https://raw.githubusercontent.com/Unmanic/unmanic/master/icon.png",
+    "description": "Unmanic is a simple tool for optimising your file library. You can use it to convert your files into a single, uniform format, manage file movements based on timestamps, or execute custom commands against a file based on its file size.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/unmanic.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/update-lxcs.json
+++ b/json/update-lxcs.json
@@ -1,0 +1,38 @@
+{
+    "name": "Proxmox VE LXC Updater",
+    "slug": "update-lxcs",
+    "categories": [
+        "Proxmox VE Tools"
+    ],
+    "date_created": "2024-04-29",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/lxc.svg",
+    "description": "This script has been created to simplify and speed up the process of updating all LXC containers across various Linux distributions, such as Ubuntu, Debian, Devuan, Alpine Linux, CentOS-Rocky-Alma, Fedora, and ArchLinux. It's designed to automatically skip templates and specific containers during the update, enhancing its convenience and usability.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/update-lxcs.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Execute within the Proxmox shell"
+        }
+    ]
+}

--- a/json/uptimekuma.json
+++ b/json/uptimekuma.json
@@ -1,0 +1,34 @@
+{
+    "name": "Uptime Kuma",
+    "slug": "uptimekuma",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3001",
+    "documentation": "",
+    "website": "https://github.com/louislam/uptime-kuma#uptime-kuma",
+    "logo": "https://github.com/louislam/uptime-kuma/blob/master/public/icon.png?raw=true",
+    "description": "Uptime Kuma is a monitoring and alerting system that tracks the availability and performance of servers, websites, and other internet-connected devices. It can be self-hosted and is open-source, offering a visually appealing interface for monitoring and receiving notifications about downtime events.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/uptimekuma.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/vaultwarden.json
+++ b/json/vaultwarden.json
@@ -1,0 +1,38 @@
+{
+    "name": "Vaultwarden",
+    "slug": "vaultwarden",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8000",
+    "documentation": "",
+    "website": "https://www.vaultwarden.net/",
+    "logo": "https://raw.githubusercontent.com/dani-garcia/vaultwarden/main/resources/vaultwarden-icon-white.svg",
+    "description": "Vaultwarden is a self-hosted password manager which provides secure and encrypted password storage. It uses client-side encryption and provides access to passwords through a web interface and mobile apps.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/vaultwarden.sh",
+            "resources": {
+                "cpu": "4",
+                "ram": "5120",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": [
+        {
+            "alert": "Vaultwarden needs to be behind a proxy (Nginx Proxy Manager) to obtain HTTPS and to allow clients to connect."
+        }
+    ]
+}

--- a/json/wallos.json
+++ b/json/wallos.json
@@ -1,0 +1,34 @@
+{
+    "name": "Wallos",
+    "slug": "wallos",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-10-24",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "",
+    "logo": "https://raw.githubusercontent.com/ellite/Wallos/refs/heads/main/images/icon/android-chrome-192x192.png",
+    "description": "Wallos is a personal finance and budgeting tool that provides an intuitive interface for tracking expenses, managing subscriptions, and monitoring financial health. It features APIs for categories, notifications, payments, and user settings, making it suitable for automation and custom integrations. Additionally, it supports multi-language functionality.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/wallos.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "5",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/wastebin.json
+++ b/json/wastebin.json
@@ -1,0 +1,34 @@
+{
+    "name": "Wastebin",
+    "slug": "wastebin",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8088",
+    "documentation": "",
+    "website": "https://github.com/matze/wastebin",
+    "logo": "https://raw.githubusercontent.com/matze/wastebin/master/assets/favicon.png?raw=true",
+    "description": "Wastebin is a minimal pastebin with a design shamelessly copied from bin.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/wastebin.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/watchyourlan.json
+++ b/json/watchyourlan.json
@@ -1,0 +1,34 @@
+{
+    "name": "WatchYourLAN",
+    "slug": "watchyourlan",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "8840",
+    "documentation": "",
+    "website": "https://github.com/aceberg/WatchYourLAN",
+    "logo": "https://raw.githubusercontent.com/aceberg/WatchYourLAN/main/assets/logo.png",
+    "description": "WatchYourLAN is a lightweight network IP scanner with web GUI.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/watchyourlan.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/webmin.json
+++ b/json/webmin.json
@@ -1,0 +1,38 @@
+{
+    "name": "Webmin System Administration",
+    "slug": "webmin",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-05-02",
+    "type": "misc",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "10000",
+    "documentation": "",
+    "website": "https://webmin.com/",
+    "logo": "https://user-images.githubusercontent.com/4426533/218263860-f7baf9d6-cb19-4ddc-86dc-ac1b7a3c3a8a.png?raw=true",
+    "description": "Webmin provides a graphical user interface (GUI) for tasks such as user account management, package management, file system configuration, network configuration, and more.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "misc/webmin.sh",
+            "resources": {
+                "cpu": "",
+                "ram": "",
+                "hdd": "",
+                "os": "",
+                "version": ""
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "root",
+        "password": "root"
+    },
+    "alerts": [
+        {
+            "alert": "Execute within an existing LXC Console"
+        }
+    ]
+}

--- a/json/whisparr.json
+++ b/json/whisparr.json
@@ -1,0 +1,34 @@
+{
+    "name": "Whisparr",
+    "slug": "whisparr",
+    "categories": [
+        "Media - Photo"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "6969",
+    "documentation": "",
+    "website": "https://github.com/Whisparr/Whisparr",
+    "logo": "https://raw.githubusercontent.com/Whisparr/Whisparr/develop/Logo/256.png",
+    "description": "Whisparr is an adult movie collection manager for Usenet and BitTorrent users.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/whisparr.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/whoogle.json
+++ b/json/whoogle.json
@@ -1,0 +1,34 @@
+{
+    "name": "Whoogle",
+    "slug": "whoogle",
+    "categories": [
+        "Miscellaneous"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "5000",
+    "documentation": "",
+    "website": "",
+    "logo": "https://github.com/tteck/Proxmox/blob/main/misc/images/whoogle.png?raw=true",
+    "description": "Get Google search results, but without any ads, javascript, AMP links, cookies, or IP address tracking.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/whoogle.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "2",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/wikijs.json
+++ b/json/wikijs.json
@@ -1,0 +1,34 @@
+{
+    "name": "Wiki.js",
+    "slug": "wikijs",
+    "categories": [
+        "Document - Notes"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://js.wiki/",
+    "logo": "https://static.requarks.io/logo/wikijs-butterfly.svg",
+    "description": "Wiki.js is a free, open-source, and modern wiki application built using Node.js. It is designed to be fast, easy to use, and flexible, with a range of features for collaboration, knowledge management, and content creation. Wiki.js supports Markdown syntax for editing pages, and includes features such as version control, page history, and access control, making it easy to manage content and collaborate with others. The software is fully customizable, with a range of themes and extensions available, and can be deployed on a local server or in the cloud, making it an ideal choice for small teams and organizations looking to create and manage a wiki. Wiki.js provides a modern, user-friendly interface, and supports a range of data sources, including local file systems, databases, and cloud storage services.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/wikijs.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "3",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/wireguard.json
+++ b/json/wireguard.json
@@ -1,0 +1,44 @@
+{
+    "name": "WireGuard",
+    "slug": "wireguard",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "10086",
+    "documentation": "",
+    "website": "https://www.wireguard.com/",
+    "logo": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn.icon-icons.com%2Ficons2%2F2699%2FPNG%2F512%2Fwireguard_logo_icon_168760.png&f=1&nofb=1",
+    "description": "WireGuard is a free and open-source virtual private network (VPN) software that uses modern cryptography to secure the data transmitted over a network. It is designed to be fast, secure, and easy to use. WireGuard supports various operating systems, including Linux, Windows, macOS, Android, and iOS. It operates at the network layer and is capable of being used with a wide range of protocols and configurations. Unlike other VPN protocols, WireGuard is designed to be simple and fast, with a focus on security and speed. It is known for its ease of setup and configuration, making it a popular choice for personal and commercial use.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/wireguard.sh",
+            "resources": {
+                "cpu": "1",
+                "ram": "512",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "admin"
+    },
+    "alerts": [
+        {
+            "alert": "Add Clients: `pivpn add`"
+        },
+        {
+            "alert": "Host Configuration: `nano /etc/pivpn/wireguard/setupVars.conf`"
+        },
+        {
+            "alert": "If you want to create new peers using a GUI, type `update` within the LXC console to install WGDashboard."
+        }
+    ]
+}

--- a/json/yunohost.json
+++ b/json/yunohost.json
@@ -1,0 +1,34 @@
+{
+    "name": "YunoHost",
+    "slug": "yunohost",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "80",
+    "documentation": "",
+    "website": "https://yunohost.org/",
+    "logo": "https://yunohost.org/assets/img/ynh_logo_roundcorner.png",
+    "description": "YunoHost is an operating system aiming for the simplest administration of a server, and therefore democratize self-hosting, while making sure it stays reliable, secure, ethical and lightweight.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/yunohost.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "20",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/zabbix.json
+++ b/json/zabbix.json
@@ -1,0 +1,38 @@
+{
+    "name": "Zabbix",
+    "slug": "zabbix",
+    "categories": [
+        "Monitoring - Analytics"
+    ],
+    "date_created": "2024-06-12",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "5454",
+    "documentation": "",
+    "website": "https://www.zabbix.com/",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/zabbix.svg",
+    "description": "Zabbix is an all-in-one monitoring solution with a variety of enterprise-grade features available right out of the box.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/zabbix.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "4096",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "admin",
+        "password": "zabbix"
+    },
+    "alerts": [
+        {
+            "alert": "Database credentials: `cat zabbix.creds`"
+        }
+    ]
+}

--- a/json/zigbee2mqtt.json
+++ b/json/zigbee2mqtt.json
@@ -1,0 +1,34 @@
+{
+    "name": "Zigbee2MQTT",
+    "slug": "zigbee2mqtt",
+    "categories": [
+        "Zigbee - Zwave"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 1,
+    "interface_port": "0",
+    "documentation": "",
+    "website": "https://www.zigbee2mqtt.io/",
+    "logo": "https://github.com/Koenkk/zigbee2mqtt/blob/master/images/logo_bee_only.png?raw=true",
+    "description": "Zigbee2MQTT is an open-source software project that allows you to use Zigbee-based smart home devices (such as those sold under the Philips Hue and Ikea Tradfri brands) with MQTT-based home automation systems, like Home Assistant, Node-RED, and others. The software acts as a bridge between your Zigbee devices and MQTT, allowing you to control and monitor these devices from your home automation system.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/zigbee2mqtt.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/zipline.json
+++ b/json/zipline.json
@@ -1,0 +1,34 @@
+{
+    "name": "Zipline",
+    "slug": "zipline",
+    "categories": [
+        "File - Code"
+    ],
+    "date_created": "2024-09-16",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 0,
+    "interface_port": "3000",
+    "documentation": "",
+    "website": "https://zipline.diced.sh/",
+    "logo": "https://raw.githubusercontent.com/diced/zipline/trunk/public/zipline_small.png",
+    "description": "Zipline is a file-sharing and URL-shortening server designed for easy setup and extensive features. It allows users to upload files, organize them into folders, create shortened URLs, and manage uploads through a user-friendly dashboard. Additional features include image compression, video thumbnails, password protection, 2FA, OAuth2 registration, and API access for custom control. It supports integrations with platforms like Discord.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/zipline.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "5",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "administrator",
+        "password": "password"
+    },
+    "alerts": []
+}

--- a/json/zoraxy.json
+++ b/json/zoraxy.json
@@ -1,0 +1,34 @@
+{
+    "name": "Zoraxy",
+    "slug": "zoraxy",
+    "categories": [
+        "Server - Networking"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 0,
+    "privileged": 0,
+    "interface_port": "8000",
+    "documentation": "",
+    "website": "https://zoraxy.arozos.com/",
+    "logo": "https://raw.githubusercontent.com/tobychui/zoraxy/refs/heads/main/docs/favicon.png",
+    "description": "Zoraxy is an all in one homelab network routing solution.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/zoraxy.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "2048",
+                "hdd": "6",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}

--- a/json/zwave-js-ui.json
+++ b/json/zwave-js-ui.json
@@ -1,0 +1,34 @@
+{
+    "name": "Z-Wave JS UI",
+    "slug": "zwave-js-ui",
+    "categories": [
+        "Zigbee - Zwave"
+    ],
+    "date_created": "2024-05-02",
+    "type": "ct",
+    "updateable": 1,
+    "privileged": 1,
+    "interface_port": "8091",
+    "documentation": "",
+    "website": "https://github.com/zwave-js/zwave-js-ui#",
+    "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/zwave.svg",
+    "description": "Z-Wave JS UI is an open-source software that serves as a gateway between Z-Wave devices and MQTT (Message Queuing Telemetry Transport) protocol, allowing users to control and monitor their Z-Wave devices via a user interface. The software provides a configurable platform to manage Z-Wave networks and integrate with other smart home systems through MQTT.",
+    "install_methods": [
+        {
+            "type": "default",
+            "script": "ct/zwave-js-ui.sh",
+            "resources": {
+                "cpu": "2",
+                "ram": "1024",
+                "hdd": "4",
+                "os": "debian",
+                "version": "12"
+            }
+        }
+    ],
+    "default_credentials": {
+        "username": "",
+        "password": ""
+    },
+    "alerts": []
+}


### PR DESCRIPTION
# Acknowledgments 

I want to acknowledge @tteck who put this all together in the first pace, this just builds upon their work.

I also want to acknowledge the amazing work @BramSuurdje put the database together on the database and suggested the json schema. Having this in the first place made this job a lot easier.

Also @havardthom who consulted during this process and helped move things along.

## Description

This merge adds a json/ directory with a .json file for each script. 

The json structure is in the format proposed by @havardthom with some minor changes due to discovery of information as I wrangled the data.

The data is extracted from the pocketbase DB in consultation with @BramSuurdje. It also parses the scripts (ct, vm and misc) for details.

The json format is as follows:

```json
{
    "name": "Emby Media Server", # The human formatted name/title
    "slug": "emby", # The slug, which is the script name without the file ext.
    "categories": [
        "Media - Photo" # The categories
    ],
    "date_created": "2024-05-02", # When the script was first added
    "type": "ct", # This differs slightly from the db. The type is ct, vm or misc. The frontend can render ct as LCX etc.
    "updateable": 0, # 0 or 1
    "privileged": 0, # 0 or 1
    "interface_port": "8096", 
    "documentation": "",
    "website": "https://emby.media/",
    "logo": "https://github.com/home-assistant/brands/blob/master/core_integrations/emby/icon.png?raw=true", 
    "description": "Emby brings together your personal videos, music, photos, and live television.",
    "install_methods": [
        {
            "type": "default",
            "script": "ct/emby.sh", # this is the script path from the root of the repo. The frontend code can generate the installer command from this.
            "resources": {
                "cpu": "2",
                "ram": "2048", # This is the value extracted from the script itself, RAM is specified in MB
                "hdd": "8",  # Hdd is specified in GB
                "os": "ubuntu",
                "version": "22.04"
            }
        }
    ],
    "default_credentials": {
        "username": "",
        "password": ""
    },
    "alerts": [ # We can have multiple alerts.
        {
            "alert": "With Privileged/Unprivileged Hardware Acceleration Support" 
        }
    ]
}
```

## Notes

I found a couple of scripts that are in the database but no longer exist as scripts:

1. scrutiny
2. collabora-online

So I think keeping the database in the repo as static files that can be committed or changed in lock-step with the scripts is a good idea. In the future we can automate checking that new scripts have a correct json file.

The script that generated these json files can be found [here](https://gist.github.com/newzealandpaul/897f59fb04cec2dc90fad15084e5a7de).

This wrangling job took quite a long time dealing with edge cases etc.

A script, or even a jq one liner could generate a categories.json file.

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [ ] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Documentation update required (this change requires an update to the documentation)