### PR TITLE
Prometheus PVE Exporter: Add `--default-timeout=300` to pip install commands

### DIFF
--- a/ct/prometheus-pve-exporter.sh
+++ b/ct/prometheus-pve-exporter.sh
@@ -37,7 +37,7 @@ function update_script() {
     msg_ok "Stopped ${APP}"
 
     msg_info "Updating ${APP}"
-    pip install prometheus-pve-exporter --upgrade --root-user-action=ignore &>/dev/null
+    pip install prometheus-pve-exporter --default-timeout=300 --upgrade --root-user-action=ignore &>/dev/null
     msg_ok "Updated ${APP}"
 
     msg_info "Starting ${APP}"

--- a/install/prometheus-pve-exporter-install.sh
+++ b/install/prometheus-pve-exporter-install.sh
@@ -28,7 +28,7 @@ rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Setup Python3"
 
 msg_info "Installing Prometheus Proxmox VE Exporter"
-python3 -m pip install --quiet --root-user-action=ignore prometheus-pve-exporter
+python3 -m pip install --default-timeout=300 --quiet --root-user-action=ignore prometheus-pve-exporter
 mkdir -p /opt/prometheus-pve-exporter
 cat <<EOF > /opt/prometheus-pve-exporter/pve.yml
 default:


### PR DESCRIPTION
## ✍️ Description

Fixing the error

```
✔️  Setup Python3
⠹  WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de82eea50>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)')': /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl
⠙  WARNING: Retrying (Retry(total=3, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de82ef050>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)')': /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl
⠇  WARNING: Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de82ef850>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)')': /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl
⠸  WARNING: Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de843b350>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)')': /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl
⠇  WARNING: Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de82f0550>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)')': /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl
⠸ERROR: Could not install packages due to an OSError: HTTPSConnectionPool(host='files.pythonhosted.org', port=443): Max retries exceeded with url: /packages/3d/3d/851129dfba38bf4bd8c0f1b42bc26b82bbdb49e360659f2e6062784ff48c/prometheus_pve_exporter-3.5.1-py3-none-any.whl (Caused by ConnectTimeoutError(<pip._vendor.urllib3.connection.HTTPSConnection object at 0x774de82f0b90>, 'Connection to files.pythonhosted.org timed out. (connect timeout=15)'))

⠼
[ERROR] in line 31: exit code 0: while executing command python3 -m pip install --quiet --root-user-action=ignore prometheus-pve-exporter
``` 

- - -
- Related Issue: #1936
- - - 


## ✅ Prerequisites

- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change

- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)

None
