### PR TITLE
Fix linkwarden update

### DIFF
--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -40,6 +40,7 @@ function update_script() {
     msg_info "Updating ${APP} to ${RELEASE}"
     cd /opt
     mv /opt/linkwarden/.env /opt/.env
+    rm -rf /opt/linkwarden
     RELEASE=$(curl -s https://api.github.com/repos/linkwarden/linkwarden/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
     wget -q "https://github.com/linkwarden/linkwarden/archive/refs/tags/${RELEASE}.zip"
     unzip -q ${RELEASE}.zip
@@ -59,7 +60,6 @@ function update_script() {
     msg_ok "Started ${APP}"
     msg_info "Cleaning up"
     rm -rf /opt/${RELEASE}.zip
-    rm -rf /opt/linkwarden_bak
     msg_ok "Cleaned"
     msg_ok "Updated Successfully"
   else


### PR DESCRIPTION
## ✍️ Description
This PR fixes linkwarden's update
* Without the `rm -rf` the `mv` line that comes after this will result in, for example, `/opt/linkwarden/linkwarden-2.9.3` instead of moving the new version to `/opt/linkwarden`.
* The removal of the `linkwarden_bak` is because this backup is never created.
* Trailing newline inserted

 

- - -
- Related Issue: #
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

