### PR TITLE
Fix Hoarder build failure by installing Chromium stable

### DIFF
--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -22,7 +22,8 @@ $STD apt-get install -y \
   sudo \
   gnupg \
   ca-certificates \
-  chromium \
+  chromium/stable \
+  chromium-common/stable \
   mc
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Chromium recently had an update which causes the Hoarder build to fail. This PR fixes the issue by specifying that Debian install Chromium and Chromium-common from the stable repo rather than the Security repo. After the container is built and when a user decides to update the system, Debian will handle this correctly by holding the packages back until it's dependencies are updated.

Fixes #719 

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Anyone who installed Hoarder via the script prior to the Chromium package update may need to manually intervene to fix conflicts prior to updating the system (running the update script is fine). Recommend that they run:

```bash
apt autoremove chromium
apt update && apt install chromium/stable chromium-common/stable
```


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
