### PR TITLE
fix keyboard shortcut (ctrl + k) with empty categories

### DIFF
--- a/frontend/src/components/CommandMenu.tsx
+++ b/frontend/src/components/CommandMenu.tsx
@@ -40,6 +40,7 @@ export default function CommandMenu() {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
+        fetchSortedCategories();
         setOpen((open) => !open);
       }
     };


### PR DESCRIPTION
## Description

On page load, if the search bar in the navbar hasn’t been clicked, pressing (Ctrl + K) does not display the categories because data fetching hasn’t been triggered. You need to click the search bar first to fetch the data.

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.

before:
![Screenshot 2024-11-11 204816](https://github.com/user-attachments/assets/eb85c88b-d3ed-4b97-88b1-6a472e6995ae)

after:
![Screenshot 2024-11-11 205349](https://github.com/user-attachments/assets/7e09900c-01d5-4683-a42d-644008b2ab1d)

