### PR TITLE
Update Spelling 'Environment' in nginxproxymanager

### DIFF
--- a/install/nginxproxymanager-install.sh
+++ b/install/nginxproxymanager-install.sh
@@ -80,7 +80,7 @@ else
   cd ./nginx-proxy-manager-${RELEASE}
   msg_ok "Downloaded Nginx Proxy Manager v${RELEASE}"
 fi
-msg_info "Setting up Enviroment"
+msg_info "Setting up Environment"
 ln -sf /usr/bin/python3 /usr/bin/python
 ln -sf /usr/bin/certbot /opt/certbot/bin/certbot
 ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx


### PR DESCRIPTION
Fix typo 'Enviroment' > 'Environment

Just a minor typo in the installation script that I spotted when running it.
