### PR TITLE
Fix chromium installation for ArchiveBox 

### DIFF
--- a/install/archivebox-install.sh
+++ b/install/archivebox-install.sh
@@ -47,14 +47,14 @@ $STD apt-get update
 $STD apt-get install -y nodejs
 msg_ok "Installed Node.js"
 
-msg_info "Installing Playright/Chromium"
-$STD pip install playwright
-$STD playwright install --with-deps chromium
-msg_ok "Installed Playright/Chromium"
+msg_info "Installing Playwright"
+$STD pip install playwright 
+$STD playwright install-deps chromium 
+msg_ok "Installed Playwright"
 
-msg_info "Installing ArchiveBox"
+msg_info "Installing Chromium and ArchiveBox"
 mkdir -p /opt/archivebox/{data,.npm,.cache,.local}
-$STD adduser --system --shell /bin/bash --gecos 'Archive Box User' --group --disabled-password  archivebox
+$STD adduser --system --shell /bin/bash --gecos 'Archive Box User' --group --disabled-password --home /home/archivebox archivebox
 chown -R archivebox:archivebox /opt/archivebox/{data,.npm,.cache,.local}
 chmod -R 755 /opt/archivebox/data
 $STD pip install archivebox
@@ -63,6 +63,7 @@ expect <<EOF
 set timeout -1
 log_user 0
 
+spawn sudo -u archivebox playwright install chromium
 spawn sudo -u archivebox archivebox setup
 
 expect "Username"


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
When I installed ArchiveBox using the normal script, it was not able to execute anything relating to chromium. This seems to be fixed when giving the archivebox user a home directory and installing chromium through playwright using this user. Otherwise, playwright installs chromium in /root/.cache, which the archivebox user cannot access and ArchiveBox itself detects the installation incorrectly as being in /nonexistent/.cache/...
Using this script, ArchiveBox is being installed correctly on my Proxmox 8.2.4 installation. 


---

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)



