### PR TITLE
Unifi.sh fix wrong URL after Install

### DIFF
--- a/ct/unifi.sh
+++ b/ct/unifi.sh
@@ -46,4 +46,4 @@ description
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8443${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}:8443${CL}"


### PR DESCRIPTION
## ✍️ Description

 The URL shown after successful setup of the LXC is giving an HTTP URL, but the endpoint itself is TLS secured, so HTTPS would be correct.

- - -
- Related Issue: #1600 
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

