### PR TITLE
Centralize all standard LXC options to avoid code duplication

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -151,7 +151,7 @@ base_settings() {
   VLAN=""
   SSH="no"
   VERB="no"
-  # Since these 2 are defined outside of default_settings function, avoid overwriting them. To align everything, they should use another constant variable (say OSTYPE), but that would require updating the default_settings function for all existing scripts
+  # Since these 2 are only defined outside of default_settings function, we add a temporary fallback. TODO: To align everything, we should add these as constant variables (e.g. OSTYPE and OSVERSION), but that would currently require updating the default_settings function for all existing scripts
   if [ -z "$var_os" ]; then
     var_os="debian"
   fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -129,7 +129,7 @@ ssh_check() {
   fi
 }
 
-# This function allows to centralize all common options so that services only need to define settings that need to be overridden (Avoid duplication of information)
+# This function sets base settings which are common for all scripts. The settings can be overriden in default_settings or advanced_settings which are defined in each script
 base_settings() {
   CT_TYPE="1"
   PW=""

--- a/misc/build.func
+++ b/misc/build.func
@@ -129,6 +129,37 @@ ssh_check() {
   fi
 }
 
+# This function allows to centralize all common options so that services only need to define settings that need to be overridden (Avoid duplication of information)
+base_settings() {
+  CT_TYPE="1"
+  PW=""
+  CT_ID=$NEXTID
+  HN=$NSAPP
+  DISK_SIZE="4"
+  CORE_COUNT="1"
+  RAM_SIZE="512"
+  BRG="vmbr0"
+  NET="dhcp"
+  GATE=""
+  APT_CACHER=""
+  APT_CACHER_IP=""
+  DISABLEIP6="no"
+  MTU=""
+  SD=""
+  NS=""
+  MAC=""
+  VLAN=""
+  SSH="no"
+  VERB="no"
+  # Since these 2 are defined outside of default_settings function, avoid overwriting them. To align everything, they should use another constant variable (say OSTYPE), but that would require updating the default_settings function for all existing scripts
+  if [ -z "$var_os" ]; then
+    var_os="debian"
+  fi
+  if [ -z "$var_version" ]; then
+    var_version="12"
+  fi
+}
+
 # This function displays the default values for various settings.
 echo_default() {
   echo -e "${DGN}Using Distribution: ${BGN}$var_os${CL}"
@@ -491,6 +522,7 @@ install_script() {
   NEXTID=$(pvesh get /cluster/nextid)
   timezone=$(cat /etc/timezone)
   header_info
+  base_settings
   if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "SETTINGS" --yesno "Use Default Settings?" --no-button Advanced 10 58); then
     header_info
     echo -e "${BL}Using Default Settings${CL}"


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Add a function, `base_settings`, to centralize all common options so that scripts only need to define settings that need to be overridden. For the great majority of scripts, all the options use the default values for `default_settings`. Key settings are already captured outside of the `default_settings` function: `var_XXX` (eg. `var_disk`, `var_cpu` ...)

With this PR, the default_settings function in scripts could go from:

```
function default_settings() {
  CT_TYPE="1"
  PW=""
  CT_ID=$NEXTID
  HN=$NSAPP
  DISK_SIZE="$var_disk"
  CORE_COUNT="$var_cpu"
  RAM_SIZE="$var_ram"
  BRG="vmbr0"
  NET="dhcp"
  GATE=""
  APT_CACHER=""
  APT_CACHER_IP=""
  DISABLEIP6="no"
  MTU=""
  SD=""
  NS=""
  MAC=""
  VLAN=""
  SSH="no"
  VERB="no"
  echo_default
}
```

to 

```
function default_settings() {
  CT_ID=$NEXTID
  HN=$NSAPP
  DISK_SIZE="$var_disk"
  CORE_COUNT="$var_cpu"
  RAM_SIZE="$var_ram"
  echo_default
}
```

and in case a script needs to overwrite an additional setting, simply add it back, like this:

```
function default_settings() {
  CT_ID=$NEXTID
  HN=$NSAPP
  DISK_SIZE="$var_disk"
  CORE_COUNT="$var_cpu"
  RAM_SIZE="$var_ram"
  DISABLEIP6="yes"
  VERB="yes"
  echo_default
}
```

I've been using this in my fork for some time. It's great when you need to add a new default variable, you don't need to update back all the scripts. Plus, it's good practice to avoid duplication of information.

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)
