### PR TITLE
feat: allow adding SSH authorized key for root (advanced settings)

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -568,6 +568,10 @@ advanced_settings() {
     echo -e "${ROOTSSH}${BOLD}${DGN}Root SSH Access: ${BGN}$SSH${CL}"
   fi
 
+  if [[ "${SSH}" == "yes" ]]; then
+    SSH_AUTHORIZED_KEY="$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "SSH Authorized key for root (leave empty for none)" 8 58 --title "SSH Key" 3>&1 1>&2 2>&3)"
+  fi
+
   if (whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "VERBOSE MODE" --yesno "Enable Verbose Mode?" 10 58); then
     VERB="yes"
   else
@@ -731,6 +735,7 @@ build_container() {
   export PASSWORD="$PW"
   export VERBOSE="$VERB"
   export SSH_ROOT="${SSH}"
+  export SSH_AUTHORIZED_KEY="${SSH_AUTHORIZED_KEY}"
   export CTID="$CT_ID"
   export CTTYPE="$CT_TYPE"
   export PCT_OSTYPE="$var_os"

--- a/misc/install.func
+++ b/misc/install.func
@@ -262,4 +262,11 @@ EOF
   fi
   echo "bash -c \"\$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
+
+  if [[ -n "${SSH_AUTHORIZED_KEY}" ]]; then
+    mkdir -p /root/.ssh
+    echo "${SSH_AUTHORIZED_KEY}" > /root/.ssh/authorized_keys
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/authorized_keys
+  fi
 }


### PR DESCRIPTION
## ✍️ Description

Adds and additional input to the advanced settings flow that allows adding an SSH authorized key for the root user.

- Related Discussion: #860 

---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [x] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)


I came up with multiple ways to implement this, but ultimately decided to go for the most pragmatic one to get a feel first.
Other possible implementation I had in mind:

- option to forward authorized_keys from the PVE host (multi select menu) to the newly created container / vm
- use a "well-known" file location or environment variable to contain the SSH key to authorize
