### PR TITLE
Add action that creates github release based on CHANGELOG.md

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,25 @@
+name: Create new release
+
+on:
+  schedule:
+    # Runs "At 00:01 every night" (UTC)
+    - cron: '1 0 * * *'
+
+jobs:
+  create-new-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Parse CHANGELOG.md for yesterday's entries and create a new release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          YESTERDAY=$(date -u --date="yesterday" +%Y-%m-%d)
+          YESTERDAY_CHANGELOG_NOTES=$(awk '/^## '"$YESTERDAY"'/ {f=1; next} f && /^## [0-9]{4}-[0-9]{2}-[0-9]{2}/ {f=0} f && !/^## / {print}' CHANGELOG.md)
+          
+          if [ -n "$YESTERDAY_CHANGELOG_NOTES" ]; then
+            gh release create "$YESTERDAY" -n "$YESTERDAY_CHANGELOG_NOTES" --latest
+          fi


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Credit to @JcMinarro for the idea (https://github.com/JcMinarro/ProxmoxVE-Releases/releases).

Add action that creates github releases based on `CHANGELOG.md`. Runs scheduled every day after midnight and creates a release (with a tag) from yesterdays entries in `CHANGELOG.md` (if there are any). Since github runners can be delayed when there is high load, running this action after midnight is more reliable.

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.

![image](https://github.com/user-attachments/assets/0000594d-b0f5-4705-9865-603c9f38d3a1)


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
https://github.com/community-scripts/ProxmoxVE/discussions/23

