### PR TITLE
Use MongoDB 4.4 in Unifi for non-AVX users

### DIFF
--- a/install/unifi-install.sh
+++ b/install/unifi-install.sh
@@ -30,16 +30,15 @@ msg_ok "Installed Eclipse Temurin JRE"
 
 if ! grep -q -m1 'avx[^ ]*' /proc/cpuinfo; then
   msg_ok "No AVX Support Detected"
-  msg_info "Installing MongoDB 4.2"
+  msg_info "Installing MongoDB 4.4"
   if ! dpkg -l | grep -q "libssl1.1"; then
     wget -q http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1n-0+deb10u6_amd64.deb
     $STD dpkg -i libssl1.1_1.1.1n-0+deb10u6_amd64.deb
-    $STD apt-get install -f -y  # Fix any broken dependencies
   fi
-  wget -qO- https://www.mongodb.org/static/pgp/server-4.2.asc | gpg --dearmor > /usr/share/keyrings/mongodb-server-4.2.gpg
-  echo "deb [signed-by=/usr/share/keyrings/mongodb-server-4.2.gpg] https://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" >/etc/apt/sources.list.d/mongodb-org-4.2.list
+  wget -qO- https://www.mongodb.org/static/pgp/server-4.4.asc | gpg --dearmor > /usr/share/keyrings/mongodb-server-4.4.gpg
+  echo "deb [signed-by=/usr/share/keyrings/mongodb-server-4.4.gpg] https://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main" >/etc/apt/sources.list.d/mongodb-org-4.4.list
   $STD apt-get update
-  $STD apt-get install -y mongodb-org=4.2.17
+  $STD apt-get install -y mongodb-org
 else
   msg_info "Installing MongoDB 7.0"
   wget -qO- https://www.mongodb.org/static/pgp/server-7.0.asc | gpg --dearmor >/usr/share/keyrings/mongodb-server-7.0.gpg

--- a/json/unifi.json
+++ b/json/unifi.json
@@ -32,7 +32,7 @@
     },
     "notes": [
         {
-            "text": "For non-AVX CPUs, MongoDB 4.2 is installed. Please note this is a legacy solution that may present security risks and could become unsupported in future updates.",
+            "text": "For non-AVX CPUs, MongoDB 4.4 is installed. Please note this is a legacy solution that may present security risks and could become unsupported in future updates.",
             "type": "warning"
         }
     ]


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

MongoDB 4.4 is the latest version without AVX support, use that instead of 4.2.

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [x] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related to https://github.com/community-scripts/ProxmoxVE/issues/685
