### PR TITLE
Update build.func to display the Proxmox Hostname

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -241,7 +241,7 @@ echo_default() {
   fi
 
   # Output the selected values with icons
-  echo -e "${HOST}${BOLD}${DGN}Hostname: ${BGN}$(hostname)${CL}"
+  echo -e "${HOST}${BOLD}${DGN}Proxmox Hostname: ${BGN}$(hostname)${CL}"
   echo -e "${OS}${BOLD}${DGN}Operating System: ${BGN}$var_os${CL}"
   echo -e "${OSVERSION}${BOLD}${DGN}Version: ${BGN}$var_version${CL}"
   echo -e "${CONTAINERTYPE}${BOLD}${DGN}Container Type: ${BGN}$CT_TYPE_DESC${CL}"
@@ -583,6 +583,7 @@ advanced_settings() {
     clear
     header_info
     echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
+    echo -e "${HOST}${BOLD}${DGN}Proxmox Hostname: ${BGN}$(hostname)${CL}"
     advanced_settings
   fi
 }

--- a/misc/build.func
+++ b/misc/build.func
@@ -8,7 +8,7 @@ variables() {
   NSAPP=$(echo ${APP,,} | tr -d ' ') # This function sets the NSAPP variable by converting the value of the APP variable to lowercase and removing any spaces.
   var_install="${NSAPP}-install"     # sets the var_install variable by appending "-install" to the value of NSAPP.
   INTEGER='^[0-9]+([.][0-9]+)?$'     # it defines the INTEGER regular expression pattern.
-  PVEHOST_NAME=$(hostname | tr a-z A-Z) # gets the Proxmox Hostname and sets it to Uppercase
+  PVEHOST_NAME=$(hostname) # gets the Proxmox Hostname and sets it to Uppercase
 }
 
 # This function sets various color variables using ANSI escape codes for formatting text in the terminal.

--- a/misc/build.func
+++ b/misc/build.func
@@ -316,7 +316,6 @@ advanced_settings() {
       fi
     done
   fi
-  
   # Setting Default Tag for Advanced Settings
   TAGS="community-script;"
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -316,7 +316,7 @@ advanced_settings() {
       fi
     done
   fi
-  echo -e "${HOST}${BOLD}${DGN}Hostname: ${BGN}$(hostname)${CL}"
+  
   # Setting Default Tag for Advanced Settings
   TAGS="community-script;"
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -316,7 +316,7 @@ advanced_settings() {
       fi
     done
   fi
-
+  echo -e "${HOST}${BOLD}${DGN}Hostname: ${BGN}$(hostname)${CL}"
   # Setting Default Tag for Advanced Settings
   TAGS="community-script;"
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -8,6 +8,7 @@ variables() {
   NSAPP=$(echo ${APP,,} | tr -d ' ') # This function sets the NSAPP variable by converting the value of the APP variable to lowercase and removing any spaces.
   var_install="${NSAPP}-install"     # sets the var_install variable by appending "-install" to the value of NSAPP.
   INTEGER='^[0-9]+([.][0-9]+)?$'     # it defines the INTEGER regular expression pattern.
+  PVEHOST_NAME=$(hostname | tr a-z A-Z) # gets the Proxmox Hostname and sets it to Uppercase
 }
 
 # This function sets various color variables using ANSI escape codes for formatting text in the terminal.
@@ -34,7 +35,6 @@ color() {
   CROSS="${TAB}✖️${TAB}${CL}"
   INFO="${TAB}💡${TAB}${CL}"
   OS="${TAB}🖥️${TAB}${CL}"
-  HOST="${TAB}🏢${TAB}${CL}"
   OSVERSION="${TAB}🌟${TAB}${CL}"
   CONTAINERTYPE="${TAB}📦${TAB}${CL}" 
   DISKSIZE="${TAB}💾${TAB}${CL}"
@@ -241,7 +241,6 @@ echo_default() {
   fi
 
   # Output the selected values with icons
-  echo -e "${HOST}${BOLD}${DGN}Proxmox Hostname: ${BGN}$(hostname)${CL}"
   echo -e "${OS}${BOLD}${DGN}Operating System: ${BGN}$var_os${CL}"
   echo -e "${OSVERSION}${BOLD}${DGN}Version: ${BGN}$var_version${CL}"
   echo -e "${CONTAINERTYPE}${BOLD}${DGN}Container Type: ${BGN}$CT_TYPE_DESC${CL}"
@@ -581,8 +580,7 @@ advanced_settings() {
   else
     clear
     header_info
-    echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
-    echo -e "${HOST}${BOLD}${DGN}Proxmox Hostname: ${BGN}$(hostname)${CL}"
+    echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings on node $PVEHOST_NAME${CL}"
     advanced_settings
   fi
 }
@@ -616,7 +614,7 @@ install_script() {
     case $CHOICE in
       1)
         header_info
-        echo -e "${DEFAULT}${BOLD}${BL}Using Default Settings${CL}"
+        echo -e "${DEFAULT}${BOLD}${BL}Using Default Settings on node $PVEHOST_NAME${CL}"
         VERB="no"
         base_settings "$VERB"  
         echo_default
@@ -624,7 +622,7 @@ install_script() {
         ;;
       2)
         header_info
-        echo -e "${DEFAULT}${BOLD}${BL}Using Default Settings (${SEARCH}${BOLD}${BL} Verbose)${CL}"
+        echo -e "${DEFAULT}${BOLD}${BL}Using Default Settings on node $PVEHOST_NAME(${SEARCH}${BOLD}${BL} Verbose)${CL}"
         VERB="yes"
         base_settings "$VERB"  
         echo_default

--- a/misc/build.func
+++ b/misc/build.func
@@ -34,6 +34,7 @@ color() {
   CROSS="${TAB}✖️${TAB}${CL}"
   INFO="${TAB}💡${TAB}${CL}"
   OS="${TAB}🖥️${TAB}${CL}"
+  HOST="${TAB}🏢${TAB}${CL}"
   OSVERSION="${TAB}🌟${TAB}${CL}"
   CONTAINERTYPE="${TAB}📦${TAB}${CL}" 
   DISKSIZE="${TAB}💾${TAB}${CL}"
@@ -240,6 +241,7 @@ echo_default() {
   fi
 
   # Output the selected values with icons
+  echo -e "${HOST}${BOLD}${DGN}Hostname: ${BGN}$(hostname)${CL}"
   echo -e "${OS}${BOLD}${DGN}Operating System: ${BGN}$var_os${CL}"
   echo -e "${OSVERSION}${BOLD}${DGN}Version: ${BGN}$var_version${CL}"
   echo -e "${CONTAINERTYPE}${BOLD}${DGN}Container Type: ${BGN}$CT_TYPE_DESC${CL}"

--- a/misc/build.func
+++ b/misc/build.func
@@ -630,7 +630,7 @@ install_script() {
         ;;
       3)
         header_info
-        echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings${CL}"
+        echo -e "${ADVANCED}${BOLD}${RD}Using Advanced Settings on node $PVEHOST_NAME${CL}"
         advanced_settings
         break
         ;;


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
Provide a summary of the changes made and/or reference the issue being addressed.

Added the function to Display the name of the Proxmox Host during CT creation. 

This is probably just a me Problem with my 5 Hosts, but sometimes when you work on more then one Host at a time it would be nice to see the Host you are working on. 

I find it is a neat little improvment and adds some verbosity. 

You can test it against my dev branch: `bash -c "$(wget -qLO - https://raw.githubusercontent.com/michelroegl-brunner/ProxmoxVE/refs/heads/DEV/ct/zammad.sh)"`



## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [X] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)

![build_advanced](https://github.com/user-attachments/assets/196e9a32-9573-46f2-a3a4-55cffbb05e4b)
![build_deafult](https://github.com/user-attachments/assets/de958e60-4ca7-4698-a803-12c5dbc9ff65)
![build_deafult_verbose](https://github.com/user-attachments/assets/ddde7bae-e325-44b4-99a0-0b8e8b6a9eaf)

