### PR TITLE
Zabbix: Use Agent2 as Default | Update Script added | some other Improvements

### DIFF
--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -57,11 +57,31 @@ header_info
 check_container_storage
 check_container_resources
 if [[ ! -f /etc/zabbix/zabbix_server.conf ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
+msg_info "Stopping ${APP} Services"
+systemctl stop zabbix-server zabbix-agent2
+msg_ok "Stopped ${APP} Services"
+
 msg_info "Updating $APP LXC"
+mkdir -p /opt/zabbix-backup/
+cp /etc/zabbix/zabbix_server.conf /opt/zabbix-backup/
+cp /etc/apache2/conf-enabled/zabbix.conf /opt/zabbix-backup/
+cp -R /usr/share/zabbix/ /opt/zabbix-backup/
+cp -R /usr/share/zabbix-* /opt/zabbix-backup/
+cd /tmp
+wget -q https://repo.zabbix.com/zabbix/7.0/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian12_all.deb
+dpkg -i zabbix-release_latest+debian12_all.deb &>/dev/null
 apt-get update &>/dev/null
-apt-get -y upgrade &>/dev/null
-systemctl restart zabbix-server
-msg_ok "Updated $APP LXC"
+apt-get install --only-upgrade zabbix-server-pgsql zabbix-frontend-php zabbix-agent2 zabbix-agent2-plugin-* &>/dev/null
+
+msg_info "Starting ${APP} Services"
+systemctl start zabbix-server zabbix-agent2
+systemctl restart apache2
+msg_ok "Started ${APP} Services"
+
+msg_info "Cleaning Up"
+rm -rf /tmp/zabbix-release_latest+debian12_all.deb
+msg_ok "Cleaned"
+msg_ok "Updated Successfully"
 exit
 }
 

--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -67,6 +67,7 @@ cp /etc/zabbix/zabbix_server.conf /opt/zabbix-backup/
 cp /etc/apache2/conf-enabled/zabbix.conf /opt/zabbix-backup/
 cp -R /usr/share/zabbix/ /opt/zabbix-backup/
 cp -R /usr/share/zabbix-* /opt/zabbix-backup/
+rm -Rf /etc/apt/sources.list.d/zabbix.list
 cd /tmp
 wget -q https://repo.zabbix.com/zabbix/7.0/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian12_all.deb
 dpkg -i zabbix-release_latest+debian12_all.deb &>/dev/null

--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -14,17 +14,19 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Zabbix"
-wget -q https://repo.zabbix.com/zabbix/7.0/debian/pool/main/z/zabbix-release/zabbix-release_7.0-1+debian12_all.deb
-$STD dpkg -i zabbix-release_7.0-1+debian12_all.deb
-rm zabbix-release_7.0-1+debian12_all.deb
+cd /tmp
+wget -q https://repo.zabbix.com/zabbix/7.0/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian12_all.deb
+$STD dpkg -i /tmp/zabbix-release_latest+debian12_all.deb
 $STD apt-get update
-$STD apt-get install -y zabbix-server-pgsql zabbix-frontend-php php8.2-pgsql zabbix-apache-conf zabbix-sql-scripts zabbix-agent
+$STD apt-get install -y zabbix-server-pgsql zabbix-frontend-php php8.2-pgsql zabbix-apache-conf zabbix-sql-scripts 
+$STD apt-get install -y zabbix-agent2 zabbix-agent2-plugin-*
 msg_ok "Installed Zabbix"
 
 msg_info "Setting up PostgreSQL"
@@ -50,14 +52,15 @@ echo -e "zabbix Database Name: \e[32m$DB_NAME\e[0m" >>~/zabbix.creds
 msg_ok "Set up PostgreSQL"
 
 msg_info "Starting Services"
-systemctl restart zabbix-server zabbix-agent apache2
-systemctl enable -q zabbix-server zabbix-agent apache2
+systemctl restart zabbix-server zabbix-agent2 apache2
+systemctl enable -q --now zabbix-server zabbix-agent2 apache2
 msg_ok "Started Services"
 
 motd_ssh
 customize
 
 msg_info "Cleaning up"
+rm -rf /tmp/zabbix-release_latest+debian12_all.deb
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"

--- a/json/zabbix.json
+++ b/json/zabbix.json
@@ -6,10 +6,10 @@
     ],
     "date_created": "2024-06-12",
     "type": "ct",
-    "updateable": false,
+    "updateable": true,
     "privileged": false,
-    "interface_port": "5454",
-    "documentation": null,
+    "interface_port": "",
+    "documentation": "https://www.zabbix.com/documentation/current/en/manual",
     "website": "https://www.zabbix.com/",
     "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/zabbix.svg",
     "description": "Zabbix is an all-in-one monitoring solution with a variety of enterprise-grade features available right out of the box.",
@@ -33,7 +33,11 @@
     "notes": [
         {
             "text": "Database credentials: `cat zabbix.creds`",
-            "type": "warning"
+            "type": "info"
+        }
+        {
+            "text": "Zabbix is running in these LXC as standard with Zabbix-Agent2",
+            "type": "info"
         }
     ]
 }

--- a/json/zabbix.json
+++ b/json/zabbix.json
@@ -36,7 +36,7 @@
             "type": "info"
         }
         {
-            "text": "Zabbix is running in these LXC as standard with Zabbix-Agent2",
+            "text": "Zabbix agent 2 is used by default",
             "type": "info"
         }
     ]


### PR DESCRIPTION
## Description
- Updating the code base
- Script flow adapted to standard
- Switch to Zabbix-Agent2 (for LXC's)
- Update script with backup data
- some other little improvements

Breaking Change, since the script is now running with a different agent, I cannot and do not want to anchor this in the CT.sh script, it causes too many problems. So if you want to use Agent2, you have to install it yourself.

Fixes #174 

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)
