### PR TITLE
Fix JSON-Editor

### DIFF
--- a/frontend/src/app/json-editor/_components/InstallMethod.tsx
+++ b/frontend/src/app/json-editor/_components/InstallMethod.tsx
@@ -64,8 +64,8 @@ function InstallMethod({
             if (key === "type") {
               updatedMethod.script =
                 value === "alpine"
-                  ? `/${prev.type}/alpine-${prev.slug}.sh`
-                  : `/${prev.type}/${prev.slug}.sh`;
+                  ? `${prev.type}/alpine-${prev.slug}.sh`
+                  : `${prev.type}/${prev.slug}.sh`;
 
               // Set OS to Alpine and reset version if type is alpine
               if (value === "alpine") {

--- a/frontend/src/app/json-editor/page.tsx
+++ b/frontend/src/app/json-editor/page.tsx
@@ -76,8 +76,8 @@ export default function JSONGenerator() {
             ...method,
             script:
               method.type === "alpine"
-                ? `/${updated.type}/alpine-${updated.slug}.sh`
-                : `/${updated.type}/${updated.slug}.sh`,
+                ? `${updated.type}/alpine-${updated.slug}.sh`
+                : `${updated.type}/${updated.slug}.sh`,
           }));
         }
 


### PR DESCRIPTION
## ✍️ Description

Fixes a issue with the JSON Editor where it puts a leading / when selecting VM or MISC

## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [X] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)

When Type is LXC it works:
![image](https://github.com/user-attachments/assets/f0ce7157-06fd-49bf-a400-eb19839632bf)

When changin to VM or MISC it puts a leading /
![image](https://github.com/user-attachments/assets/9a18f5d8-3425-45d6-b9f8-acda2dfc8411)

After switching back to LXC the slash stays:
![image](https://github.com/user-attachments/assets/87052c73-e6df-48f1-911f-de2dc7464dbd)

With the fix:
![image](https://github.com/user-attachments/assets/5edabf89-55f1-4bd2-8eb6-14adfd3057e5)


