### PR TITLE
GitHub Actions: Fix Shellsheck workflow to only run on changes `*.sh` files

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,15 +18,45 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Get changed files
-      id: changes
+      id: changed-files
+      uses: tj-actions/changed-files@v45
+      with:
+        files: |
+          **.sh
+
+    # This is a manual copy from https://github.com/ludeeus/action-shellcheck/blob/00b27aa7cb85167568cb48a3838b75f4265f2bca/action.yaml#L59
+    # Why? Because the action is not capable of adding ONLY a list of files.
+    # We aim to only check the files that have changed.
+    # This is used as we deal with a codebase that throws a lot of warnings.
+    # Checking only the changed files is a good compromise to improve the codebase over time.
+    - name: Download shellcheck
+      shell: bash
+      env:
+        INPUT_VERSION: "v0.10.0"
       run: |
-        if ${{ github.event_name == 'pull_request' }}; then
-          echo "files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          osvariant="darwin"
         else
-          echo "files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+          osvariant="linux"
         fi
 
-    - name: Run ShellCheck
-      if: steps.changes.outputs.files != ''
+        baseurl="https://github.com/koalaman/shellcheck/releases/download"
+
+        curl -Lso "${{ github.action_path }}/sc.tar.xz" \
+          "${baseurl}/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz"
+
+        tar -xf "${{ github.action_path }}/sc.tar.xz" -C "${{ github.action_path }}"
+        mv "${{ github.action_path }}/shellcheck-${INPUT_VERSION}/shellcheck" \
+          "${{ github.action_path }}/shellcheck"
+
+    - name: Display shellcheck version
+      shell: bash
       run: |
-        echo "${{ steps.changes.outputs.files }}" | xargs shellcheck
+        "${{ github.action_path }}/shellcheck" --version
+
+    - name: Run ShellCheck
+      if: steps.changed-files-specific.outputs.any_changed == 'true'
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+      run: |
+        echo "${ALL_CHANGED_FILES}" | xargs shellcheck


### PR DESCRIPTION
## ✍️ Description

The Shellcheck GitHub Action workflow is not running. It throws an error in the "Get changed files" step:

```sh
Run if true; then
fatal: ambiguous argument 'HEAD^1': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
``` 

See https://github.com/community-scripts/ProxmoxVE/actions/runs/12724031265/job/35469760341

This Pull Request is using the same "Get changes files" logic from another workflow: https://github.com/community-scripts/ProxmoxVE/blob/cc40b5957d6fc96441875b9c61b4d116a4825b49/.github/workflows/validate-filenames.yml#L36-L43
 
### Why this change?

The current way can't work. E.g. in https://github.com/community-scripts/ProxmoxVE/commit/a119a27b4f969d192dfcb66b4b0e034bf38e1a99#diff-549859aac5bcaebdf605d3ffd525377f2b314b5cc6eb4ebad490bd2cc52617a7L21, the action `ludeeus/action-shellcheck` was removed and `shellcheck` was executed directly. But `shellcheck` was never installed. This was never caught, as we never entered this step (due to the error above).

Right now, we don't use `ludeeus/action-shellcheck` as this repository requires to only run Shellcheck on changed files (due to the amount of warnings). The `ludeeus/action-shellcheck` action doesn't support an "only run on those files" input.
We mitigate this by using the same code as the `ludeeus/action-shellcheck` action to install shellcheck. Then, we run it ourselves. This is a (temp) workaround until this repo is shellcheck warning free.

Additionally we introduce https://github.com/marketplace/actions/changed-files to detect changed-files. The latest change (see https://github.com/community-scripts/ProxmoxVE/commit/b8671b97af2b6070f840ac8e719c80c0d4d5dda3) on the changed files detection also proved that this doesn't seem to be straightforward.
As Github action is used only in the Github env and not locally, I think it make sense to use an existing codebase that is proven.

⚠️ See the testing note below - The action `tj-actions/changed-files` need to be approved by Repo admins.

---

## 🛠️ Type of Change

- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites

- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

### ⚠️ A note on testing

Testing is / was partially possible.
The github action "" needs to be approved by Repository admins:

> tj-actions/changed-files@v45 is not allowed to be used in community-scripts/ProxmoxVE. Actions in this workflow must be: within a repository owned by community-scripts, created by GitHub, or matching the following: ludeeus/action-shellcheck@*.

---

## 📋 Additional Information (optional)

-

