### PR TITLE
[core]: Remove Figlet | Get Headers by Repo & Store Local

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -233,65 +233,41 @@ update_motd_ip() {
   fi
 }
 
-# This function sets the APP-Name into an ASCII Header in Slant, figlet needed on proxmox main node.
-header_info() {
-  # Helper function: Install FIGlet and download fonts
-  install_figlet() {
-    echo -e "${INFO}${BOLD}${DGN}Installing FIGlet...${CL}"
+# Function to download & save header files
+get_header() {
+  local app_name=$(echo ${APP,,} | tr -d ' ') 
+  local header_url="https://github.com/community-scripts/ProxmoxVE/raw/header_testing/ct/headers/${app_name}"
+  local local_header_path="/usr/local/community-scripts/headers/${app_name}"
 
-    temp_dir=$(mktemp -d)
-    curl -sL https://github.com/community-scripts/ProxmoxVE/raw/refs/heads/main/misc/figlet.tar.xz -o "$temp_dir/figlet.tar.xz"
-    mkdir -p /tmp/figlet
-    tar -xf "$temp_dir/figlet.tar.xz" -C /tmp/figlet --strip-components=1
-    cd /tmp/figlet
-    make >/dev/null
+  mkdir -p "/usr/local/community-scripts/headers"
 
-    if [ -f "figlet" ]; then
-      chmod +x figlet
-      mv figlet /usr/local/bin/
-      mkdir -p /usr/local/share/figlet
-      cp -r /tmp/figlet/fonts/*.flf /usr/local/share/figlet/
-      echo -e "${CM}${BOLD}${DGN}FIGlet successfully installed.${CL}"
-    else
-      echo -e "${ERR}${BOLD}${RED}Failed to install FIGlet.${CL}"
+  # Check if local file already present
+  if [ ! -f "$local_header_path" ]; then
+    wget -qO "$local_header_path" "$header_url"
+    if [ $? -ne 0 ]; then
+      echo -e "${WARN}${BOLD}${YLW}Failed to download header for ${app_name}. No header will be displayed.${CL}"
       return 1
-    fi
-    rm -rf "$temp_dir"
-  }
-
-  # Check if figlet and the slant font are available
-  if ! figlet -f slant "Test" &>/dev/null; then
-    echo -e "${INFO}${BOLD}${DGN}FIGlet or the slant font is missing. Installing...${CL}"
-
-    if [ -f /etc/debian_version ] || [ -f /etc/lsb-release ]; then
-      # Debian/Ubuntu-based systems
-      apt-get update -y &>/dev/null
-      apt-get install -y wget build-essential &>/dev/null
-      install_figlet
-
-    elif [ -f /etc/alpine-release ]; then
-      # Alpine-based systems
-      apk add --no-cache tar xz build-base wget &>/dev/null
-      export TERM=xterm
-      install_figlet
-
-    else
-      echo -e "${ERR}${BOLD}${RED}Unsupported operating system.${CL}"
-      return 1
-    fi
-
-    # Ensure the slant font is available
-    if [ ! -f "/usr/share/figlet/slant.flf" ]; then
-      echo -e "${INFO}${BOLD}${DGN}Downloading slant font...${CL}"
-      wget -qO /usr/share/figlet/slant.flf "http://www.figlet.org/fonts/slant.flf"
     fi
   fi
+  cat "$local_header_path"
+}
 
-  # Display ASCII header
+# This function sets the APP-Name into an ASCII Header in Slant, figlet needed on proxmox main node.
+header_info() {
+  local app_name=$(echo ${APP,,} | tr -d ' ') 
+  local header_content
+
+  # Download & save Header-File locally
+  header_content=$(get_header "$app_name")
+  if [ $? -ne 0 ]; then
+    # Fallback: Doesn't show Header
+    return 0
+  fi
+
+  # Show ASCII-Header
   term_width=$(tput cols 2>/dev/null || echo 120)
-  ascii_art=$(figlet -f slant -w "$term_width" "$APP")
   clear
-  echo "$ascii_art"
+  echo "$header_content"
 }
 
 # This function checks if the script is running through SSH and prompts the user to confirm if they want to proceed or exit.

--- a/misc/build.func
+++ b/misc/build.func
@@ -236,7 +236,7 @@ update_motd_ip() {
 # Function to download & save header files
 get_header() {
   local app_name=$(echo ${APP,,} | tr -d ' ') 
-  local header_url="https://github.com/community-scripts/ProxmoxVE/raw/header_testing/ct/headers/${app_name}"
+  local header_url="https://github.com/community-scripts/ProxmoxVE/raw/main/ct/headers/${app_name}"
   local local_header_path="/usr/local/community-scripts/headers/${app_name}"
 
   mkdir -p "/usr/local/community-scripts/headers"


### PR DESCRIPTION
## ✍️ Description

- Remove Figlet Generation on LXC's and Proxmox Nodes
- Get Headers by repo, if not an header available -> doenst show header
- Store Headers local, dont need an active internet connection after create/update for this.

=> Work with an GH Action in our repo, files stored in ct/headers

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [x] New feature (non-breaking change that adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

