### PR TITLE
Implement overridable URL for scripts

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/agentdvr.sh
+++ b/ct/agentdvr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine-docker.sh
+++ b/ct/alpine-docker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine-grafana.sh
+++ b/ct/alpine-grafana.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine-nextcloud.sh
+++ b/ct/alpine-nextcloud.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine-vaultwarden.sh
+++ b/ct/alpine-vaultwarden.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine-zigbee2mqtt.sh
+++ b/ct/alpine-zigbee2mqtt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/alpine.sh
+++ b/ct/alpine.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/apache-cassandra.sh
+++ b/ct/apache-cassandra.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/apache-couchdb.sh
+++ b/ct/apache-couchdb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/refs/heads/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: Michel Roegl-Brunner (michelroegl-brunner)
 # License: | MIT https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/apt-cacher-ng.sh
+++ b/ct/apt-cacher-ng.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/aria2.sh
+++ b/ct/aria2.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/audiobookshelf.sh
+++ b/ct/audiobookshelf.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/authentik.sh
+++ b/ct/authentik.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: remz1337
 # License: MIT

--- a/ct/autobrr.sh
+++ b/ct/autobrr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/blocky.sh
+++ b/ct/blocky.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/bunkerweb.sh
+++ b/ct/bunkerweb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/caddy.sh
+++ b/ct/caddy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/calibre-web.sh
+++ b/ct/calibre-web.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: remz1337
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/casaos.sh
+++ b/ct/casaos.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/channels.sh
+++ b/ct/channels.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/checkmk.sh
+++ b/ct/checkmk.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: Michel Roegl-Brunner (michelroegl-brunner)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/cloudflared.sh
+++ b/ct/cloudflared.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: havardthom
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/daemonsync.sh
+++ b/ct/daemonsync.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/dashy.sh
+++ b/ct/dashy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/debian.sh
+++ b/ct/debian.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/deconz.sh
+++ b/ct/deconz.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/deluge.sh
+++ b/ct/deluge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/docker.sh
+++ b/ct/docker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/dockge.sh
+++ b/ct/dockge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/emby.sh
+++ b/ct/emby.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/emqx.sh
+++ b/ct/emqx.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/ersatztv.sh
+++ b/ct/ersatztv.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/esphome.sh
+++ b/ct/esphome.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/fenrus.sh
+++ b/ct/fenrus.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: Scorpoon
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/fhem.sh
+++ b/ct/fhem.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/flaresolverr.sh
+++ b/ct/flaresolverr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: remz1337
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/flowiseai.sh
+++ b/ct/flowiseai.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/forgejo.sh
+++ b/ct/forgejo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/frigate.sh
+++ b/ct/frigate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Authors: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/gitea.sh
+++ b/ct/gitea.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: Rogue-King
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/glance.sh
+++ b/ct/glance.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: kristocopani
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/go2rtc.sh
+++ b/ct/go2rtc.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/gokapi.sh
+++ b/ct/gokapi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/gotify.sh
+++ b/ct/gotify.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/grafana.sh
+++ b/ct/grafana.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/grocy.sh
+++ b/ct/grocy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/headscale.sh
+++ b/ct/headscale.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/heimdall-dashboard.sh
+++ b/ct/heimdall-dashboard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/hivemq.sh
+++ b/ct/hivemq.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz) & vhsdream
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homarr.sh
+++ b/ct/homarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homeassistant-core.sh
+++ b/ct/homeassistant-core.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homebox.sh
+++ b/ct/homebox.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homebridge.sh
+++ b/ct/homebridge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/homer.sh
+++ b/ct/homer.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/hyperhdr.sh
+++ b/ct/hyperhdr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/hyperion.sh
+++ b/ct/hyperion.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/influxdb.sh
+++ b/ct/influxdb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/inspircd.sh
+++ b/ct/inspircd.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: kristocopani
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/iobroker.sh
+++ b/ct/iobroker.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/iventoy.sh
+++ b/ct/iventoy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/jackett.sh
+++ b/ct/jackett.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/kavita.sh
+++ b/ct/kavita.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/keycloak.sh
+++ b/ct/keycloak.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/komga.sh
+++ b/ct/komga.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: madelyn (DysfunctionalProgramming)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/kubo.sh
+++ b/ct/kubo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: ulmentflam
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/lazylibrarian.sh
+++ b/ct/lazylibrarian.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: MountyMapleSyrup (MountyMapleSyrup)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/lidarr.sh
+++ b/ct/lidarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/listmonk.sh
+++ b/ct/listmonk.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: bvdberg01
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/lldap.sh
+++ b/ct/lldap.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: remz1337
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/lubelogger.sh
+++ b/ct/lubelogger.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: kristocopani
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mafl.sh
+++ b/ct/mafl.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/magicmirror.sh
+++ b/ct/magicmirror.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mariadb.sh
+++ b/ct/mariadb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/matterbridge.sh
+++ b/ct/matterbridge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mediamtx.sh
+++ b/ct/mediamtx.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/medusa.sh
+++ b/ct/medusa.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/memos.sh
+++ b/ct/memos.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/meshcentral.sh
+++ b/ct/meshcentral.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/metube.sh
+++ b/ct/metube.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mongodb.sh
+++ b/ct/mongodb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/motioneye.sh
+++ b/ct/motioneye.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mqtt.sh
+++ b/ct/mqtt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mylar3.sh
+++ b/ct/mylar3.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: davalanche
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/myspeed.sh
+++ b/ct/myspeed.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/mysql.sh
+++ b/ct/mysql.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/n8n.sh
+++ b/ct/n8n.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/navidrome.sh
+++ b/ct/navidrome.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/neo4j.sh
+++ b/ct/neo4j.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: havardthom
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/netbox.sh
+++ b/ct/netbox.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: bvdberg01
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/nextcloudpi.sh
+++ b/ct/nextcloudpi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/nextpvr.sh
+++ b/ct/nextpvr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: MickLesk (Canbiz)
 # License: MIT

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/nocodb.sh
+++ b/ct/nocodb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/node-red.sh
+++ b/ct/node-red.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/notifiarr.sh
+++ b/ct/notifiarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/ntfy.sh
+++ b/ct/ntfy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/nzbget.sh
+++ b/ct/nzbget.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: havardthom
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/octoprint.sh
+++ b/ct/octoprint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: havardthom
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/ombi.sh
+++ b/ct/ombi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/omv.sh
+++ b/ct/omv.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/onedev.sh
+++ b/ct/onedev.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: kristocopani
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/openhab.sh
+++ b/ct/openhab.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/openobserve.sh
+++ b/ct/openobserve.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: havardthom
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/owncast.sh
+++ b/ct/owncast.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pairdrop.sh
+++ b/ct/pairdrop.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pbs.sh
+++ b/ct/pbs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/peanut.sh
+++ b/ct/peanut.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster) | Co-Author: remz1337
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/petio.sh
+++ b/ct/petio.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pialert.sh
+++ b/ct/pialert.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pihole.sh
+++ b/ct/pihole.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pingvin.sh
+++ b/ct/pingvin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/plex.sh
+++ b/ct/plex.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/pocketbase.sh
+++ b/ct/pocketbase.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/podman-homeassistant.sh
+++ b/ct/podman-homeassistant.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/podman.sh
+++ b/ct/podman.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/postgresql.sh
+++ b/ct/postgresql.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/prometheus.sh
+++ b/ct/prometheus.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/prowlarr.sh
+++ b/ct/prowlarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/qbittorrent.sh
+++ b/ct/qbittorrent.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/rabbitmq.sh
+++ b/ct/rabbitmq.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck | Co-Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/radarr.sh
+++ b/ct/radarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/readarr.sh
+++ b/ct/readarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/readeck.sh
+++ b/ct/readeck.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/recyclarr.sh
+++ b/ct/recyclarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: MrYadro
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/redis.sh
+++ b/ct/redis.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/rockylinux.sh
+++ b/ct/rockylinux.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT

