### PR TITLE
Fix `rm` bug in Vikunja update

### DIFF
--- a/ct/vikunja.sh
+++ b/ct/vikunja.sh
@@ -67,7 +67,7 @@ if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_v
 
   msg_info "Updating ${APP} to ${RELEASE}"
   cd /opt
-  rm -r /opt/vikunja/vikunja
+  rm -rf /opt/vikunja/vikunja
   wget -q "https://dl.vikunja.io/vikunja/$RELEASE/vikunja-$RELEASE-amd64.deb"
   DEBIAN_FRONTEND=noninteractive dpkg -i vikunja-$RELEASE-amd64.deb &>/dev/null
   echo "${RELEASE}" >/opt/${APP}_version.txt

--- a/ct/vikunja.sh
+++ b/ct/vikunja.sh
@@ -67,7 +67,7 @@ if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_v
 
   msg_info "Updating ${APP} to ${RELEASE}"
   cd /opt
-  rm -rf /opt/*
+  rm -r /opt/vikunja/vikunja
   wget -q "https://dl.vikunja.io/vikunja/$RELEASE/vikunja-$RELEASE-amd64.deb"
   DEBIAN_FRONTEND=noninteractive dpkg -i vikunja-$RELEASE-amd64.deb &>/dev/null
   echo "${RELEASE}" >/opt/${APP}_version.txt


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Fixes an Issue with old installs where /opt/* is delete. Changed so only the binary is deleted, not all foldres.

Fixes #684

## Type of change
Please check the relevant option(s):

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [X] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:

