### PR TITLE
Remove changing DISK_REF for zfspool mikrotik-routeros.sh

### DIFF
--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -251,7 +251,7 @@ nfs | dir)
   DISK_REF="$VMID/"
   DISK_IMPORT="-format qcow2"
   ;;
-btrfs | zfspool)
+btrfs)
   DISK_EXT=""
   DISK_REF="$VMID/"
   DISK_IMPORT="-format raw"

--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -252,8 +252,13 @@ nfs | dir)
   DISK_IMPORT="-format qcow2"
   ;;
 btrfs)
-  DISK_EXT=""
+  DISK_EXT=".raw"
   DISK_REF="$VMID/"
+  DISK_IMPORT="-format raw"
+  ;;
+zfspool)
+  DISK_EXT=""
+  DISK_REF=""
   DISK_IMPORT="-format raw"
   ;;
 esac


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

When running the original script using zfspool as storage I  got the error:

"unable to parse zfs volume name..."

Removing the part that cchnages the DISK_REF is disk is to be located on a zfspool has solved this.

Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
