### PR TITLE
Fix actual update - missing hidden files, downloaded release cleanup

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -44,9 +44,8 @@ function update_script() {
         cd /tmp
         wget -q https://github.com/actualbudget/actual-server/archive/refs/tags/v${RELEASE}.tar.gz
         mv /opt/actualbudget /opt/actualbudget_bak
-        mkdir -p /opt/actualbudget/
         tar -xzf v${RELEASE}.tar.gz >/dev/null 2>&1
-        mv *ctual-server-*/* /opt/actualbudget
+        mv *ctual-server-* /opt/actualbudget
         rm -rf /opt/actualbudget/.env
         mv /opt/actualbudget_bak/.env /opt/actualbudget
         mv /opt/actualbudget_bak/server-files /opt/actualbudget/server-files

--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -60,7 +60,7 @@ function update_script() {
         
         msg_info "Cleaning Up"
         rm -rf /opt/actualbudget_bak
-        rm -rf /tmp/actual-server.tar.gz
+        rm -rf /tmp/v${RELEASE}.tar.gz
         msg_ok "Cleaned"
         msg_ok "Updated Successfully"
     else


### PR DESCRIPTION
## ✍️ Description

Fixes #1707.

Update script had different logic around folder and file movement when compared to install script, I followed install script logic.

Update script did not move the hidden files (dotfiles) from newly downloaded release of Actual Budget due to bash, by default, not matching dot files (`mv *ctual-server-*/*` behavior depends on bash's `dotglob` option).

The bottom `rm -rf` of `.tar.gz` seemed not effective - I updated it to follow install script logic. 

- - -
- Related Issue: #1707
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

