### PR TITLE
Check lxc maxkeys

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -166,7 +166,7 @@ maxkeys_check() {
   if [ "${used_lxc_keys}" -gt "${threshold_keys}" ]; then
     msg_error "Kernel key limits problem (count) detected."
     echo -e "${CROSS}${RD} Your PVE node is close to the key limit of $per_user_maxkeys; this will cause problems when starting containers."
-    echo -e "${CROSS}${RD} Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxkeys=${new_limit_keys}${CL}"
+    echo -e "${CROSS}${RD} Add or update /etc/sysctl.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxkeys=${new_limit_keys}${CL}"
     echo
     failure=1
   fi
@@ -174,7 +174,7 @@ maxkeys_check() {
   if [ "${used_lxc_bytes}" -gt "${threshold_bytes}" ]; then
     msg_error "Kernel key limits problem (bytes) detected."
     echo -e "${CROSS}${RD} Your PVE node is close to the key bytes limit of $per_user_maxbytes; this will cause problems when starting containers."
-    echo -e "${CROSS}${RD} Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxbytes=${new_limit_bytes}${CL}"
+    echo -e "${CROSS}${RD} Add or update /etc/sysctl.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxbytes=${new_limit_bytes}${CL}"
     echo
     failure=1
   fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -146,6 +146,45 @@ pve_check() {
 fi
 }
 
+# When a node is running tens of containers, it's possible to exceed the kernel's
+# cryptographic key storage allocations. These are tuneable, so verify if the
+# currently deployment is approaching the limits, advise the user on how to tune
+# the limits, and exit the script.
+maxkeys_check() {
+  # https://cleveruptime.com/docs/files/proc-key-users
+  # https://docs.kernel.org/security/keys/core.html
+  per_user_maxkeys=$(cat /proc/sys/kernel/keys/maxkeys)
+  per_user_maxbytes=$(cat /proc/sys/kernel/keys/maxbytes)
+  used_lxc_keys=$(awk '/100000:/ {print $2}' /proc/key-users)
+  used_lxc_bytes=$(awk '/100000:/ {split($5, a, "/"); print a[1]}' /proc/key-users)
+  threshold_keys=$((per_user_maxkeys - 100))
+  new_limit_keys=$((per_user_maxkeys * 2))
+  threshold_bytes=$((per_user_maxbytes - 1000))
+  new_limit_bytes=$((per_user_maxbytes * 2))
+  failure=0
+  # Every LXC container will use one or more keys. Sampling indicates 1 for alpine, 25+ for debian.
+  if [ "${used_lxc_keys}" -gt "${threshold_keys}" ]; then
+    msg_error "Kernel key limits problem (count) detected."
+    echo -e "${CROSS}${RD} Your PVE node is close to the key limit of $per_user_maxkeys; this will cause problems when starting containers."
+    echo -e "${CROSS}${RD} Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxkeys=${new_limit_keys}${CL}"
+    echo
+    failure=1
+  fi
+  # There's also a bytes limit on keys.
+  if [ "${used_lxc_bytes}" -gt "${threshold_bytes}" ]; then
+    msg_error "Kernel key limits problem (bytes) detected."
+    echo -e "${CROSS}${RD} Your PVE node is close to the key bytes limit of $per_user_maxbytes; this will cause problems when starting containers."
+    echo -e "${CROSS}${RD} Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting ${GN}kernel.keys.maxbytes=${new_limit_bytes}${CL}"
+    echo
+    failure=1
+  fi
+  if [[ "${failure}" -eq 1 ]]; then
+    echo "You can pick values other than the suggested ones. After creating or updating the recommended "
+    echo "configuration file, run   service procps force-reload   and retry this script."
+    exit
+  fi
+}
+
 # This function checks the system architecture and exits if it's not "amd64".
 arch_check() {
   if [ "$(dpkg --print-architecture)" != "amd64" ]; then
@@ -661,6 +700,7 @@ install_script() {
   root_check
   arch_check
   ssh_check
+  maxkeys_check
 
   if systemctl is-active -q ping-instances.service; then
     systemctl -q stop ping-instances.service


### PR DESCRIPTION
## ✍️ Description

The Linux kernel has an allocation of space for storing cryptographic keys - this allocation is measured in both counts and bytes. Root has a distinct limit from regular users. When the UID used by Proxmox to run containers reaches either limit, the container will fail to start, or encounter other problems.

The limits are available in /proc, as well as the usage on a per-user basis.

This PR adds a new `check` function to the `build.func` library, and calls the function in `install_script` after the other `check` functions.

The check function does some simple integer threshold calculation to detect when either limit is close to being breached, and then provides guidance on how to resolve the problem. I am assuming that a file in /etc/sysctl/conf.d will not be touched by Proxmox upgrades (versus modifying the sysctl.conf file, which dpkg will probably clobber).

 The recommended value is a simple doubling of what's present, since anything else would require calling `bc` to do the math and then dancing with printf to throw away floating point values.

The OP in #1258 encountered this with a mere 40 containers running.

My testing shows that creating a container uses a varying number of keys.
* debian.sh 27 keys
* ubuntu.sh: 30 keys
* alpine.sh: 1 key
* docker.sh: 32 keys

At a guess, docker containers will use even more keys if more than one docker image is running in the container.

- - -

- Related Issue: #1258
---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [X] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] ~Documentation updated (I have updated any relevant documentation)~

---

## 📋 Additional Information (optional)
I extracted the core logic to a standalone shell script, and override the values detected by reading the data out of /proc. Both messages were triggered as expected.
```
root@pve:~# bash  foo.sh
  ✖  Kernel key limits problem (count) detected.
  ✖   Your PVE node is close to the key limit of 200; this will cause problems when starting containers.
  ✖   Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting kernel.keys.maxkeys=400

  ✖  Kernel key limits problem (bytes) detected.
  ✖   Your PVE node is close to the key bytes limit of 3000; this will cause problems when starting containers.
  ✖   Add or update /etc/sysctl/conf.d/98-community-scripts.conf, setting kernel.keys.maxbytes=6000

You can pick values other than the suggested ones. After creating or updating the recommended 
configuration file, run   service procps force-reload   and retry this script.
```

I then copied the branch over to the pve node, updated debian.sh to directly source build.func from the filesystem instead of via curl, set the maxkeys to 100 and
![image](https://github.com/user-attachments/assets/9f67cb09-0d7d-446a-ae6d-c0071da56e91)

Finally, I created the file based on the instructions, ran the command as documented, and maxkeys in /proc shows the new value I picked (3000).