### PR TITLE
fix: remove rounded styles from command primitive

### DIFF
--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -15,7 +15,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden bg-popover text-popover-foreground",
       className,
     )}
     {...props}


### PR DESCRIPTION
## ✍️ Description

Fix an issue in the search command component that makes the palette blurry. The current command palette (search) looks like this:

<img width="395" alt="image" src="https://github.com/user-attachments/assets/3a405835-7543-4a1b-b441-1184c5115206" />

While the search is sharp the rest is blurry. By removing the `rounded-md` style (see https://github.com/shadcn-ui/ui/issues/711), it immediately becomes sharp:

<img width="395" alt="image" src="https://github.com/user-attachments/assets/b3d6d42a-1f25-4c8c-80bb-f1c3e8496971" />

- - -
- Related Issue: none
- Related PR: none
- Related Discussion: none
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [ ] New feature (non-breaking change that adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [ ] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

This was also an issue in Beszel, here https://github.com/henrygd/beszel/issues/137, the change is tested with it too :)