### PR TITLE
[Archivebox] Fix wrong port being printed post install.

### DIFF
--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -57,4 +57,4 @@ description
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8080/admin/login${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8000/admin/login${CL}"


### PR DESCRIPTION
At the conclusion of the setup the msg_ok block tells the user to use port 8080, this should be 8000.

> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
Provide a summary of the changes made and/or reference the issue being addressed.

 

- - -
**_Please remove unneeded lines!_**
- Related Issue: # (issue number, if applicable)  
- Related PR: # (if applicable)  
- Related Discussion: []()(if applicable)  

---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ✅ ] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [ ✅ ] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ✅ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

