### PR TITLE
WIP: Github Actions: Fix "Get changed files" in Shellcheck workflow

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,11 +20,14 @@ jobs:
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@v45
+      with:
+        files: |
+          **.sh
 
     #- name: Get changed files
     #  id: changed-files
     #  run: |
-    #    if ${{ github.event_name == 'pull_request_target' }}; then
+    #    if ${{ github.event_name == 'pull_request' }}; then
     #      echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)" >> $GITHUB_OUTPUT
     #    else
     #      echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,25 +17,34 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@v45
-      with:
-        files: |
-          **.sh
-
     #- name: Get changed files
     #  id: changed-files
-    #  run: |
-    #    if ${{ github.event_name == 'pull_request' }}; then
-    #      echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)" >> $GITHUB_OUTPUT
-    #    else
-    #      echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
-    #    fi
+    #  uses: tj-actions/changed-files@v45
+    #  with:
+    #    files: |
+    #      **.sh
+
+    - name: Get changed files
+      id: changed-files
+      run: |
+        if ${{ github.event_name == 'pull_request' }}; then
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)"
+        else
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)"
+        fi
+        # Filter only for *.sh files
+        echo "files=$(printf "%s\n" ${{ steps.changed-files.outputs.files }} | { grep -E '^.*\.sh$' || true; }) >> $GITHUB_OUTPUT
 
     - name: Run ShellCheck
-      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      if: steps.changed-files.outputs.files != ''
       env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
       run: |
         echo "${ALL_CHANGED_FILES}" | xargs shellcheck
+
+    #- name: Run ShellCheck
+    #  if: steps.changed-files-specific.outputs.any_changed == 'true'
+    #  env:
+    #    ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+    #  run: |
+    #    echo "${ALL_CHANGED_FILES}" | xargs shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -28,12 +28,13 @@ jobs:
       id: changed-files
       run: |
         if ${{ github.event_name == 'pull_request' }}; then
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)"
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)
         else
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)"
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)
         fi
+
         # Filter only for *.sh files
-        echo "files=$(printf "%s\n" ${{ steps.changed-files.outputs.files }} | { grep -E '^.*\.sh$' || true; }) >> $GITHUB_OUTPUT
+        echo "files=$(printf "%s\n" $CHANGED_GIT_FILES | { grep -E '^.*\.sh$' || true; })" >> $GITHUB_OUTPUT
 
     - name: Run ShellCheck
       if: steps.changed-files.outputs.files != ''

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,35 +17,39 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    #- name: Get changed files
-    #  id: changed-files
-    #  uses: tj-actions/changed-files@v45
-    #  with:
-    #    files: |
-    #      **.sh
-
     - name: Get changed files
       id: changed-files
+      uses: tj-actions/changed-files@v45
+      with:
+        files: |
+          **.sh
+
+    # This is a manual copy from https://github.com/ludeeus/action-shellcheck/blob/00b27aa7cb85167568cb48a3838b75f4265f2bca/action.yaml#L59
+    # Why? Because the action is not capable of adding ONLY a list of files.
+    # We aim to only check the files that have changed.
+    # This is used as we deal with a codebase that throws a lot of warnings.
+    # Checking only the changed files is a good compromise to improve the codebase over time.
+    - name: Download shellcheck
+      shell: bash
+      env:
+        INPUT_VERSION: "v0.10.0"
       run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }})
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          osvariant="darwin"
         else
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          osvariant="linux"
         fi
 
-        # Filter only for *.sh files
-        echo "files=$(printf "%s\n" $CHANGED_GIT_FILES | { grep -E '^.*\.sh$' || true; })" >> $GITHUB_OUTPUT
+        baseurl="https://github.com/koalaman/shellcheck/releases/download"
 
-    - name: Run ShellCheck
-      if: steps.changed-files.outputs.files != ''
-      env:
-        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+        curl -Lso "${{ github.action_path }}/sc.tar.xz" \
+          "${baseurl}/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz"
+
+        tar -xf "${{ github.action_path }}/sc.tar.xz" -C "${{ github.action_path }}"
+        mv "${{ github.action_path }}/shellcheck-${INPUT_VERSION}/shellcheck" \
+          "${{ github.action_path }}/shellcheck"
+
+    - name: Display shellcheck version
+      shell: bash
       run: |
-        echo "${ALL_CHANGED_FILES}" | xargs shellcheck
-
-    #- name: Run ShellCheck
-    #  if: steps.changed-files-specific.outputs.any_changed == 'true'
-    #  env:
-    #    ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-    #  run: |
-    #    echo "${ALL_CHANGED_FILES}" | xargs shellcheck
+        "${{ github.action_path }}/shellcheck" --version

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,15 +18,21 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get changed files
-      id: changes
-      run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          echo "files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
-        else
-          echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
-        fi
+      id: changed-files
+      uses: tj-actions/changed-files@v45
+
+    #- name: Get changed files
+    #  id: changed-files
+    #  run: |
+    #    if ${{ github.event_name == 'pull_request_target' }}; then
+    #      echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)" >> $GITHUB_OUTPUT
+    #    else
+    #      echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+    #    fi
 
     - name: Run ShellCheck
-      if: steps.changes.outputs.files != ''
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       run: |
-        echo "${{ steps.changes.outputs.files }}" | xargs shellcheck
+        echo "${ALL_CHANGED_FILES}" | xargs shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -28,9 +28,9 @@ jobs:
       id: changed-files
       run: |
         if ${{ github.event_name == 'pull_request' }}; then
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }} | xargs)
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ steps.pr.outputs.result && fromJSON(steps.pr.outputs.result).merge_commit_sha }})
         else
-          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)
+          CHANGED_GIT_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
         fi
 
         # Filter only for *.sh files

--- a/install/adguard-install.sh
+++ b/install/adguard-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
-msg_ok "Installed Dependencies "
+msg_ok "Installed Dependencies"
 
 msg_info "Installing AdGuard Home"
 $STD tar zxvf <(curl -fsSL https://static.adtidy.org/adguardhome/release/AdGuardHome_linux_amd64.tar.gz) -C /opt

--- a/install/adguard-install.sh
+++ b/install/adguard-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y curl
 $STD apt-get install -y sudo
 $STD apt-get install -y mc
-msg_ok "Installed Dependencies"
+msg_ok "Installed Dependencies "
 
 msg_info "Installing AdGuard Home"
 $STD tar zxvf <(curl -fsSL https://static.adtidy.org/adguardhome/release/AdGuardHome_linux_amd64.tar.gz) -C /opt


### PR DESCRIPTION
## ✍️ Description

The Shellcheck GitHub Action workflow is not running. It throws an error in the "Get changed files" step:

```sh
Run if true; then
fatal: ambiguous argument 'HEAD^1': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
``` 

See https://github.com/community-scripts/ProxmoxVE/actions/runs/12724031265/job/35469760341

This Pull Request is using the same "Get changes files" logic from another workflow: https://github.com/community-scripts/ProxmoxVE/blob/cc40b5957d6fc96441875b9c61b4d116a4825b49/.github/workflows/validate-filenames.yml#L36-L43

### Work in Progress!

This Pull Request is work in progress as the testing can only be done via Github actions.
I will comment, once this is ready.

---

## 🛠️ Type of Change

- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites

- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)

An alternative would be to use https://github.com/marketplace/actions/changed-files instead of custom crafted shell scripts.

