### PR TITLE
Update Home Assistant core to python 3.13

### DIFF
--- a/ct/homeassistant-core.sh
+++ b/ct/homeassistant-core.sh
@@ -79,7 +79,7 @@ function update_script() {
       echo -e "${GN}Updating to Stable Version${CL}"
       BR=""
     fi
-    if [[ "$PY" == "python3.11" ]]; then echo -e "⚠️  Home Assistant will soon require Python 3.12."; fi
+    if [[ "$PY" == "python3.12" || "$PY" == "python3.11" ]]; then echo -e "⚠️  Since Version 2024.12 Home Assistant will require Python 3.13."; fi
 
     msg_info "Stopping Home Assistant"
     systemctl stop homeassistant

--- a/install/homeassistant-core-install.sh
+++ b/install/homeassistant-core-install.sh
@@ -14,24 +14,54 @@ network_check
 update_os
 
 msg_info "Installing Dependencies (Patience)"
-$STD apt-get install -y git curl sudo mc bluez libffi-dev libssl-dev libjpeg-dev zlib1g-dev autoconf build-essential libopenjp2-7 libturbojpeg0-dev ffmpeg liblapack3 liblapack-dev dbus-broker libpcap-dev libavdevice-dev libavformat-dev libavcodec-dev libavutil-dev libavfilter-dev libmariadb-dev-compat libatlas-base-dev pip python3.12-dev
+$STD apt-get install -y \
+     git \
+     curl \
+     sudo \
+     mc \
+     bluez \
+     libffi-dev \
+     libssl-dev \
+     libjpeg-dev \
+     zlib1g-dev \
+     autoconf \
+     build-essential \
+     libopenjp2-7 \
+     libturbojpeg0-dev \
+     ffmpeg \
+     liblapack3 \
+     liblapack-dev \
+     dbus-broker \
+     libpcap-dev \
+     libavdevice-dev \
+     libavformat-dev \
+     libavcodec-dev \
+     libavutil-dev \
+     libavfilter-dev \
+     libmariadb-dev-compat \
+     libatlas-base-dev \
+     pip \
+     software-properties-common
+$STD add-apt-repository -y ppa:deadsnakes/ppa
+$STD apt-get update
+$STD apt-get install -y python3.13-dev
 msg_ok "Installed Dependencies"
 
 msg_info "Installing UV"
 $STD pip install uv
-msg_ok "Installed UV"
+msg_ok "Installing UV"
 
-msg_info "Setting up Home Assistant-Core environment"
+msg_info "Setup Home Assistant-Core"
 mkdir /srv/homeassistant
 cd /srv/homeassistant
 uv venv . &>/dev/null
 source bin/activate
-msg_ok "Created virtual environment with UV"
+msg_ok "Setup Home Assistant-Core"
 
-msg_info "Installing Home Assistant-Core and packages"
+msg_info "Setup Home Assistant-Core Packages"
 $STD uv pip install webrtcvad wheel homeassistant mysqlclient psycopg2-binary isal
 mkdir -p /root/.homeassistant
-msg_ok "Installed Home Assistant-Core and required packages"
+msg_ok "Setup Home Assistant-Core Packages"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/homeassistant.service
@@ -49,7 +79,7 @@ RestartForceExitStatus=100
 WantedBy=multi-user.target
 EOF
 systemctl enable -q --now homeassistant
-msg_ok "Created Service"
+msg_ok "Creating Service"
 
 motd_ssh
 customize
@@ -57,4 +87,4 @@ customize
 msg_info "Cleaning up"
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
-msg_ok "Cleaned"
+msg_ok "Cleaning up"


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Update the script to install Python 3.13 instead of 3.12. This is required by Home Assistant 2024.12. 
Python 13.3 is not yet in the official apt sources for Ubunut 24.02, so it uses  deadsnakes channel.

Home Assistant still installs with the current script version and seems to be working with python 3.12

Fixes #693 

## Type of change
Please check the relevant option(s):

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
