### PR TITLE
Update photoprism-install.sh

### DIFF
--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -43,7 +43,7 @@ fi
 ldconfig
 cat <<EOF >/opt/photoprism/config/.env
 PHOTOPRISM_AUTH_MODE='password'
-PHOTOPRISM_ADMIN_PASSWORD='helper-scripts.com'
+PHOTOPRISM_ADMIN_PASSWORD='changeme'
 PHOTOPRISM_HTTP_HOST='0.0.0.0'
 PHOTOPRISM_HTTP_PORT='2342'
 PHOTOPRISM_SITE_CAPTION='https://Helper-Scripts.com'


### PR DESCRIPTION
Wrong password entered in script ("Helper-Scripts.com") compared to website ("changeme").

## Description

The password for PhotoPrism on the site does not match the password in the installation script.

On the site: Helper-Scripts.com
In the script: changeme
