### PR TITLE
Fix: Authentik Fix wrong HDD Size

### DIFF
--- a/ct/authentik.sh
+++ b/ct/authentik.sh
@@ -8,7 +8,7 @@ source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/m
 # App Default Values
 APP="Authentik"
 var_tags="identity-provider"
-var_disk="15"
+var_disk="12"
 var_cpu="6"
 var_ram="8192"
 var_os="debian"


### PR DESCRIPTION
## ✍️ Description

Fix the wrong HDD size, as the LXC is created with a 12 GB disk size by default, and the HDD size menu in advanced settings shows 15 GB instead
 

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- []X Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  


