### PR TITLE
[Bugfix] Add Whiptail Information to set ressources (Tandoor, ActualBudget, CalibreWeb)

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -55,6 +55,7 @@ function default_settings() {
 function update_script() {
 header_info
 if [[ ! -d /opt/actualbudget ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
 msg_info "Updating ${APP}"
 systemctl stop actualbudget.service
 cd /opt/actualbudget

--- a/ct/calibre-web.sh
+++ b/ct/calibre-web.sh
@@ -58,6 +58,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
   header_info
   msg_info "Updating $APP LXC"
   systemctl stop cps

--- a/ct/tandoor.sh
+++ b/ct/tandoor.sh
@@ -56,6 +56,7 @@ function default_settings() {
 function update_script() {
   header_info
   if [[ ! -d /opt/tandoor ]]; then msg_error "No ${APP} Installation Found!"; exit; fi 
+  whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75
   if cd /opt/tandoor && git pull | grep -q 'Already up to date'; then
     msg_ok "There is currently no update available."
   else


### PR DESCRIPTION
Fixes # (issue)
Add: 
whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "SET RESOURCES" "Please set the resources in your ${APP} LXC to ${var_cpu}vCPU and ${var_ram}RAM for the build process before continuing" 10 75

for Tandoor, ActualBudget, CalibreWeb.


## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
