### PR TITLE
Remove old resource message from vaultwarden

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -53,6 +53,9 @@ function default_settings() {
 }
 
 function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
   if [[ ! -f /etc/systemd/system/vaultwarden.service ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
@@ -71,9 +74,6 @@ function update_script() {
     "3" "Set Admin Token" OFF \
     3>&1 1>&2 2>&3)
 
-  header_info
-  check_container_storage
-  check_container_resources
   if [ "$UPD" == "1" ]; then
     msg_info "Stopping Vaultwarden"
     systemctl stop vaultwarden.service
@@ -101,7 +101,6 @@ function update_script() {
     msg_ok "Started Vaultwarden"
 
     msg_ok "$VAULT Update Successful"
-    echo -e "\n ⚠️  Ensure you set resources back to normal settings \n"
     exit
   fi
   if [ "$UPD" == "2" ]; then


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Remove old resource message from vaultwarden

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
