### PR TITLE
Move core dependencies to a function that templates can call

### DIFF
--- a/install/alpine-docker-install.sh
+++ b/install/alpine-docker-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 msg_info "Installing Dependencies"
 $STD apk add tzdata

--- a/install/alpine-docker-install.sh
+++ b/install/alpine-docker-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+install_core_dependencies
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
 $STD apk add tzdata
-$STD apk add nano
-$STD apk add mc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Docker"

--- a/install/alpine-grafana-install.sh
+++ b/install/alpine-grafana-install.sh
@@ -12,14 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+install_core_dependencies
 
 msg_info "Installing Grafana"
 $STD apk add grafana

--- a/install/alpine-grafana-install.sh
+++ b/install/alpine-grafana-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 msg_info "Installing Grafana"
 $STD apk add grafana

--- a/install/alpine-install.sh
+++ b/install/alpine-install.sh
@@ -12,14 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+install_core_dependencies
 
 motd_ssh
 customize

--- a/install/alpine-install.sh
+++ b/install/alpine-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 motd_ssh
 customize

--- a/install/alpine-nextcloud-install.sh
+++ b/install/alpine-nextcloud-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+install_core_dependencies
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
 $STD apk add openssl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
 $STD apk add nginx
 msg_ok "Installed Dependencies"
 

--- a/install/alpine-nextcloud-install.sh
+++ b/install/alpine-nextcloud-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 msg_info "Installing Dependencies"
 $STD apk add openssl

--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 msg_info "Installing Dependencies"
 $STD apk add openssl

--- a/install/alpine-vaultwarden-install.sh
+++ b/install/alpine-vaultwarden-install.sh
@@ -12,14 +12,10 @@ catch_errors
 setting_up_container
 network_check
 update_os
+install_core_dependencies
 
 msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
 $STD apk add openssl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
 $STD apk add argon2
 msg_ok "Installed Dependencies"
 

--- a/install/alpine-zigbee2mqtt-install.sh
+++ b/install/alpine-zigbee2mqtt-install.sh
@@ -12,14 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-
-msg_info "Installing Dependencies"
-$STD apk add newt
-$STD apk add curl
-$STD apk add openssh
-$STD apk add nano
-$STD apk add mc
-msg_ok "Installed Dependencies"
+install_core_dependencies
 
 msg_info "Installing Alpine-Zigbee2MQTT"
 $STD apk add zigbee2mqtt

--- a/install/alpine-zigbee2mqtt-install.sh
+++ b/install/alpine-zigbee2mqtt-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 msg_info "Installing Alpine-Zigbee2MQTT"
 $STD apk add zigbee2mqtt

--- a/install/debian-install.sh
+++ b/install/debian-install.sh
@@ -12,12 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-
-msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
-msg_ok "Installed Dependencies"
+install_core_dependencies
 
 motd_ssh
 customize

--- a/install/debian-install.sh
+++ b/install/debian-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 motd_ssh
 customize

--- a/install/ubuntu-install.sh
+++ b/install/ubuntu-install.sh
@@ -12,12 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-
-msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
-msg_ok "Installed Dependencies"
+install_core_dependencies
 
 motd_ssh
 customize

--- a/install/ubuntu-install.sh
+++ b/install/ubuntu-install.sh
@@ -12,7 +12,7 @@ catch_errors
 setting_up_container
 network_check
 update_os
