### PR TITLE
Give option to proceed with installation on unsupported PVE versions

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -99,8 +99,13 @@ pve_check() {
   if ! pveversion | grep -Eq "pve-manager/8.[1-3]"; then
     msg_error "This version of Proxmox Virtual Environment is not supported"
     echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
+    if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "UNSUPPORTED VERSION DETECTED" --yesno "This version of PVE is not supported. Running an installation script on unsupported PVE version might not work. Proceed using with installation anyway?" 10 72; then
+      echo -e "\nProceeding with installation on unsupported PVE version..."
+    else
+      echo -e "Exiting..."
+      sleep 2
+      exit
+    fi
     exit
 fi
 }

--- a/misc/build.func
+++ b/misc/build.func
@@ -99,7 +99,7 @@ pve_check() {
   if ! pveversion | grep -Eq "pve-manager/8.[1-3]"; then
     msg_error "This version of Proxmox Virtual Environment is not supported"
     echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "UNSUPPORTED VERSION DETECTED" --yesno "This version of PVE is not supported. Running an installation script on unsupported PVE version might not work. Proceed using with installation anyway?" 10 72; then
+    if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "UNSUPPORTED VERSION DETECTED" --yesno "This version of PVE is not supported. Running an installation script on unsupported PVE version might not work. Proceed with installation anyway?" 10 72; then
       echo -e "\nProceeding with installation on unsupported PVE version..."
     else
       echo -e "Exiting..."


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Small update to the `pve_check` function to give the option to users running older PVE version to still proceed with the scripts. We should keep the "officially supported" version to the latest major PVE, but I myself took a long time to migrate from PVE 7 to 8, and all scripts still worked fine.

Still, this comes with a big disclaimer that older version are unsupported, thus if they face any issue, they should upgrade and test again before opening an issue.

Let me know what you think. Not much of an issue on my end anymore since I upgraded, but I figured some may be in that situation.

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)
