### PR TITLE
[overrideable url] Change from wget to curl when fetching create_lxc.sh

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -820,7 +820,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(wget -qLO - https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/create_lxc.sh)" || exit
+  bash -c "$(curl -sL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/create_lxc.sh)" || exit
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
In #1202, I proposed that a new environment variable could be used to change the URL that the scripts fetch data from, enabling easy testing against custom repositories (or even local disk) without having to edit the files every time. In #1230, the request was made to split the PR into smaller PRs.

This is the first PR of the stack. wget cannot handle `file:///` URLs, which means local testing will not work. Given all other cases of remote file fetching in the scripts are done with `curl`, it makes sense to switch this use case too.

Curl's default mode is "-O -", "-s" replaces "-q".

There is a question in my mind about whether all containers should have curl installed by default, so that the `lxc attach ... bash -c ... wget $var_install` line could also be curl. I note at least one issue/discussion where someone has reported that a script doesn't work because curl isn't installed. It is easy for every script that wants curl to install it, but perhaps it's easier if this project just makes sure curl is available at all times and to recommend using curl in scripts?
- - -

- Related PR: #1230
- Related Discussion: #1202

---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [X] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] ~Documentation updated (I have updated any relevant documentation)~

---

## 📋 Additional Information (optional)
Run via:
* git pull
* git checkout wget-to-curl
* bash ct/lidarr.sh
![image](https://github.com/user-attachments/assets/68355fc1-ecc3-48c3-afb9-f38915452a05)