--- a/ct/rtsptoweb.sh
+++ b/ct/rtsptoweb.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/runtipi.sh
+++ b/ct/runtipi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/sabnzbd.sh
+++ b/ct/sabnzbd.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/sftpgo.sh
+++ b/ct/sftpgo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/shinobi.sh
+++ b/ct/shinobi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/smokeping.sh
+++ b/ct/smokeping.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/snipeit.sh
+++ b/ct/snipeit.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: Michel Roegl-Brunner (michelroegl-brunner)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/sonarr.sh
+++ b/ct/sonarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/spoolman.sh
+++ b/ct/spoolman.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/syncthing.sh
+++ b/ct/syncthing.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/tandoor.sh
+++ b/ct/tandoor.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/tasmoadmin.sh
+++ b/ct/tasmoadmin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/tdarr.sh
+++ b/ct/tdarr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/the-lounge.sh
+++ b/ct/the-lounge.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: kristocopani
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/threadfin.sh
+++ b/ct/threadfin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/tianji.sh
+++ b/ct/tianji.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/traccar.sh
+++ b/ct/traccar.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/traefik.sh
+++ b/ct/traefik.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/transmission.sh
+++ b/ct/transmission.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/trilium.sh
+++ b/ct/trilium.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/ubuntu.sh
+++ b/ct/ubuntu.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/umami.sh
+++ b/ct/umami.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/umbrel.sh
+++ b/ct/umbrel.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/unbound.sh
+++ b/ct/unbound.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: wimb0
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/unifi.sh
+++ b/ct/unifi.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/unmanic.sh
+++ b/ct/unmanic.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/uptimekuma.sh
+++ b/ct/uptimekuma.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/vikunja.sh
+++ b/ct/vikunja.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/wallos.sh
+++ b/ct/wallos.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/wastebin.sh
+++ b/ct/wastebin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/watchyourlan.sh
+++ b/ct/watchyourlan.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/wavelog.sh
+++ b/ct/wavelog.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: Don Locke (DonLocke)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/whisparr.sh
+++ b/ct/whisparr.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/whoogle.sh
+++ b/ct/whoogle.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/wikijs.sh
+++ b/ct/wikijs.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/wireguard.sh
+++ b/ct/wireguard.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/yunohost.sh
+++ b/ct/yunohost.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/zammad.sh
+++ b/ct/zammad.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 community-scripts ORG
 # Author: Michel Roegl-Brunner (michelroegl-brunner)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/zigbee2mqtt.sh
