### PR TITLE
Fixed unreliable IPv4 internet check in install.func

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -82,9 +82,6 @@ network_check() {
     msg_ok "IPv4 Internet Connected";
     ipv4_connected=true
   else
-    msg_ok "Internet Connected"; 
-  else
-  
     msg_error "Internet NOT Connected"
     read -r -p "Would you like to continue anyway? <y/N> " prompt
     if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -78,7 +78,13 @@ setting_up_container() {
 network_check() {
   set +e
   trap - ERR
-  if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then msg_ok "Internet Connected"; else
+  if ping -c 1 -W 1 1.1.1.1 &>/dev/null || ping -c 1 -W 1 8.8.8.8 &>/dev/null || ping -c 1 -W 1 9.9.9.9 &>/dev/null; then 
+    msg_ok "IPv4 Internet Connected";
+    ipv4_connected=true
+  else
+    msg_ok "Internet Connected"; 
+  else
+  
     msg_error "Internet NOT Connected"
     read -r -p "Would you like to continue anyway? <y/N> " prompt
     if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then

--- a/misc/install.func
+++ b/misc/install.func
@@ -119,7 +119,7 @@ network_check() {
   ipv6_connected=false
   sleep 1
 # Check IPv4 connectivity
-  if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then 
+  if ping -c 1 -W 1 1.1.1.1 &>/dev/null || ping -c 1 -W 1 8.8.8.8 &>/dev/null || ping -c 1 -W 1 9.9.9.9 &>/dev/null; then 
     msg_ok "IPv4 Internet Connected";
     ipv4_connected=true
   else


### PR DESCRIPTION
Old check only tried a single IP address (1.1.1.1) which is not always online. Added Google (8.8.8.8) and CloudFlare (9.9.9.9) public resolvers so that if any of the three IPs are reachable, the test will succeed.

> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description
Fix for unreliable IPv4 internet test in install.func

Provide a summary of the changes made and/or reference the issue being addressed.
Old check only tried a single IP address (1.1.1.1) which is not always online. 
Added Google (8.8.8.8) and CloudFlare (9.9.9.9) public resolvers so that if any of the three IPs are reachable, the test will succeed.

Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
