### PR TITLE
Add utility functions for processing Github releases

### DIFF
--- a/misc/install.func
+++ b/misc/install.func
@@ -201,3 +201,52 @@ EOF
   echo "bash -c \"\$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
 }
+
+# This function downloads the latest release of a GitHub repository
+download_latest_github_release() {
+  local user="$1"
+  local repo="$2"
+
+  local release_info=$(curl -s "https://api.github.com/repos/$user/$repo/releases/latest")
+
+  local tarball_url=$(echo "$release_info" | grep '"tarball_url":' | cut -d '"' -f 4)
+
+  if [ -z "$tarball_url" ]; then
+    msg_error "Could not fetch the latest release tarball URL."
+    exit 1
+  fi
+
+  local output_file="${repo}-latest.tar.gz"
+  curl -s -L "$tarball_url" -o "$output_file"
+
+  if [ $? -ne 0 ]; then
+    msg_error "Failed to download the release tarball."
+    exit 1
+  fi
+
+  echo "$output_file"
+}
+
+# This function extracts a GitHub release tarball into a target directory
+extract_github_tarball() {
+  local tarball="$1"
+  local target_root="$2"
+
+  local temp_dir=$(mktemp -d)
+  tar -xf "$tarball" -C "$temp_dir"
+
+  if [ $? -ne 0 ]; then
+    msg_error "Failed to extract the release tarball."
+    rm -rf "$temp_dir"
+    exit 1
+  fi
+
+  # Find the root directory inside the temp directory
+  local extracted_root=$(find "$temp_dir" -mindepth 1 -maxdepth 1 -type d)
+
+  # Create the target directory and move the files
+  mkdir -p "$target_root"
+  mv "$extracted_root"/* "$target_root"
+
+  rm -rf "$temp_dir"
+}

--- a/misc/install.func
+++ b/misc/install.func
@@ -203,50 +203,21 @@ EOF
 }
 
 # This function downloads the latest release of a GitHub repository
-download_latest_github_release() {
+github_download_latest_release() {
   local user="$1"
   local repo="$2"
-
-  local release_info=$(curl -s "https://api.github.com/repos/$user/$repo/releases/latest")
-
-  local tarball_url=$(echo "$release_info" | grep '"tarball_url":' | cut -d '"' -f 4)
-
-  if [ -z "$tarball_url" ]; then
-    msg_error "Could not fetch the latest release tarball URL."
-    exit 1
-  fi
-
-  local output_file="${repo}-latest.tar.gz"
-  curl -s -L "$tarball_url" -o "$output_file"
-
-  if [ $? -ne 0 ]; then
-    msg_error "Failed to download the release tarball."
-    exit 1
-  fi
-
-  echo "$output_file"
+  local output_file="$3"
+  local tarball_url=$($STD wget -qLO - "https://api.github.com/repos/$user/$repo/releases/latest" | grep '"tarball_url":' | cut -d '"' -f 4)
+  $STD wget -qLO "$output_file" "$tarball_url"
 }
 
 # This function extracts a GitHub release tarball into a target directory
-extract_github_tarball() {
-  local tarball="$1"
-  local target_root="$2"
-
-  local temp_dir=$(mktemp -d)
-  tar -xf "$tarball" -C "$temp_dir"
-
-  if [ $? -ne 0 ]; then
-    msg_error "Failed to extract the release tarball."
-    rm -rf "$temp_dir"
-    exit 1
-  fi
-
-  # Find the root directory inside the temp directory
-  local extracted_root=$(find "$temp_dir" -mindepth 1 -maxdepth 1 -type d)
-
-  # Create the target directory and move the files
-  mkdir -p "$target_root"
-  mv "$extracted_root"/* "$target_root"
-
-  rm -rf "$temp_dir"
+github_extract_latest_release() {
+  local user="$1"
+  local repo="$2"
+  local output_directory="$3"
+  mkdir -p "$output_directory"
+  github_download_latest_release "$user" "$repo" "/tmp/$repo.tar.gz"
+  tar -xzf "/tmp/$repo.tar.gz" -C "$output_directory" --strip-components 1
+  rm "/tmp/$repo.tar.gz"
 }


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Many scripts download github releases. This PR adds two utility functions:

**download_latest_github_release**(user, repo) downloads the latest release and returns (echos) the filename. It relies on the github HTTP API.

**extract_github_tarball**(tarball, directory) untars a github release into target directory (this is regardless of how the release is named).

This could be used to fix issue #321.

Because this modifies install.func it should be considered high risk. 

These functions can be easily test, for example:

```
#!/bin/sh
source misc/install.func
color
downloaded_file=$(download_latest_github_release BurntSushi ripgrep)
extract_github_tarball $downloaded_file release
```

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)