### PR TITLE
Install/update ActualBudget based on releases, not latest master

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -34,13 +34,16 @@ function update_script() {
     fi
     msg_info "Updating ${APP}"
     systemctl stop actualbudget.service
-    RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq '.[0].name')
+    RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq --raw-output '.[0].name')
+    TEMPD="$(mktemp -d)"
+    cd "${TEMPD}"
+    wget -q https://codeload.github.com/actualbudget/actual-server/legacy.tar.gz/refs/tags/${RELEASE} -O - | tar -xz
+    mv actualbudget-actual-server-*/* /opt/actualbudget/
     cd /opt/actualbudget
-    git pull &>/dev/null
-    git checkout "$RELEASE"
     yarn install &>/dev/null
     systemctl start actualbudget.service
     msg_ok "Successfully Updated ${APP} to ${RELEASE}"
+    rm -rf "${TEMPD}"
     exit
 }
 

--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -34,11 +34,13 @@ function update_script() {
     fi
     msg_info "Updating ${APP}"
     systemctl stop actualbudget.service
+    RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq '.[0].name')
     cd /opt/actualbudget
     git pull &>/dev/null
+    git checkout "$RELEASE"
     yarn install &>/dev/null
     systemctl start actualbudget.service
-    msg_ok "Successfully Updated ${APP}"
+    msg_ok "Successfully Updated ${APP} to ${RELEASE}"
     exit
 }
 

--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -35,9 +35,10 @@ $STD apt-get install -y nodejs
 $STD npm install --global yarn
 msg_ok "Installed Node.js"
 
-RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq '.[0].name')
+RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq --raw-output '.[0].name')
 msg_info "Installing Actual Budget $RELEASE"
-$STD git clone https://github.com/actualbudget/actual-server.git /opt/actualbudget
+wget -q https://codeload.github.com/actualbudget/actual-server/legacy.tar.gz/refs/tags/${RELEASE} -O - | tar -xz
+mv actualbudget-actual-server-* /opt/actualbudget
 mkdir -p /opt/actualbudget/server-files
 chown -R root:root /opt/actualbudget/server-files
 chmod 755 /opt/actualbudget/server-files
@@ -46,7 +47,6 @@ ACTUAL_UPLOAD_DIR=/opt/actualbudget/server-files
 PORT=5006
 EOF
 cd /opt/actualbudget
-$STD git checkout "$RELEASE"
 $STD yarn install
 msg_ok "Installed Actual Budget"
 

--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -35,7 +35,8 @@ $STD apt-get install -y nodejs
 $STD npm install --global yarn
 msg_ok "Installed Node.js"
 
-msg_info "Installing Actual Budget"
+RELEASE=$(curl -s https://api.github.com/repos/actualbudget/actual-server/tags | jq '.[0].name')
+msg_info "Installing Actual Budget $RELEASE"
 $STD git clone https://github.com/actualbudget/actual-server.git /opt/actualbudget
 mkdir -p /opt/actualbudget/server-files
 chown -R root:root /opt/actualbudget/server-files
@@ -45,6 +46,7 @@ ACTUAL_UPLOAD_DIR=/opt/actualbudget/server-files
 PORT=5006
 EOF
 cd /opt/actualbudget
+$STD git checkout "$RELEASE"
 $STD yarn install
 msg_ok "Installed Actual Budget"
 


### PR DESCRIPTION
## ✍️ Description
I noticed that ActualBudget gets installed by just `git clone`/`git pull`, which (unless I am missing something) means that it's always on latest master branch instead of following stable releases.
This PR fixes this and switches to using the latest stable based on tagged releases.

I'd like to note that I didn't find or create any related issues/discussions, since the change was small I went ahead and implemented it without asking. If there are any concerns with this (or with the implementation) please let me know.

I'm also marking this as a breaking change since if someone is on the latest master an "update" would actually downgrade them. Syncing this with the next release might be a good idea.
 

- - -

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [X] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [X] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

