### PR TITLE
Revert Base Scripts Tag to proxmox-helper-scripts

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -317,7 +317,7 @@ advanced_settings() {
     done
   fi
   # Setting Default Tag for Advanced Settings
-  TAGS="community-script;"
+  TAGS="proxmox-helper-scripts;${var_tags:-}"
 
   CT_TYPE=""
   while [ -z "$CT_TYPE" ]; do

--- a/misc/build.func
+++ b/misc/build.func
@@ -214,7 +214,7 @@ base_settings() {
   MAC=""
   VLAN=""
   SSH="no"
-  TAGS="community-script;"
+  TAGS="proxmox-helper-scripts;"
   
   # Override default settings with variables from ct script
   CT_TYPE=${var_unprivileged:-$CT_TYPE}


### PR DESCRIPTION
## ✍️ Description
It seems like a new tag has been introduced, which is kinda breaking backwards-comparability.

- - -
**_Please remove unneeded lines!_**
- Related PR: https://github.com/community-scripts/ProxmoxVE/pull/333

---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)

With this PR I re-introduce the old "`proxmox-helper-scripts`" tag isntead of having a new "`community-script`" tag.