### PR TITLE
PBS.sh: Fix wrong URL after Setup

### DIFF
--- a/ct/pbs.sh
+++ b/ct/pbs.sh
@@ -52,4 +52,4 @@ description
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8007${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}:8007${CL}"


### PR DESCRIPTION
## ✍️ Description

Promox Backup Server uses HTTPS on Port 8007 by default. The given URL after setup was `http://<ip>:8007`.
I corrected that on the output. 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  


