### PR TITLE
[jellyseerr] Update nodejs if not up-to-date

### DIFF
--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -34,7 +34,7 @@ function update_script() {
         exit
     fi
 
-    if [ "$(node -v | cut -c2- | cut -d. -f1)" -ne 22 ]; then
+    if [ "$(node -v | cut -c2-3)" -ne 22 ]; then
         msg_info "Updating Node.js Repository"
         echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
         msg_ok "Updating Node.js Repository"

--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -34,6 +34,22 @@ function update_script() {
         exit
     fi
 
+    if [ "$(node -v | cut -c2- | cut -d. -f1)" -ne 22 ]; then
+        msg_info "Updating Node.js Repository"
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+        msg_ok "Updating Node.js Repository"
+
+        msg_info "Updating Packages"
+        apt-get update &>/dev/null
+        apt-get -y upgrade &>/dev/null
+        msg_ok "Updating Packages"
+        
+        msg_info "Cleaning up"
+        apt-get -y autoremove
+        apt-get -y autoclean
+        msg_ok "Cleaning up"
+    fi
+
     if ! command -v pnpm &> /dev/null; then
         msg_error "pnpm not found. Installing..."
         npm install -g pnpm &>/dev/null


### PR DESCRIPTION
## ✍️ Description

With older installation of Jellyseer, running `update` in LXC breaks the Jellyseerr, because Node was v20, and pnpm fails with
```
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "/opt/jellyseerr".

Expected version: ^22.0.0
Got: v20.18.0
```

So with this change, update script checks for current node version, and if it's not v22.x, it just updates the node source list to the same one that is in the [install script](https://github.com/community-scripts/ProxmoxVE/blob/8cb63aa07ca4c3c3190897487644b88bdf1e305e/install/jellyseerr-install.sh), and then upgrades packages.

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  


