### PR TITLE
Update Prometheus + Alertmanager: Unify scripts for easier maintenance

### DIFF
--- a/ct/prometheus-alertmanager.sh
+++ b/ct/prometheus-alertmanager.sh
@@ -42,18 +42,17 @@ function update_script() {
     cd /opt
     wget -q https://github.com/prometheus/alertmanager/releases/download/v${RELEASE}/alertmanager-${RELEASE}.linux-amd64.tar.gz
     tar -xf alertmanager-${RELEASE}.linux-amd64.tar.gz
-    cd alertmanager-${RELEASE}.linux-amd64
-    cp -rf alertmanager amtool /usr/local/bin/
+    cp -rf alertmanager-${RELEASE}.linux-amd64/alertmanager alertmanager-${RELEASE}.linux-amd64/amtool /usr/local/bin/
     rm -rf alertmanager-${RELEASE}.linux-amd64 alertmanager-${RELEASE}.linux-amd64.tar.gz
     echo "${RELEASE}" >/opt/${APP}_version.txt
-    msg_ok "Updated ${APP} to ${RELEASE}"
+    msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Starting ${APP}"
     systemctl start prometheus-alertmanager
     msg_ok "Started ${APP}"
     msg_ok "Updated Successfully"
   else
-    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+    msg_ok "No update required. ${APP} is already at v${RELEASE}"
   fi
   exit
 }

--- a/ct/prometheus.sh
+++ b/ct/prometheus.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
-# Copyright (c) 2021-2025 tteck
+# Copyright (c) 2021-2025 community-scripts ORG
 # Author: tteck (tteckster)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://prometheus.io/
@@ -38,22 +38,21 @@ function update_script() {
     systemctl stop prometheus
     msg_ok "Stopped ${APP}"
 
-    msg_info "Updating ${APP} to ${RELEASE}"
+    msg_info "Updating ${APP} to v${RELEASE}"
+    cd /opt
     wget -q https://github.com/prometheus/prometheus/releases/download/v${RELEASE}/prometheus-${RELEASE}.linux-amd64.tar.gz
     tar -xf prometheus-${RELEASE}.linux-amd64.tar.gz
-    cd prometheus-${RELEASE}.linux-amd64
-    cp -rf prometheus promtool /usr/local/bin/
-    cd ~
+    cp -rf prometheus-${RELEASE}.linux-amd64/prometheus prometheus-${RELEASE}.linux-amd64/promtool /usr/local/bin/
     rm -rf prometheus-${RELEASE}.linux-amd64 prometheus-${RELEASE}.linux-amd64.tar.gz
     echo "${RELEASE}" >/opt/${APP}_version.txt
-    msg_ok "Updated ${APP} to ${RELEASE}"
+    msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Starting ${APP}"
     systemctl start prometheus
     msg_ok "Started ${APP}"
     msg_ok "Updated Successfully"
   else
-    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+    msg_ok "No update required. ${APP} is already at v${RELEASE}"
   fi
   exit
 }

--- a/install/prometheus-install.sh
+++ b/install/prometheus-install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2021-2025 tteck
+# Copyright (c) 2021-2025 community-scripts ORG
 # Author: tteck (tteckster)
-# License: MIT
-# https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://prometheus.io/
 
 source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
 color
@@ -14,9 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y curl
-$STD apt-get install -y sudo
-$STD apt-get install -y mc
+$STD apt-get install -y \
+  curl \
+  sudo \
+  mc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Prometheus"
@@ -25,14 +26,13 @@ mkdir -p /etc/prometheus
 mkdir -p /var/lib/prometheus
 wget -q https://github.com/prometheus/prometheus/releases/download/v${RELEASE}/prometheus-${RELEASE}.linux-amd64.tar.gz
 tar -xf prometheus-${RELEASE}.linux-amd64.tar.gz
-cd prometheus-${RELEASE}.linux-amd64
-mv prometheus promtool /usr/local/bin/
-mv prometheus.yml /etc/prometheus/prometheus.yml
+mv prometheus-${RELEASE}.linux-amd64/prometheus prometheus-${RELEASE}.linux-amd64/promtool /usr/local/bin/
+mv prometheus-${RELEASE}.linux-amd64/prometheus.yml /etc/prometheus/prometheus.yml
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Installed Prometheus"
 
 msg_info "Creating Service"
-service_path="/etc/systemd/system/prometheus.service"
+cat <<EOF >/etc/systemd/system/prometheus.service"
 echo "[Unit]
 Description=Prometheus
 Wants=network-online.target
@@ -49,7 +49,8 @@ ExecStart=/usr/local/bin/prometheus \
 ExecReload=/bin/kill -HUP \$MAINPID
 
 [Install]
-WantedBy=multi-user.target" >$service_path
+WantedBy=multi-user.target"
+EOF
 systemctl enable -q --now prometheus
 msg_ok "Created Service"
 
@@ -59,5 +60,5 @@ customize
 msg_info "Cleaning up"
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
-rm -rf ../prometheus-${RELEASE}.linux-amd64 ../prometheus-${RELEASE}.linux-amd64.tar.gz
+rm -rf prometheus-${RELEASE}.linux-amd64 prometheus-${RELEASE}.linux-amd64.tar.gz
 msg_ok "Cleaned"


### PR DESCRIPTION
## ✍️ Description

Recently, Prometheus Alertmanager was merged, see https://github.com/community-scripts/ProxmoxVE/pull/1272

Alertmanager is _very_ similar in the installation as Prometheus.
This Pull Request unifies the scripts for Prometheus and Alertmanager, based of the feedback from https://github.com/community-scripts/ProxmoxVE/pull/1272.

In particular:
* Using absolute pathes
* Prefixing ${RELEASE} with `v`
* Running update functions in `/opt` and not in `~`
* Fixing a bug in the Alertmanager Update script (the `rm -rf` should fail, as we (originally) cd`ed into the unpacked folder, but did not `cd ..`)

For Prometheus, there is no functional change.
This is just a unification of both scripts.

---

## 🛠️ Type of Change

- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites

- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)

None