+++ b/ct/zigbee2mqtt.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2025 tteck
-# Author: tteck (tteckster) | Co-Author: MickLesk
+# Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://www.zigbee2mqtt.io/
 

--- a/ct/zipline.sh
+++ b/ct/zipline.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: MickLesk (Canbiz)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/zoraxy.sh
+++ b/ct/zoraxy.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/zwave-js-ui.sh
+++ b/ct/zwave-js-ui.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func)
+: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"
+source <(curl -s "${CSCRIPTS_BASE_URL}/misc/build.func")
 # Copyright (c) 2021-2024 tteck
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/misc/build.func
+++ b/misc/build.func
@@ -778,9 +778,9 @@ build_container() {
   TEMP_DIR=$(mktemp -d)
   pushd $TEMP_DIR >/dev/null
   if [ "$var_os" == "alpine" ]; then
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/alpine-install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s ${CSCRIPTS_BASE_URL}/misc/alpine-install.func)"
   else
-    export FUNCTIONS_FILE_PATH="$(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/install.func)"
+    export FUNCTIONS_FILE_PATH="$(curl -s ${CSCRIPTS_BASE_URL}/misc/install.func)"
   fi
   export CACHER="$APT_CACHER"
   export CACHER_IP="$APT_CACHER_IP"
@@ -811,7 +811,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/ct/create_lxc.sh)" || exit
+  bash -c "$(wget -qLO - ${CSCRIPTS_BASE_URL}/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then
@@ -873,7 +873,7 @@ http://dl-cdn.alpinelinux.org/alpine/latest-stable/community
 EOF'
     pct exec "$CTID" -- ash -c "apk add bash >/dev/null"
   fi
-  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/install/$var_install.sh)" || exit
+  lxc-attach -n "$CTID" -- bash -c "$(wget -qLO - ${CSCRIPTS_BASE_URL}/install/$var_install.sh)" || exit
 
 }
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -811,7 +811,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - ${CSCRIPTS_BASE_URL}/ct/create_lxc.sh)" || exit
+  bash -c "$(curl -sL ${CSCRIPTS_BASE_URL}/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
In #1202, I proposed that it would be beneficial to support a mechanism that allows changing the URL sourced by the `ct/*.sh` scripts through an environment variable. This PR implements the changes needed to achieve this, as best I can tell.

It is now possible to set the environment variable `CSCRIPTS_BASE_URL` to any URL format that `curl` supports - http://, https://, file://, and more - which points to the base location for the `ct`, `misc`, `install` etcetera directories.

A previous version of this PR declared a second variable, `BRANCH`, and re-used it in the `CSCRIPTS_BASE_URL` default definition. After some thinking, I decided this was probably not the right approach; I presume there is automation for switching from develop to main (or the other way) that replaces URLs already, so having a separate variable for the branch didn't make much sense. Changing branches in the URL now (for testing by hand etc) is a case of setting `CSCRIPTS_BASE_URL` to whatever repository URL is needed, with the branch present in the string.

This PR is essentially a codemod done with `rg -sl 'curl -s' | xargs sed -i -e '/ProxmoxVE\/develop\/misc/ i: "${CSCRIPTS_BASE_URL:=https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop}"' -e 's%https://raw.githubusercontent.com/community-scripts/ProxmoxVE/develop/misc/build.func%"${CSCRIPTS_BASE_URL}/misc/build.func"%'`

`build.func` had one call to `wget` (outside of the containers) that has to be switched to `curl`, as `wget` does not understand `file:///` URLs. Since the other fetches in the file are done with `curl`, consistency here makes sense to me.

I cross-checked with some `rg` usage that the other occurrences of ProxmoxVE/develop were in Markdown files or image URLs.
 - - -
**_Please remove unneeded lines!_**
- Related Discussion: #1202 

---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [X] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] ~Documentation updated (I have updated any relevant documentation)~

---

## 📋 Additional Information (optional)
From the linked discussion
```
~/Source/ProxmoxVE$ CSCRIPTS_BASE_URL=file://$HOME/Source/ProxmoxVE bash ct/lidarr.sh
FIGlet or the slant font is missing. Installing...
Unsupported operating system.
Using file:///home/cricalix/Source/ProxmoxVE as source of truth
  🖥  Operating System: debian
  🌟  Version: 12
  📦  Container Type: Unprivileged (WOOHOO)
  💾  Disk Size: 4GB
  🧠  CPU Cores: 2
  🛠  RAM Size: 1024MB
  🆔  Container ID: 
  🚀  Creating a Lidarr LXC using the above default settings
```

Previously submitted as #1211, which I broke somehow..

[Screencast_20250104_124526.webm](https://github.com/user-attachments/assets/bb0a20ba-bbb7-4fb5-9b74-a74928f982f3)

![20250104_124631](https://github.com/user-attachments/assets/af264057-52b4-435c-83d9-6b4e8130d10b)

