### PR TITLE
Fix: install mosquitto from mosquitto repo

### DIFF
--- a/install/mqtt-install.sh
+++ b/install/mqtt-install.sh
@@ -21,6 +21,11 @@ $STD apt-get install -y gpg
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Mosquitto MQTT Broker"
+source /etc/os-release
+curl -fsSL http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key >/usr/share/keyrings/mosquitto-repo.gpg.key
+chmod go+r /usr/share/keyrings/mosquitto-repo.gpg.key
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mosquitto-repo.gpg.key] http://repo.mosquitto.org/debian ${VERSION_CODENAME} main" >/etc/apt/sources.list.d/mosquitto.list
+$STD apt-get update
 $STD apt-get -y install mosquitto
 $STD apt-get -y install mosquitto-clients
 cat <<EOF >/etc/mosquitto/conf.d/default.conf


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

The `mosquitto` version from the official debian repositories is still [`2.0.11`, which was released in 2021, according to their git repository](https://github.com/eclipse-mosquitto/mosquitto/releases/tag/v2.0.11).
Running the `update` script would only ever update other packages, but never `mosquitto`.

This PR changes the install script to use the debian repository provided by Eclipse / Mosquitto, to get more recent versions.

This change will only affect new installs. Existing containers will continue to happily (not) update to any newer `mosquitto` version.

## Type of change

Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites

The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)
