### PR TITLE
Update jellyseerr-install.sh to use Node 22 as required by latest Jellyseerr version

### DIFF
--- a/install/jellyseerr-install.sh
+++ b/install/jellyseerr-install.sh
@@ -24,7 +24,7 @@ msg_ok "Installed Dependencies"
 msg_info "Setting up Node.js Repository"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 msg_ok "Set up Node.js Repository"
 
 msg_info "Installing Node.js"


### PR DESCRIPTION
> **🛠️ Note:**  
> We are meticulous about merging code into the main branch, so please understand that pull requests not meeting the project's standards may be rejected. It's never personal!  
> 🎮 **Note for game-related scripts:** These have a lower likelihood of being merged.

---

## ✍️ Description
Update Jellyseerr's installation script to use Node version 22. As of v2.3.0, the proxmox helper script no longer installs Jellyseer as it fails due to new Node version being required (script is 20, jellyseerr is now using 22).

https://github.com/Fallenbagel/jellyseerr/releases/tag/v2.3.0

- - -
**_Please remove unneeded lines!_**
- Related PR: Fallenbagel/jellyseerr#1229

---

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)  
- [X] Documentation updated (I have updated any relevant documentation)

---

## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

