### PR TITLE
[Fix] Alpine-IT-Tools, add missing ssh package for root ssh access

### DIFF
--- a/install/alpine-it-tools-install.sh
+++ b/install/alpine-it-tools-install.sh
@@ -17,6 +17,7 @@ msg_info "Installing Dependencies"
 $STD apk add \
   curl \
   mc \
+  openssh \
   nginx \
   unzip
 msg_ok "Installed Dependencies"


### PR DESCRIPTION
## ✍️ Description

Theoretical fix for apline-it-tools not installing.
 

- - -
- Related Issue: #1890
- Related PR: -
- Related Discussion: -
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

Warning this is only a theoretical fix by comparing other apline scripts and alpine-it-tools and reading the error, I'm currently not able to test this.