### PR TITLE
Prometheus Proxmox VE Exporter: Set correct website slug

### DIFF
--- a/json/prometheus-pve-exporter.json
+++ b/json/prometheus-pve-exporter.json
@@ -1,6 +1,6 @@
 {
     "name": "Prometheus Proxmox VE Exporter",
-    "slug": "prometheus-proxmox-ve-exporter",
+    "slug": "prometheus-pve-exporter",
     "categories": [
         1,
         9


### PR DESCRIPTION
## ✍️ Description

If i click "Source Code" in https://community-scripts.github.io/ProxmoxVE/scripts?id=prometheus-proxmox-ve-exporter, i get a 404.

This PR is setting the right slug to fix the link to the Source Code.

## ✅ Prerequisites

- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change

- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)

None
