### PR TITLE
Fix Kimai Apache2 Rights

### DIFF
--- a/install/kimai-install.sh
+++ b/install/kimai-install.sh
@@ -56,9 +56,9 @@ $STD composer install --no-dev --optimize-autoloader --no-interaction
 cp .env.dist .env
 sed -i "/^DATABASE_URL=/c\DATABASE_URL=mysql://$DB_USER:$DB_PASS@127.0.0.1:3306/$DB_NAME?charset=utf8mb4&serverVersion=$MYSQL_VERSION" /opt/kimai/.env
 $STD bin/console kimai:install -n
-chown -R :www-data .
-chmod -R g+r .
-chmod -R g+rw var/
+chown -R :www-data /opt/kimai
+chmod -R g+r /opt/kimai
+chmod -R g+rw /opt/kimai
 sudo chown -R www-data:www-data /opt/kimai
 sudo chmod -R 755 /opt/kimai
 $STD expect <<EOF


### PR DESCRIPTION
## Description
Apache2 may not have found the correct path. Nevertheless, data could be created without problems, only some changes to the sliders (ONLY in the settings area) did not work without apache2 reload.

Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
