### PR TITLE
Remove custom update script in Pi-Alert installation

### DIFF
--- a/install/pialert-install.sh
+++ b/install/pialert-install.sh
@@ -79,8 +79,6 @@ done
 sed -i 's#PIALERT_PATH\s*=\s*'\''/home/pi/pialert'\''#PIALERT_PATH           = '\''/opt/pialert'\''#' /opt/pialert/config/pialert.conf
 sed -i 's/$HOME/\/opt/g' /opt/pialert/install/pialert.cron
 crontab /opt/pialert/install/pialert.cron
-echo "bash -c \"\$(wget -qLO - https://github.com/leiweibau/Pi.Alert/raw/main/install/pialert_update.sh)\" -s --lxc" >/usr/bin/update
-chmod +x /usr/bin/update
 echo "python3 /opt/pialert/back/pialert.py 1" >/usr/bin/scan
 chmod +x /usr/bin/scan
 echo "/opt/pialert/back/pialert-cli set_permissions --lxc" >/usr/bin/permissions


### PR DESCRIPTION
## Description

Remove custom update script in Pi-Alert installation. The file `/usr/bin/update` is created automatically by the customize function in install.func and should not be overwritten (keep the update logic in the update script)

## Type of change
- [X] Bug fix (non-breaking change that resolves an issue)
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
