### PR TITLE
Fix Hoarder corepack install/update error

### DIFF
--- a/ct/hoarder.sh
+++ b/ct/hoarder.sh
@@ -39,6 +39,9 @@ function update_script() {
     systemctl stop hoarder-web hoarder-workers hoarder-browser
     msg_ok "Stopped Services"
     msg_info "Updating ${APP} to v${RELEASE}"
+    if [[ $(corepack -v) < "0.31.0" ]]; then
+      npm install -g corepack@0.31.0 &>/dev/null
+    fi
     cd /opt
     if [[ -f /opt/hoarder/.env ]] && [[ ! -f /etc/hoarder/hoarder.env ]]; then
       mkdir -p /etc/hoarder

--- a/install/hoarder-install.sh
+++ b/install/hoarder-install.sh
@@ -56,6 +56,7 @@ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dea
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 $STD apt-get update
 $STD apt-get install -y nodejs
+$STD npm install -g corepack@0.31.0
 msg_ok "Installed Node.js"
 
 msg_info "Installing Hoarder"


### PR DESCRIPTION
Installs Corepack v0.31.0 during Hoarder installation; checks if Corepack needs updating during Hoarder update.

## ✍️ Description

Fix ported from https://github.com/hoarder-app/hoarder/commit/ccd9159ba80d87a5cf1d80544f23faf69d93b1af

Installs Corepack v0.31.0 during fresh Hoarder install; checks if Corepack needs updating during Hoarder update.
 

- - -
- Related Issue: #1786
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

