### PR TITLE
ChangeDetection Update: Update also Browsers

### DIFF
--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -28,18 +28,29 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
+
   if [[ ! -f /etc/systemd/system/changedetection.service ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  msg_info "Updating ${APP} LXC"
+
   if ! dpkg -s libjpeg-dev >/dev/null 2>&1; then
+    msg_info "Installing Dependencies"
     apt-get update
     apt-get install -y libjpeg-dev
+    msg_ok "Updated Dependencies"
   fi
+
+  msg_info "Updating ${APP}"
   pip3 install changedetection.io --upgrade &>/dev/null
+  msg_ok "Updated ${APP}"
+
+  msg_info "Updating Playwright"
   pip3 install playwright --upgrade &>/dev/null
+  msg_ok "Updated Playwright"
+
   if [[ -f /etc/systemd/system/browserless.service ]]; then
+    msg_info "Updating Browserless (Patience)"
     git -C /opt/browserless/ fetch --all &>/dev/null
     git -C /opt/browserless/ reset --hard origin/main &>/dev/null
     npm update --prefix /opt/browserless &>/dev/null
@@ -51,9 +62,11 @@ function update_script() {
     npm run build:function --prefix /opt/browserless &>/dev/null
     npm prune production --prefix /opt/browserless &>/dev/null
     systemctl restart browserless
+    msg_ok "Updated Browserless"
   else
     msg_error "No Browserless Installation Found!"
   fi
+
   systemctl restart changedetection
   msg_ok "Updated Successfully"
   exit

--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -43,6 +43,10 @@ function update_script() {
     git -C /opt/browserless/ fetch --all &>/dev/null
     git -C /opt/browserless/ reset --hard origin/main &>/dev/null
     npm update --prefix /opt/browserless &>/dev/null
+    /opt/browserless/node_modules/playwright-core/cli.js install --with-deps &>/dev/null
+    # Update Chrome separately, as it has to be done with the force option. Otherwise the installation of other browsers will not be done if Chrome is already installed.
+    /opt/browserless/node_modules/playwright-core/cli.js install --force chrome &>/dev/null
+    /opt/browserless/node_modules/playwright-core/cli.js install chromium firefox webkit &>/dev/null
     npm run build --prefix /opt/browserless &>/dev/null
     npm run build:function --prefix /opt/browserless &>/dev/null
     npm prune production --prefix /opt/browserless &>/dev/null


### PR DESCRIPTION
## ✍️ Description
In ChangeDetection-Script (ct/changedetection.sh):
- Update also browsers in function update_script
- Adding more messages in function update_script
- Make function update_script more readable by adding line breaks
 

- - -
- Related Issue: #1026   
---

## 🛠️ Type of Change
Please check the relevant option(s):
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Fix an issue (#1026) that Browserless-service is not starting up after an update of Broswerless and/or Playwright, because now chromium_headless is needed and/or the installed version of the browsers are not compatible anymore.

This fix was verified by me by upgrading from a working backup. Also could reproduce the issue when updating from the working backup beforehand.

