### PR TITLE
fix: add homepage version during build step

### DIFF
--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -52,13 +52,13 @@ function update_script() {
     cd /opt/homepage
     npx update-browserslist-db@latest
     pnpm install
-    pnpm build
+    NEXT_PUBLIC_VERSION=$RELEASE NEXT_PUBLIC_REVISION='source' pnpm build
     systemctl start homepage
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated Homepage to v${RELEASE}"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
-  fi
+  fit
   exit
 }
 

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -52,15 +52,13 @@ function update_script() {
     cd /opt/homepage
     npx update-browserslist-db@latest
     pnpm install
-    NEXT_PUBLIC_VERSION=v$RELEASE
-    NEXT_PUBLIC_REVISION='source'
-    pnpm build
+    NEXT_PUBLIC_VERSION=v$RELEASE NEXT_PUBLIC_REVISION='source' pnpm build
     systemctl start homepage
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated Homepage to v${RELEASE}"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
-  fit
+  fi
   exit
 }
 

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -52,7 +52,9 @@ function update_script() {
     cd /opt/homepage
     npx update-browserslist-db@latest
     pnpm install
-    NEXT_PUBLIC_VERSION=$RELEASE NEXT_PUBLIC_REVISION='source' pnpm build
+    NEXT_PUBLIC_VERSION=v$RELEASE
+    NEXT_PUBLIC_REVISION='source'
+    pnpm build
     systemctl start homepage
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated Homepage to v${RELEASE}"

--- a/install/homepage-install.sh
+++ b/install/homepage-install.sh
@@ -42,6 +42,8 @@ mv homepage-${RELEASE}/* /opt/homepage
 rm -rf homepage-${RELEASE}
 cd /opt/homepage
 cp /opt/homepage/src/skeleton/* /opt/homepage/config
+NEXT_PUBLIC_VERSION=v$RELEASE
+NEXT_PUBLIC_REVISION='source'
 $STD pnpm install
 $STD pnpm build
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt

--- a/install/homepage-install.sh
+++ b/install/homepage-install.sh
@@ -42,10 +42,8 @@ mv homepage-${RELEASE}/* /opt/homepage
 rm -rf homepage-${RELEASE}
 cd /opt/homepage
 cp /opt/homepage/src/skeleton/* /opt/homepage/config
-NEXT_PUBLIC_VERSION=v$RELEASE
-NEXT_PUBLIC_REVISION='source'
 $STD pnpm install
-$STD pnpm build
+$STD NEXT_PUBLIC_VERSION=v$RELEASE NEXT_PUBLIC_REVISION='source' pnpm build
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Installed Homepage v${RELEASE}"
 


### PR DESCRIPTION
## ✍️ Description

Closes #1062

This pull request includes updates to the build process for the homepage application. The changes ensure that environment variables are set during the build process to include version and revision information.

Build process updates:

* [`ct/homepage.sh`](diffhunk://#diff-5e706703158f4b406e5cb906477e30a8eae0a623969866bf7d1f46fdcea69201L55-R55): Modified the `update_script` function to include `NEXT_PUBLIC_VERSION` and `NEXT_PUBLIC_REVISION` environment variables during the `pnpm build` step.
* [`install/homepage-install.sh`](diffhunk://#diff-c29df5fa995f8f78893b692af5fbd9ef3b3b531741df232aecb876f98194e583L46-R46): Updated the install script to set `NEXT_PUBLIC_VERSION` and `NEXT_PUBLIC_REVISION` environment variables during the `pnpm build` step.
 

- - -
- Related Issue: #1062

---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [x] Documentation updated (I have updated any relevant documentation)


