### PR TITLE
Apache-Guacamole script bug fix

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -51,6 +51,14 @@ chmod -R g+r /opt/apache-guacamole/tomcat9/conf
 chmod g+x /opt/apache-guacamole/tomcat9/conf
 msg_ok "Setup Apache Tomcat"
 
+msg_info "Creating guacd.conf"
+cat <<EOF >/etc/guacamole/guacd.conf
+[server]
+bind_host = 0.0.0.0
+bind_port = 4822
+EOF
+msg_ok "Created guacd.conf"
+
 msg_info "Setup Apache Guacamole"
 mkdir -p /etc/guacamole/{extensions,lib}
 RELEASE_SERVER=$(curl -sL https://api.github.com/repos/apache/guacamole-server/tags | jq -r '.[0].name')

--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -54,7 +54,7 @@ msg_ok "Setup Apache Tomcat"
 msg_info "Creating guacd.conf"
 cat <<EOF >/etc/guacamole/guacd.conf
 [server]
-bind_host = 0.0.0.0
+bind_host = 127.0.0.1
 bind_port = 4822
 EOF
 msg_ok "Created guacd.conf"

--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -51,14 +51,6 @@ chmod -R g+r /opt/apache-guacamole/tomcat9/conf
 chmod g+x /opt/apache-guacamole/tomcat9/conf
 msg_ok "Setup Apache Tomcat"
 
-msg_info "Creating guacd.conf"
-cat <<EOF >/etc/guacamole/guacd.conf
-[server]
-bind_host = 127.0.0.1
-bind_port = 4822
-EOF
-msg_ok "Created guacd.conf"
-
 msg_info "Setup Apache Guacamole"
 mkdir -p /etc/guacamole/{extensions,lib}
 RELEASE_SERVER=$(curl -sL https://api.github.com/repos/apache/guacamole-server/tags | jq -r '.[0].name')
@@ -106,6 +98,11 @@ cat *.sql | mysql -u root ${DB_NAME}
 msg_ok "Setup Database"
 
 msg_info "Setup Service"
+cat <<EOF >/etc/guacamole/guacd.conf
+[server]
+bind_host = 127.0.0.1
+bind_port = 4822
+EOF
 JAVA_HOME=$(update-alternatives --query javadoc | grep Value: | head -n1 | sed 's/Value: //' | sed 's@bin/javadoc$@@')
 cat <<EOF >/etc/systemd/system/tomcat.service
 [Unit]
@@ -130,6 +127,7 @@ Restart=always
 WantedBy=multi-user.target
 EOF
 systemctl -q enable --now tomcat guacd mysql
+systemctl start guacd
 msg_ok "Setup Service"
 
 motd_ssh

--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -127,7 +127,6 @@ Restart=always
 WantedBy=multi-user.target
 EOF
 systemctl -q enable --now tomcat guacd mysql
-systemctl start guacd
 msg_ok "Setup Service"
 
 motd_ssh


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
Provide a summary of the changes made and/or reference the issue being addressed.


- - -

This pull request addresses the issue of guacd not binding correctly to an IPv4 address, causing failures when Tomcat attempts to establish a connection. The changes include a fix for the installation script to create a proper guacd.conf file, ensuring seamless communication between Tomcat and guacd.
- Related issue: [#968](https://github.com/community-scripts/ProxmoxVE/issues/968)

Key changes:

- Added creation of /etc/guacamole/guacd.conf in the installation script.
- Set bind_host=127.0.0.1 as the default for guacd to enhance security and localize access unless explicitly required otherwise.

---

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [X] Documentation updated (I have updated any relevant documentation)

---
