### PR TITLE
Fix variable name for CT_TYPE override

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -204,7 +204,7 @@ base_settings() {
   TAGS="community-script;"
   
   # Override default settings with variables from ct script
-  CT_TYPE=${var_privileged:-$CT_TYPE}
+  CT_TYPE=${var_unprivileged:-$CT_TYPE}
   DISK_SIZE=${var_disk:-$DISK_SIZE}
   CORE_COUNT=${var_cpu:-$CORE_COUNT}
   RAM_SIZE=${var_ram:-$RAM_SIZE}


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
Noticed a wrong variable name in build.func. ct.sh use `var_unprivileged`, not `var_privileged`

- 

- - -

- Related Issue: # (issue number, if applicable)  
- Related PR: # (if applicable)  
- Related Discussion: [Link](https://github.com/community-scripts/ProxmoxVE/discussions)  

---

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

