### PR TITLE
[core] build.func&install.func: Fix ssh keynot added error

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -827,6 +827,7 @@ build_container() {
   export PASSWORD="$PW"
   export VERBOSE="$VERB"
   export SSH_ROOT="${SSH}"
+  export SSH_AUTHORIZED_KEY
   export CTID="$CT_ID"
   export CTTYPE="$CT_TYPE"
   export PCT_OSTYPE="$var_os"

--- a/misc/install.func
+++ b/misc/install.func
@@ -255,4 +255,11 @@ EOF
   fi
   echo "bash -c \"\$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/${app}.sh)\"" >/usr/bin/update
   chmod +x /usr/bin/update
+
+  if [[ -n "${SSH_AUTHORIZED_KEY}" ]]; then
+    mkdir -p /root/.ssh
+    echo "${SSH_AUTHORIZED_KEY}" > /root/.ssh/authorized_keys
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/authorized_keys
+  fi
 }


### PR DESCRIPTION
## ✍️ Description

A [PR I created for `develop`](#1060) was recently cherry-picked into `main` (#1456), but it only contained one half of the changes.
The SSH key that can be specified during advanced setup was not being added to the container.
This PR addresses that, recovering the changes made in the original PR.

- Related PR: #1456
- Related PR: #1060 
- Related Discussion: #860

---

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [ ] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [ ] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)

When creating the original PR, I was also pondering the idea of skipping the part that replaces

```
PermitRootLogin prohibit-password`
```
with
```
PermitRootLogin yes
```
in the sshd config, when a root password has been set.
What do you think, would this be a worthy improvement?

