### PR TITLE
Update pihole-install.sh

### DIFF
--- a/install/pihole-install.sh
+++ b/install/pihole-install.sh
@@ -44,6 +44,7 @@ msg_ok "Installed Pi-hole"
 
 read -r -p "Would you like to add Unbound? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  read -r -p "Should Unbound be configured as a forwarding DNS server (using DNS-over-TLS (DoT)) as opposed to a recursive DNS server <y/N> " prompt
   msg_info "Installing Unbound"
   $STD apt-get install -y unbound
   cat <<EOF >/etc/unbound/unbound.conf.d/pi-hole.conf
@@ -73,7 +74,6 @@ server:
   infra-cache-slabs: 8
   key-cache-slabs: 8
   serve-expired: yes
-  root-hints: /var/lib/unbound/root.hints
   serve-expired-ttl: 3600
   edns-buffer-size: 1232
   prefetch: yes
@@ -94,8 +94,34 @@ EOF
   cat <<EOF >/etc/dnsmasq.d/99-edns.conf
 edns-packet-max=1232
 EOF
-  wget -qO /var/lib/unbound/root.hints https://www.internic.net/domain/named.root
-  sed -i -e 's/PIHOLE_DNS_1=8.8.8.8/PIHOLE_DNS_1=127.0.0.1#5335/' -e 's/PIHOLE_DNS_2=8.8.4.4/#PIHOLE_DNS_2=8.8.4.4/' /etc/pihole/setupVars.conf
+
+  if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+    cat <<EOF >>/etc/unbound/unbound.conf.d/pi-hole.conf
+  tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
+forward-zone:
+  name: "."
+  forward-tls-upstream: yes
+  forward-first: no
+
+  forward-addr: 8.8.8.8@853#dns.google
+  forward-addr: 8.8.4.4@853#dns.google
+  forward-addr: 2001:4860:4860::8888@853#dns.google
+  forward-addr: 2001:4860:4860::8844@853#dns.google
+
+  #forward-addr: 1.1.1.1@853#cloudflare-dns.com
+  #forward-addr: 1.0.0.1@853#cloudflare-dns.com
+  #forward-addr: 2606:4700:4700::1111@853#cloudflare-dns.com
+  #forward-addr: 2606:4700:4700::1001@853#cloudflare-dns.com
+
+  #forward-addr: 9.9.9.9@853#dns.quad9.net
+  #forward-addr: 149.112.112.112@853#dns.quad9.net
+  #forward-addr: 2620:fe::fe@853#dns.quad9.net
+  #forward-addr: 2620:fe::9@853#dns.quad9.net
+EOF
+  fi
+
+  sed -i -e 's/PIHOLE_DNS_1=8.8.8.8/PIHOLE_DNS_1=127.0.0.1#5335/' -e '/PIHOLE_DNS_2=8.8.4.4/d' /etc/pihole/setupVars.conf
+  sed -i -e 's/server=8.8.8.8/server=127.0.0.1#5335/' -e '/server=8.8.4.4/d' /etc/dnsmasq.d/01-pihole.conf
   systemctl enable -q --now unbound
   systemctl restart pihole-FTL.service
   msg_ok "Installed Unbound"

--- a/install/pihole-install.sh
+++ b/install/pihole-install.sh
@@ -44,7 +44,7 @@ msg_ok "Installed Pi-hole"
 
 read -r -p "Would you like to add Unbound? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
-  read -r -p "Should Unbound be configured as a forwarding DNS server (using DNS-over-TLS (DoT)) as opposed to a recursive DNS server <y/N> " prompt
+  read -r -p "Unbound is configured as a recursive DNS server by default, would you like it to be configured as a forwarding DNS server (using DNS-over-TLS (DoT)) instead? <y/N> " prompt
   msg_info "Installing Unbound"
   $STD apt-get install -y unbound
   cat <<EOF >/etc/unbound/unbound.conf.d/pi-hole.conf

--- a/json/pihole.json
+++ b/json/pihole.json
@@ -38,6 +38,10 @@
         {
             "text": "With an option to add Unbound",
             "type": "warning"
+        },
+        {
+            "text": "With an option to configure Unbound as a forwarding DNS server (using DNS-over-TLS (DoT)) as opposed to a recursive DNS server",
+            "type": "warning"
         }
     ]
 }

--- a/json/pihole.json
+++ b/json/pihole.json
@@ -37,11 +37,11 @@
         },
         {
             "text": "With an option to add Unbound",
-            "type": "warning"
+            "type": "info"
         },
         {
             "text": "With an option to configure Unbound as a forwarding DNS server (using DNS-over-TLS (DoT)) as opposed to a recursive DNS server",
-            "type": "warning"
+            "type": "info"
         }
     ]
 }


### PR DESCRIPTION
## Description

* Added the option to configure Unbound as a forwarding DNS server (using DNS-over-TLS (DoT)).

* Simplified the Unbound configuration.  The root hints file is actually provided by the dns-root-data package so there is no need to explicitly define it (via the root-hints configuration directive) and wget it.  Also, there was no mechanism to update the file after the initial fetch - this will now done by the package manager.

* Fix: Unbound (127.0.0.1#5335) would not become active until a configuration change was made and saved or the application was updated.  These are the only times (other than during install) that /etc/dnsmasq.d/01-pihole.conf is synced with /etc/pihole/setupVars.conf.  Updated the install script to swap out the dns server in /etc/dnsmasq.d/01-pihole.conf similar to /etc/pihole/setupVars.conf.  Delete 8.8.4.4 in both files as opposed to commenting it out as the commented out line would never be recycled.

## Type of change
Please check the relevant option(s):

- [X] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [X] Documentation updated (I have updated any relevant documentation)