### PR TITLE
Added note regarding OVM as this as historically caused a lot of supp…

### DIFF
--- a/json/omv.json
+++ b/json/omv.json
@@ -32,7 +32,7 @@
     },
     "notes": [
         {
-            "text": "Running OVM in a LXC container <a href='https://github.com/tteck/Proxmox/discussions/1075'>may require a complicated disk setup</a>. Consider using a VM instead.",
+            "text": "Running OVM in a LXC container may require a complicated disk setup, consider using a VM instead. More info: `https://github.com/tteck/Proxmox/discussions/1075`",
             "type": "warning"
         }
     ]

--- a/json/omv.json
+++ b/json/omv.json
@@ -32,7 +32,7 @@
     },
     "notes": [
         {
-            "text": "Running OVM in a LXC container may require a complicated disk setup, consider using a VM instead. More info: `https://github.com/tteck/Proxmox/discussions/1075`",
+            "text": "Running OVM in a LXC container may require a complicated disk setup, consider using a VM instead. More info: `https://github.com/community-scripts/ProxmoxVE/discussions/175`",
             "type": "warning"
         }
     ]

--- a/json/omv.json
+++ b/json/omv.json
@@ -30,5 +30,10 @@
         "username": "admin",
         "password": "openmediavault"
     },
-    "notes": []
+    "notes": [
+        {
+            "text": "Running OVM in a LXC container <a href='https://github.com/tteck/Proxmox/discussions/1075'>may require a complicated disk setup</a>. Consider using a VM instead.",
+            "type": "warning"
+        }
+    ]
 }


### PR DESCRIPTION
## Description

Adds a note to the slightly controversial OpenMediaVault LXC that adding disks is difficult with a link to a previous discussion about how to add disks. Officially OMV does not support LXCs and at one point @tteck removed the OVM script. 

Fixes #132 

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)
- [ ] Documentation update required (this change requires an update to the documentation)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Testing performed (I have tested my changes, ensuring everything works as expected)