### PR TITLE
Fix Actual Budget install missing build tools

### DIFF
--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -14,11 +14,13 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
-$STD apt-get install -y gpg
-$STD apt-get install -y git
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc \
+  gpg \
+  git \
+  build-essential
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up Node.js Repository"


### PR DESCRIPTION
## Description

The Actual Budget install fails at the `yarn install` step. Actual Budget depends on `better-sqlite3` which uses `node-gyp` to build the native module. `node-gyp` requires build tools (namely `make` and `cc`) to compile the sqlite module. This PR adds the `build-essential` package to allow `node-gyp` to build the sqlite module and successfully complete the Actual Budget installation. 

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Before adding build tools, running helper script in verbose mode:

![Screenshot 2024-11-23 at 10 56 53](https://github.com/user-attachments/assets/cc61eb01-b522-40a6-9b9e-3cf45ea4847f)

The output of the failed build log:
![Screenshot 2024-11-23 at 10 46 36](https://github.com/user-attachments/assets/340edfed-0bea-448a-860a-571532f2a739)

After adding build-essential and running script:
![Screenshot 2024-11-23 at 10 44 42](https://github.com/user-attachments/assets/9ba0bca3-7f67-49b5-96c3-f94f6d5b4477)
