### PR TITLE
generate_app_name in build.func

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -134,13 +134,13 @@ generate_app_name() {
         sudo apt-get install -y figlet &> /dev/null
     fi
 
-    # Den Wert der APP-Variable annehmen (kann angepasst werden)
+    # Use the Value of the APP Variable
     APP="$1"
 
-    # ASCII-Art erzeugen und formatieren
+    # Create and Formatting ASCII
     ascii_art=$(figlet -f slant "$APP")
 
-    # Ausgabe als cat <<EOF
+    # Output es cat <<EOF
     cat <<EOF
 $ascii_art
 EOF

--- a/misc/build.func
+++ b/misc/build.func
@@ -129,7 +129,7 @@ ssh_check() {
   fi
 }
 
-generate_app_name() {
+generate_app_header() {
     if ! command -v figlet &> /dev/null; then
         sudo apt-get install -y figlet &> /dev/null
     fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -140,7 +140,6 @@ generate_app_name() {
     # Create and Formatting ASCII
     ascii_art=$(figlet -f slant "$APP")
 
-    # Output es cat <<EOF
     cat <<EOF
 $ascii_art
 EOF

--- a/misc/build.func
+++ b/misc/build.func
@@ -129,6 +129,23 @@ ssh_check() {
   fi
 }
 
+generate_app_name() {
+    if ! command -v figlet &> /dev/null; then
+        sudo apt-get install -y figlet &> /dev/null
+    fi
+
+    # Den Wert der APP-Variable annehmen (kann angepasst werden)
+    APP="$1"
+
+    # ASCII-Art erzeugen und formatieren
+    ascii_art=$(figlet -f slant "$APP")
+
+    # Ausgabe als cat <<EOF
+    cat <<EOF
+$ascii_art
+EOF
+}
+
 # This function displays the default values for various settings.
 echo_default() {
   echo -e "${DGN}Using Distribution: ${BGN}$var_os${CL}"


### PR DESCRIPTION
## Description
Adding an ascii generation. Not so much code is needed anymore and cleans up the CT.sh.

In addition, the PR of new scripts no longer causes the problem that the wrong ASCII is used. 

As Example:
https://github.com/MickLesk/Proxmox_DEV/blob/main/ct/nextpvr.sh

You can test it with:
```bash
 bash -c "$(wget -qLO - https://raw.githubusercontent.com/MickLesk/Proxmox_DEV/refs/heads/main/ct/nextpvr.sh)"
``` 

Only this needed:
```bash
function header_info {
clear
generate_app_name "AppName"
}
header_info
```

Breaking Change, because i use the tool: figlet
Its a very small tool. 

=> Create Documentation: 
Users can created the tool self with "apt-get install figlet" or my script do it (without output)

Log
```sh
Need to get 137 kB of archives.
After this operation, 757 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian bookworm/main amd64 figlet amd64 2.2.5-3+b1 [137 kB]
Fetched 137 kB in 0s (665 kB/s)
```


Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


![image](https://github.com/user-attachments/assets/fed46b8e-b1e3-4173-a6ff-4ea140e91c31)

