### PR TITLE
Introduce editorconfig for more consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+; editorconfig.org
+root = true
+
+[*]
+charset                     = utf-8
+continuation_indent_size    = 2
+end_of_line                 = lf
+indent_size                 = 2
+indent_style                = space
+insert_final_newline        = true
+max_line_length             = 120
+tab_width                   = 2
+; trim_trailing_whitespace    = true ; disabled until files are cleaned up
+
+[*.md]
+trim_trailing_whitespace    = false


### PR DESCRIPTION
## ✍️ Description

Over my previous contributions I was struggling with the formatting in this repository, especially since my editor (vscode) uses tabs with a default width of 4, my preferred formatting for shell scripts.
[EditorConfig](https://editorconfig.org/) is a way to allow everyone to code consistently, without having to guess or try to imitate the formatting observed in existing files.

The config in this PR was created to cover the formatting that I _think_ is being applied in this repository.


