### PR TITLE
Fix for unreliable IPv4 internet test in alpine-install.func

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -78,7 +78,9 @@ setting_up_container() {
 network_check() {
   set +e
   trap - ERR
-  if ping -c 1 -W 1 1.1.1.1 &>/dev/null; then msg_ok "Internet Connected"; else
+  if ping -c 1 -W 1 1.1.1.1 &>/dev/null || ping -c 1 -W 1 8.8.8.8 &>/dev/null || ping -c 1 -W 1 9.9.9.9 &>/dev/null; then   
+    msg_ok "Internet Connected" 
+  else
     msg_error "Internet NOT Connected"
     read -r -p "Would you like to continue anyway? <y/N> " prompt
     if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then


### PR DESCRIPTION


> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description
Old test only checked a single IP, which is not ideal if that IP is not up 100% of the time (and it has not been, historically). Added two additional public resolver IPs to the test, e.g. 8.8.8.8 (Google) and 9.9.9.9 (CloudFlare). If any one of the three IPs responds to a ping, the internet verification succeeds. This is much more reliable than using a single IP address. Also moved down the conditional and else for better readability.

Provide a summary of the changes made and/or reference the issue being addressed.
Fixes unreliable IPv4 internet test.

Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [ X ] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [ X ] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ X ] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ X ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
