### PR TITLE
Doubled RAM for SAB

### DIFF
--- a/ct/sabnzbd.sh
+++ b/ct/sabnzbd.sh
@@ -9,7 +9,7 @@ source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/m
 APP="SABnzbd"
 var_tags="downloader"
 var_cpu="2"
-var_ram="2048"
+var_ram="4096"
 var_disk="8"
 var_os="debian"
 var_version="12"


### PR DESCRIPTION
## ✍️ Description
Having only 2GB of RAM will result in unrar OOM crashes.

- - -
**_Please remove unneeded lines!_**
- Related Issue: https://github.com/sabnzbd/sabnzbd/issues/3007

---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  

---

