### PR TITLE
Fix IT-Tools Website Entry (Default | Alpine) 

### DIFF
--- a/json/it-tools.json
+++ b/json/it-tools.json
@@ -10,12 +10,12 @@
   "privileged": false,
   "interface_port": 80,
   "documentation": null,
-  "website": "https://github.com/CorentinTh/it-tools",
+  "website": "https://it-tools.tech/",
   "logo": "https://raw.githubusercontent.com/CorentinTh/it-tools/08d977b8cdb7ffb76adfa18ba6eb4b73795ec814/public/safari-pinned-tab.svg",
   "description": "IT-Tools is a web-based suite of utilities designed to streamline and simplify various IT tasks, providing tools for developers and system administrators to manage their workflows efficiently.",
   "install_methods": [
       {
-          "type": "alpine",
+          "type": "default",
           "script": "ct/alpine-it-tools.sh",
           "resources": {
               "cpu": 1,


### PR DESCRIPTION
## ✍️ Description

Switch "alpine" to default, because it shows an empty default and an correct alpine:
<img width="723" alt="image" src="https://github.com/user-attachments/assets/ac4cbe36-bc09-4952-a930-815c566dfe0a" />



## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
