### PR TITLE
Fix port and website in nextcloudpi.json

### DIFF
--- a/json/nextcloudpi.json
+++ b/json/nextcloudpi.json
@@ -8,9 +8,9 @@
     "type": "ct",
     "updateable": false,
     "privileged": false,
-    "interface_port": 433,
+    "interface_port": 4443,
     "documentation": null,
-    "website": "https://www.turnkeylinux.org/nextcloud",
+    "website": "https://github.com/nextcloud/nextcloudpi",
     "logo": "https://raw.githubusercontent.com/loganmarchione/homelab-svg-assets/main/assets/nextcloud.svg",
     "description": "NextCloudPi is a popular self-hosted solution for file collaboration and data storage. It is built on the NextCloud software, which is an open-source platform for data management.",
     "install_methods": [


### PR DESCRIPTION
> [!NOTE]
> We are meticulous when it comes to merging code into the main branch, so please understand that we may reject pull requests that do not meet the project's standards. It's never personal. Also, game-related scripts have a lower chance of being merged.

## Description

Replace the website with the correct GitHub repository link.
Correct the default port of the NextcloudPi Panel, which should be 4443.

Fixes # (issue)

## Type of change
Please check the relevant option(s):

- [x] Bug fix (non-breaking change that resolves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [ ] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [ ] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)

## Additional Information (optional)
Provide any additional context or screenshots about the feature or fix here.


## Related Pull Requests / Discussions

If there are other pull requests or discussions related to this change, please link them here:
- Related PR #
