### PR TITLE
Stirling-PDF: replace dependency for v0.35.0 and add check and fix in stirling-pdf.sh

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -59,6 +59,10 @@ check_container_resources
 if [[ ! -d /opt/Stirling-PDF ]]; then msg_error "No ${APP} Installation Found!"; exit; fi
 msg_info "Updating ${APP}"
 systemctl stop stirlingpdf
+if [[ -n $(dpkg -l | grep -w ocrmypdf) ]] && [[ -z $(dpkg -l | grep -w qpdf) ]]; then
+  apt-get remove -y ocrmypdf &>/dev/null
+  apt-get install -y qpdf &>/dev/null
+fi
 RELEASE=$(curl -s https://api.github.com/repos/Stirling-Tools/Stirling-PDF/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 wget -q https://github.com/Stirling-Tools/Stirling-PDF/archive/refs/tags/v$RELEASE.tar.gz
 tar -xzf v$RELEASE.tar.gz

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -28,7 +28,7 @@ $STD apt-get install -y \
   make \
   g++ \
   unpaper \
-  ocrmypdf \
+  qpdf \
   poppler-utils
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Version 0.35.0 of Stirling-PDF now uses qpdf for OCR instead of ocrmypdf. This PR replaces ocrmypdf with qpdf in the install script, and for those with existing installations updating to 0.35.0 and later, checks for and replaces the packages during the update process.

Fixes #590 

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
See discussion at #590 for screenshots of the issue.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
