### PR TITLE
Update MOTD: Add Dynamic IP with profile.d by @JcMinarro

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -146,17 +146,16 @@ motd_ssh() {
     OS_NAME="Alpine Linux"
     OS_VERSION="Unknown"
   fi
-  # Set MOTD with application info and system details
-  MOTD_FILE="/etc/motd"
-  if [ -f "$MOTD_FILE" ]; then
-    echo -e "\n${BOLD}${APPLICATION} LXC Container${CL}" > "$MOTD_FILE"
-    echo -e "${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| Project: ${GN}ProxmoxVE ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\n" >> "$MOTD_FILE"
-    echo -e "${TAB}${OS}${YW} OS: ${GN}${OS_NAME} ${OS_VERSION}${CL}" >> "$MOTD_FILE"
-    echo -e "${TAB}${HOSTNAME}${YW} Hostname: ${GN}$(hostname)${CL}" >> "$MOTD_FILE"
-    echo -e "${TAB}${INFO}${YW} IP Address: ${GN}${IP}${CL}" >> "$MOTD_FILE"
-  else
-    echo -e "${RD}[WARNING] MOTD file does not exist!${CL}" >&2
-  fi
+
+  PROFILE_FILE="/etc/profile.d/00_lxc-details.sh"
+  echo "echo -e \"\"" > "$PROFILE_FILE"
+  echo -e "echo -e \"${BOLD}${APPLICATION} LXC Container${CL}"\" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\"" >> "$PROFILE_FILE"
+  echo "echo \"\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${OS}${YW} OS: ${GN}${OS_NAME} - Version: ${OS_VERSION}${CL}\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${HOSTNAME}${YW} Hostname: ${GN}\$(hostname)${CL}\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${INFO}${YW} IP Address: ${GN}\$(ip -4 addr show eth0 | awk '/inet / {print \$2}' | cut -d/ -f1 | head -n 1)${CL}\"" >> "$PROFILE_FILE"
+
   # Configure SSH if enabled
   if [[ "${SSH_ROOT}" == "yes" ]]; then
     # Enable sshd service

--- a/misc/install.func
+++ b/misc/install.func
@@ -202,9 +202,6 @@ motd_ssh() {
   # Set terminal to 256-color mode
   grep -qxF "export TERM='xterm-256color'" /root/.bashrc || echo "export TERM='xterm-256color'" >> /root/.bashrc
 
-  # Get the current private IP address
-  IP=$(hostname -I | awk '{print $1}')  # Private IP
-
   # Get OS information (Debian / Ubuntu)
   if [ -f "/etc/os-release" ]; then
     OS_NAME=$(grep ^NAME /etc/os-release | cut -d= -f2 | tr -d '"')
@@ -214,20 +211,14 @@ motd_ssh() {
     OS_VERSION=$(cat /etc/debian_version)
   fi
 
-  # Set MOTD with application info, system details
-  MOTD_FILE="/etc/motd"
-  if [ -f "$MOTD_FILE" ]; then
-    # Start MOTD with application info and link
-    echo -e "\n${BOLD}${APPLICATION} LXC Container${CL}" > "$MOTD_FILE"
-    echo -e "${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\n" >> "$MOTD_FILE"
-
-    # Add system information with icons
-    echo -e "${TAB}${OS}${YW} OS: ${GN}${OS_NAME} - Version: ${OS_VERSION}${CL}" >> "$MOTD_FILE"
-    echo -e "${TAB}${HOSTNAME}${YW} Hostname: ${GN}$(hostname)${CL}" >> "$MOTD_FILE"
-    echo -e "${TAB}${INFO}${YW} IP Address: ${GN}${IP}${CL}" >> "$MOTD_FILE"
-  else
-    echo "MotD file does not exist!" >&2
-  fi
+  PROFILE_FILE="/etc/profile.d/00_lxc-details.sh"
+  echo "echo -e \"\"" > "$PROFILE_FILE"
+  echo -e "echo -e \"${BOLD}${APPLICATION} LXC Container${CL}"\" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\"" >> "$PROFILE_FILE"
+  echo "echo \"\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${OS}${YW} OS: ${GN}${OS_NAME} - Version: ${OS_VERSION}${CL}\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${HOSTNAME}${YW} Hostname: ${GN}\$(hostname)${CL}\"" >> "$PROFILE_FILE"
+  echo -e "echo -e \"${TAB}${INFO}${YW} IP Address: ${GN}\$(hostname -I | awk '{print \$1}')${CL}\"" >> "$PROFILE_FILE"
 
   # Disable default MOTD scripts
   chmod -x /etc/update-motd.d/*


### PR DESCRIPTION
## ✍️ Description
Instead of hardcode data within the /etc/motd file, adding a script on /etc/profile.d/ to load dynamic values as the IP and/or the hostname of the LXC

 

- - -
- Related Issue: #1632
- Related PR: #1216
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [x] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)   

