### PR TITLE
Fix Omada - Crawling latest version

### DIFF
--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -32,8 +32,8 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  latest_url=$(curl -fsSL "https://www.tp-link.com/en/support/download/omada-software-controller/" | grep -o 'https://.*x64.deb' | head -n1)
-  latest_version=$(basename "${latest_url}")
+  latest_url=$(curl -fsSL "https://www.tp-link.com/en/support/download/omada-software-controller/" | grep -oP 'href="([^"]+linux_x64[^"]+\.deb)"' | sed 's/href="//' | sort | tail -n 1)
+  latest_version=$(basename "$latest_url")
   if [ -z "${latest_version}" ]; then
     msg_error "It seems that the server (tp-link.com) might be down. Please try again at a later time."
     exit

--- a/install/omada-install.sh
+++ b/install/omada-install.sh
@@ -14,11 +14,12 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
-$STD apt-get install -y gnupg
-$STD apt-get install -y jsvc
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc \
+  gnupg \
+  jsvc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Azul Zulu"

--- a/install/omada-install.sh
+++ b/install/omada-install.sh
@@ -37,7 +37,7 @@ wget -qL https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/3.6/multiv
 $STD dpkg -i mongodb-org-server_3.6.23_amd64.deb
 msg_ok "Installed MongoDB"
 
-latest_url=$(curl -fsSL "https://www.tp-link.com/en/support/download/omada-software-controller/" | grep -o 'https://.*x64.deb' | head -n1)
+latest_url=$(curl -fsSL "https://www.tp-link.com/en/support/download/omada-software-controller/" | grep -oP 'href="([^"]+linux_x64[^"]+\.deb)"' | sed 's/href="//' | sort | tail -n 1)
 latest_version=$(basename "$latest_url")
 
 msg_info "Installing Omada Controller"


### PR DESCRIPTION
## ✍️ Description
The script was always downloading the older version because the grep command was extracting all links containing linux_x64 in the HTML content. However, the extraction wasn't sorted, and the head -n1 command was picking the first match, which might not always be the latest version. Additionally, the HTML content could include multiple links with similar patterns, such as older versions or different file types (e.g., .tar.gz), causing the script to select the wrong one.

By adding a sort command, we ensured that the list of URLs was ordered, and then using tail -n 1 ensured the script always selects the most recent version, based on the sorted list.
 

- - -
- Related Issue: #889 

---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [x] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

