### PR TITLE
Filter out duplicate scripts in LatestScripts component and sort by creation date

### DIFF
--- a/frontend/src/app/scripts/_components/ScriptInfoBlocks.tsx
+++ b/frontend/src/app/scripts/_components/ScriptInfoBlocks.tsx
@@ -35,8 +35,18 @@ export function LatestScripts({ items }: { items: Category[] }) {
 
   const latestScripts = useMemo(() => {
     if (!items) return [];
+    
     const scripts = items.flatMap((category) => category.scripts || []);
-    return scripts.sort(
+
+    // Filter out duplicates by slug
+    const uniqueScriptsMap = new Map<string, Script>();
+    scripts.forEach((script) => {
+      if (!uniqueScriptsMap.has(script.slug)) {
+        uniqueScriptsMap.set(script.slug, script);
+      }
+    });
+
+    return Array.from(uniqueScriptsMap.values()).sort(
       (a, b) =>
         new Date(b.date_created).getTime() - new Date(a.date_created).getTime(),
     );
@@ -49,7 +59,7 @@ export function LatestScripts({ items }: { items: Category[] }) {
   const goToPreviousPage = () => {
     setPage((prevPage) => prevPage - 1);
   };
-
+  
   const startIndex = (page - 1) * ITEMS_PER_PAGE;
   const endIndex = page * ITEMS_PER_PAGE;
 


### PR DESCRIPTION
## ✍️ Description

This pull request includes a update to the `LatestScripts` function in the `ScriptInfoBlocks.tsx` file, focusing on filtering out duplicate scripts and improving the sorting mechanism.

Key changes:

* [`frontend/src/app/scripts/_components/ScriptInfoBlocks.tsx`](diffhunk://#diff-879c319f50f0a92482cc7228edea097072191aff8564256c5e47549c3bd3ffe0R38-R49): Added logic to filter out duplicate scripts based on their slug using a `Map` data structure and ensured the resulting list is sorted by the creation date in descending order.

- - -
- Related Issue: fixes #1726 and fixes #1821
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

