### PR TITLE
fix: zigbee2mqtt default interface port 8080

### DIFF
--- a/json/zigbee2mqtt.json
+++ b/json/zigbee2mqtt.json
@@ -8,7 +8,7 @@
     "type": "ct",
     "updateable": true,
     "privileged": true,
-    "interface_port": 9442,
+    "interface_port": 8080,
     "documentation": "https://www.zigbee2mqtt.io/guide/getting-started/",
     "website": "https://www.zigbee2mqtt.io/",
     "logo": "https://github.com/Koenkk/zigbee2mqtt/blob/master/images/logo_bee_only.png?raw=true",


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

The default interface port for Zigbee2MQTT is `8080`, not `9442`.

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [ ] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

N/A
