### PR TITLE
Fix Tianji: Add heap-space value for nodejs

### DIFF
--- a/ct/tianji.sh
+++ b/ct/tianji.sh
@@ -45,6 +45,7 @@ function update_script() {
     unzip -q v${RELEASE}.zip
     mv tianji-${RELEASE} /opt/tianji
     cd tianji
+    export NODE_OPTIONS="--max_old_space_size=4096"
     pnpm install --filter @tianji/client... --config.dedupe-peer-dependents=false --frozen-lockfile >/dev/null 2>&1
     pnpm build:static >/dev/null 2>&1
     pnpm install --filter @tianji/server... --config.dedupe-peer-dependents=false >/dev/null 2>&1


### PR DESCRIPTION
## ✍️ Description

add:
export NODE_OPTIONS="--max_old_space_size=4096"
 

- - -
- Related Issue: #1973
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