-install_core_dependencies
+install_core_packages
 
 motd_ssh
 customize

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -136,9 +136,9 @@ update_os() {
 # Install core packages that (almost) every container will depend upon.
 # Be sure to update install.func for apt-based systems as appropriate.
 install_core_dependencies() {
-  msg_info "Installing core dependencies"
+  msg_info "Installing Core Dependencies"
   $STD apk add curl mc nano newt openssh sudo
-  msg_ok "Installed core dependencies"
+  msg_ok "Installed Core Dependencies"
 }
 
 # This function modifies the message of the day (motd) and SSH settings

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -133,6 +133,14 @@ update_os() {
   msg_ok "Updated Container OS"
 }
 
+# Install core packages that (almost) every container will depend upon.
+# Be sure to update install.func for apt-based systems as appropriate.
+install_core_dependencies() {
+  msg_info "Installing core dependencies"
+  $STD apk add curl mc nano newt openssh sudo
+  msg_ok "Installed core dependencies"
+}
+
 # This function modifies the message of the day (motd) and SSH settings
 motd_ssh() {
   # Set terminal to 256-color mode

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -135,10 +135,10 @@ update_os() {
 
 # Install core packages that (almost) every container will depend upon.
 # Be sure to update install.func for apt-based systems as appropriate.
-install_core_dependencies() {
-  msg_info "Installing Core Dependencies"
+install_core_packages() {
+  msg_info "Installing Core Packages"
   $STD apk add curl mc nano newt openssh sudo
-  msg_ok "Installed Core Dependencies"
+  msg_ok "Installed Core Packages"
 }
 
 # This function modifies the message of the day (motd) and SSH settings

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -137,7 +137,7 @@ update_os() {
 # Be sure to update install.func for apt-based systems as appropriate.
 install_core_packages() {
   msg_info "Installing Core Packages"
-  $STD apk add curl mc nano newt openssh sudo
+  apk add -q curl mc nano newt openssh sudo &>/dev/null
   msg_ok "Installed Core Packages"
 }
 

--- a/misc/install.func
+++ b/misc/install.func
@@ -200,11 +200,10 @@ EOF
 # Install core packages that (almost) every container will depend upon.
 # Be sure to update alpine-install.func to match for apk-based systems when
 # adding a new package.
-# a new package.
-install_core_dependencies() {
-  msg_info "Installing Core Dependencies"
+install_core_packages() {
+  msg_info "Installing Core Packages"
   $STD apt-get install curl mc sudo
-  msg_ok "Installed Core Dependencies"
+  msg_ok "Installed Core Packages"
 }
 
 # This function modifies the message of the day (motd) and SSH settings

--- a/misc/install.func
+++ b/misc/install.func
@@ -197,6 +197,16 @@ EOF
   msg_ok "Updated Container OS"
 }
 
+# Install core packages that (almost) every container will depend upon.
+# Be sure to update alpine-install.func to match for apk-based systems when
+# adding a new package.
+# a new package.
+install_core_dependencies() {
+  msg_info "Installing core dependencies"
+  $STD apt-get install curl mc sudo
+  msg_ok "Installed core dependencies"
+}
+
 # This function modifies the message of the day (motd) and SSH settings
 motd_ssh() {
   # Set terminal to 256-color mode

--- a/misc/install.func
+++ b/misc/install.func
@@ -202,7 +202,7 @@ EOF
 # adding a new package.
 install_core_packages() {
   msg_info "Installing Core Packages"
-  $STD apt-get install curl mc sudo
+  apt-get install -y curl mc sudo &> /dev/null
   msg_ok "Installed Core Packages"
 }
 

--- a/misc/install.func
+++ b/misc/install.func
@@ -202,9 +202,9 @@ EOF
 # adding a new package.
 # a new package.
 install_core_dependencies() {
-  msg_info "Installing core dependencies"
+  msg_info "Installing Core Dependencies"
   $STD apt-get install curl mc sudo
-  msg_ok "Installed core dependencies"
+  msg_ok "Installed Core Dependencies"
 }
 
 # This function modifies the message of the day (motd) and SSH settings


### PR DESCRIPTION
## ✍️ Description
Every single install script installs a consistent set of additional packages, and every author of the scripts has to copy/paste the relevant `apt` or `apk` lines into their script. For example, across all three base distros (Alpine, Debian, Ubuntu), `sudo`, `mc`, and `curl` are installed, and on every Alpine image, `openssh`, `newt`, and `nano` are also installed.

I think it makes sense to consolidate these manual installations into a single function for several reasons:
1. Adding a new default/core package becomes a case of updating a maximum of two files (for instance, making gnupg a default/core package)
2. Reduction in boilerplate across all scripts - complete removal in some cases, replaced by a single line

In this PR, I'm adding a new function - `install_core_packages` - to both `install.func` and `install-alpine.func`, and replacing the manual dependency installation across a handful of scripts with the function for testing purposes.

If this PR is acceptable, I'll do the work to update the other 200+ installation scripts.

---

## 🛠️ Type of Change
Please check the relevant options:  
- [ ] Bug fix (non-breaking change that resolves an issue)  
- [X] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] ~Documentation updated (I have updated any relevant documentation)~

---

## 📋 Additional Information (optional)

I ran a locally modified checkout that replaced the URLs with pointers to my repository in ct/alpine.sh, misc/build.func, and ran the Alpine installer script.
```
    ___    __      _          
   /   |  / /___  (_)___  ___ 
  / /| | / / __ \/ / __ \/ _ \
 / ___ |/ / /_/ / / / / /  __/
/_/  |_/_/ .___/_/_/ /_/\___/ 
        /_/                   
  ⚙️  Using Default Settings on node pve
  🖥️  Operating System: alpine
  🌟  Version: 3.20
  📦  Container Type: Unprivileged
  💾  Disk Size: 0.1GB
  🧠  CPU Cores: 1
  🛠️  RAM Size: 512MiB
  🆔  Container ID: 112
  🚀  Creating a Alpine LXC using the above default settings
  
  ✔️  Using local for Template Storage.
  ✔️  Using local-lvm for Container Storage.
  ✔️  Updated LXC Template List
  ✔️  LXC Container 112 was successfully created.
  ✔️  Started LXC Container
  ✔️  Set up Container OS
  ✔️  Network Connected: 192.168.0.129
  ✔️  Internet Connected
  ✔️  DNS Resolved github.com to 4.208.26.197
  ✔️  Updated Container OS
  ✔️  Installed Core Packages
  ✔️  Customized Container
  ✔️  Completed Successfully!
```
```
alpine:~# apk list | grep -E '^(sudo|mc|newt|nano|curl|openssh)-[0-9]'
curl-8.11.1-r0 x86_64 {curl} (curl) [installed]
mc-4.8.32-r0 x86_64 {mc} (GPL-3.0-or-later) [installed]
nano-8.2-r0 x86_64 {nano} (GPL-3.0-or-later) [installed]
newt-0.52.24-r1 x86_64 {newt} (LGPL-2.0-only) [installed]
openssh-9.9_p1-r2 x86_64 {openssh} (SSH-OpenSSH) [installed]
sudo-1.9.16_p2-r0 x86_64 {sudo} (custom ISC) [installed]
```

