### PR TITLE
Update build.func: Ubuntu advanced settings version

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -462,8 +462,7 @@ advanced_settings() {
         else
           exit_script
         fi
-      fi
-      if [ "$var_default_version" == "22.04" ]; then
+      elif [ "$var_default_version" == "22.04" ]; then
         if var_version=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "UBUNTU VERSION" --radiolist "Choose Version" 10 58 4 \
           "20.04" "Focal" OFF \
           "22.04" "Jammy" ON \
@@ -476,9 +475,8 @@ advanced_settings() {
         else
           exit_script
         fi
-      fi
-      if [ "$var_default_version" == "24.04" ]; then
-        if var_version=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "UBUNTU VERSION" --radiolist "Choose Version" 10 58 4 \
+      elif [ "$var_default_version" == "24.04" ]; then
+	        if var_version=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "UBUNTU VERSION" --radiolist "Choose Version" 10 58 4 \
           "20.04" "Focal" OFF \
           "22.04" "Jammy" OFF \
           "24.04" "Noble" ON \
@@ -489,9 +487,8 @@ advanced_settings() {
           fi
         else
           exit_script
-        fi
-      fi
-      if [ "$var_default_version" == "24.10" ]; then
+        fi   
+      else
         if var_version=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "UBUNTU VERSION" --radiolist "Choose Version" 10 58 4 \
           "20.04" "Focal" OFF \
           "22.04" "Jammy" OFF \


### PR DESCRIPTION

## ✍️ Description


 Fixes a issue with endless loop in Ubuntu Advanced when the default is a Debian as the if checks never succeed. Fallback to ubuntu 24.10 when no match before.

- - -
- Related Issue: #1700
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

