### PR TITLE
fix: guacd service not start during Apache-Guacamole script installation process

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -126,7 +126,21 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl -q enable --now tomcat guacd mysql
+cat <<EOF >/etc/systemd/system/guacd.service
+[Unit]
+Description=Guacamole Proxy Daemon (guacd)
+After=mysql.service tomcat.service
+Requires=mysql.service tomcat.service
+[Service]
+Type=forking
+ExecStart=/etc/init.d/guacd start
+ExecStop=/etc/init.d/guacd stop
+ExecReload=/etc/init.d/guacd restart
+PIDFile=/var/run/guacd.pid
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl -q enable --now mysql tomcat guacd
 msg_ok "Setup Service"
 
 motd_ssh


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description

This pull request wraps the guacd init script with a systemd unit file and adds relevant dependency directives to the guacd systemd service, which ensures a proper startup order and fixes guacd service not start during the installation process.

- - -
- Related PR: #1039
- Related Discussion: https://github.com/community-scripts/ProxmoxVE/pull/1039#issuecomment-2564057004, https://github.com/community-scripts/ProxmoxVE/pull/1039#issuecomment-2564057438 and https://github.com/community-scripts/ProxmoxVE/pull/1039#issuecomment-2566121782
---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  
Screenshot of guacd wrap service test.
<img width="1041" alt="guacd service test" src="https://github.com/user-attachments/assets/72ef8321-6d58-4862-a5d2-643feb995834" />

