### PR TITLE
Fix: Stirling-PDF > LibreOffice/unoconv Integration Issues 

### DIFF
--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -79,8 +79,8 @@ msg_ok "Installed Language Packs"
 
 msg_info "Installing Stirling-PDF (Additional Patience)"
 RELEASE=$(curl -s https://api.github.com/repos/Stirling-Tools/Stirling-PDF/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-wget -q https://github.com/Stirling-Tools/Stirling-PDF/archive/refs/tags/v$RELEASE.tar.gz
-tar -xzf v$RELEASE.tar.gz
+wget -q https://github.com/Stirling-Tools/Stirling-PDF/archive/refs/tags/v${RELEASE}.tar.gz
+tar -xzf v${RELEASE}.tar.gz
 cd Stirling-PDF-$RELEASE
 chmod +x ./gradlew
 $STD ./gradlew build
@@ -90,7 +90,7 @@ mv ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
 mv scripts /opt/Stirling-PDF/
 ln -s /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar /opt/Stirling-PDF/Stirling-PDF.jar
 ln -s /usr/share/tesseract-ocr/5/tessdata/ /usr/share/tessdata
-msg_ok "Installed Stirling-PDF v$RELEASE"
+msg_ok "Installed Stirling-PDF"
 
 msg_info "Creating Service"
 # Create LibreOffice listener service
@@ -149,12 +149,7 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
-msg_ok "Cleaned"
-
-msg_info "Cleaning up"
-rm -rf v$RELEASE.tar.gz /zulu-repo_1.0.0-3_all.deb
+rm -rf v${RELEASE}.tar.gz /zulu-repo_1.0.0-3_all.deb
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -92,7 +92,7 @@ ln -s /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar /opt/Stirling-PDF/Stirling-PDF
 ln -s /usr/share/tesseract-ocr/5/tessdata/ /usr/share/tessdata
 msg_ok "Installed Stirling-PDF v$RELEASE"
 
-msg_info "Configuring LibreOffice Service"
+msg_info "Creating Service"
 # Create LibreOffice listener service
 cat <<EOF >/etc/systemd/system/libreoffice-listener.service
 [Unit]
@@ -118,7 +118,6 @@ PYTHONPATH=/usr/lib/python3/dist-packages:/usr/lib/libreoffice/program
 LD_LIBRARY_PATH=/usr/lib/libreoffice/program
 EOF
 
-msg_info "Creating StirlingPDF Service"
 cat <<EOF >/etc/systemd/system/stirlingpdf.service
 [Unit]
 Description=Stirling-PDF service
@@ -142,14 +141,17 @@ WantedBy=multi-user.target
 EOF
 
 # Enable and start services
-systemctl enable -q libreoffice-listener
-systemctl enable -q stirlingpdf
-systemctl start libreoffice-listener
-systemctl start stirlingpdf
-msg_ok "Created and Started Services"
+systemctl enable -q --now libreoffice-listener
+systemctl enable -q --now stirlingpdf
+msg_ok "Created Service"
 
 motd_ssh
 customize
+
+msg_info "Cleaning up"
+$STD apt-get -y autoremove
+$STD apt-get -y autoclean
+msg_ok "Cleaned"
 
 msg_info "Cleaning up"
 rm -rf v$RELEASE.tar.gz /zulu-repo_1.0.0-3_all.deb


### PR DESCRIPTION
## ✍️ Description
The current installation script for the StirlingPDF LXC has issues with LibreOffice and unoconv integration, causing document conversion failures. These issues are caused by the following:

1. Missing LibreOffice dependencies
2. No dedicated LibreOffice listener service
3. Incorrect port configuration for unoconv/LibreOffice communication
4. Missing environment variables for Python-UNO bridge

Issues with document conversion and missing environmental variables were resolved by:

1. Adding essential LibreOffice packages (libreoffice-core, libreoffice-common, libreoffice-base-core)
2. Explicitly installing python3-uno
3. Creating a dedicated LibreOffice listener service configured for port 2002 (unoconv's default)
4. Adding necessary environment variables for proper Python-UNO bridge functionality
5. Modifying StirlingPDF service to depend on LibreOffice listener service
6. Adding service configuration for automatic restarts
- - -
- Related Issue: #1321 
---
## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

