### PR TITLE
Calibre binaries must be installed alongside Calibre-Web, added them

### DIFF
--- a/install/calibre-web-install.sh
+++ b/install/calibre-web-install.sh
@@ -35,6 +35,7 @@ msg_ok "Installed Kepubify"
 
 msg_info "Installing Calibre-Web"
 mkdir -p /opt/calibre-web
+$STD apt-get install -y calibre
 $STD wget https://github.com/janeczku/calibre-web/raw/master/library/metadata.db -P /opt/calibre-web
 $STD pip install calibreweb
 $STD pip install jsonschema

--- a/install/sqlserver2022-install.sh
+++ b/install/sqlserver2022-install.sh
@@ -33,6 +33,7 @@ msg_ok "Setup Server 2022"
 
 msg_info "Installing SQL Server Tools"
 export DEBIAN_FRONTEND=noninteractive
+export ACCEPT_EULA=Y
 curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc
 curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 $STD apt-get update

--- a/json/the-lounge.json
+++ b/json/the-lounge.json
@@ -32,7 +32,7 @@
     },
     "notes": [
       {
-        "text": "The Lounge is running in private mode. Use `sudo -u thelounge thelounge add name` to create users.",
+        "text": "The Lounge is running in private mode. Use `runuser -u thelounge -- thelounge add name` to create users.",
         "type": "info"
       }
     ]


### PR DESCRIPTION
## ✍️ Description


 

- - -
- Related Issue: #1748 
- Related PR: #1748 
- Related Discussion: #1748 
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [*] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [*] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [*] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Calibre binaries are in /usr/bin
User must set the path in Basic config:
![image](https://github.com/user-attachments/assets/1021feb1-1e61-49d1-bba7-1cee0b0dd218)

