### PR TITLE
Bookstack: Fix Update function composer

### DIFF
--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -71,7 +71,7 @@ if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_v
   mv BookStack-${RELEASE} /opt/bookstack
   mv /opt/.env /opt/bookstack/.env
   cd /opt/bookstack
-  composer install --no-dev --no-interaction &>/dev/null
+  COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev  &>/dev/null
   php artisan key:generate --force &>/dev/null
   php artisan migrate --force &>/dev/null
   echo "${RELEASE}" >/opt/${APP}_version.txt

--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -70,9 +70,10 @@ if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_v
   unzip -q v${RELEASE}.zip
   mv BookStack-${RELEASE} /opt/bookstack
   mv /opt/.env /opt/bookstack/.env
-  COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev  &>/dev/null
-  php artisan key:generate &>/dev/null
-  php artisan migrate &>/dev/null
+  cd /opt/bookstack
+  composer install --no-dev --no-interaction &>/dev/null
+  php artisan key:generate --force &>/dev/null
+  php artisan migrate --force &>/dev/null
   echo "${RELEASE}" >/opt/${APP}_version.txt
   msg_ok "Updated ${APP}"
 


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

In the preveious version of this script the update would fail with 
```
✓ Services Stopped / Updating Bookstack to 24.10.3    [ERROR] in line 73: exit code 0: while executing command COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev &> /dev/null
```
Also would the script stop at **php artisan key:generate ** and ** php artisan migrate** without the switch **--force**



## Type of change
Please check the relevant option(s):

- [X] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [X] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [X] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.

Fixes the problem in the [Discusion](https://github.com/community-scripts/ProxmoxVE/discussions/582)

## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
