### PR TITLE
[core]: Enhance LXC template handling and improve error recovery

### DIFF
--- a/ct/create_lxc.sh
+++ b/ct/create_lxc.sh
@@ -182,24 +182,39 @@ mapfile -t TEMPLATES < <(pveam available -section system | sed -n "s/.*\($TEMPLA
 [ ${#TEMPLATES[@]} -gt 0 ] || { msg_error "Unable to find a template when searching for '$TEMPLATE_SEARCH'."; exit 207; }
 TEMPLATE="${TEMPLATES[-1]}"
 
-# Download LXC template if needed
-if ! pveam list $TEMPLATE_STORAGE | grep -q $TEMPLATE; then
+TEMPLATE_PATH="/var/lib/vz/template/cache/$TEMPLATE"
+# Check if template exists, if corrupt remove and redownload
+if ! pveam list "$TEMPLATE_STORAGE" | grep -q "$TEMPLATE"; then
+  [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
   msg_info "Downloading LXC Template"
-  pveam download $TEMPLATE_STORAGE $TEMPLATE >/dev/null ||
-    msg_error "A problem occured while downloading the LXC template."
-    exit 208
+  pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
+    { msg_error "A problem occurred while downloading the LXC template."; exit 208; }
   msg_ok "Downloaded LXC Template"
 fi
 
+# Check and fix subuid/subgid
+grep -q "root:100000:65536" /etc/subuid || echo "root:100000:65536" >> /etc/subuid
+grep -q "root:100000:65536" /etc/subgid || echo "root:100000:65536" >> /etc/subgid
+
 # Combine all options
-DEFAULT_PCT_OPTIONS=(
-  -arch $(dpkg --print-architecture))
-
 PCT_OPTIONS=(${PCT_OPTIONS[@]:-${DEFAULT_PCT_OPTIONS[@]}})
-[[ " ${PCT_OPTIONS[@]} " =~ " -rootfs " ]] || PCT_OPTIONS+=(-rootfs $CONTAINER_STORAGE:${PCT_DISK_SIZE:-8})
+[[ " ${PCT_OPTIONS[@]} " =~ " -rootfs " ]] || PCT_OPTIONS+=(-rootfs "$CONTAINER_STORAGE:${PCT_DISK_SIZE:-8}")
 
-# Create container
+# Create container with template integrity check
 msg_info "Creating LXC Container"
-pct create $CTID ${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE} ${PCT_OPTIONS[@]} >/dev/null || { msg_error "A problem occured while trying to create container.";  exit 200; }
-msg_ok "LXC Container ${BL}$CTID${CL} ${GN}was successfully created."
+if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" >/dev/null; then
+  msg_info "Container creation failed, checking template integrity..."
+  [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
+  msg_ok "Template integrity check completed"
+  
+  msg_info "Re-downloading LXC Template"
+  pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
+    { msg_error "A problem occurred while re-downloading the LXC template."; exit 208; }
+  msg_ok "Re-downloaded LXC Template"
 
+  if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" >/dev/null; then
+    msg_error "A problem occurred while trying to create container after re-downloading template."
+    exit 200
+  fi
+fi
+msg_ok "LXC Container ${BL}$CTID${CL} ${GN}was successfully created."

--- a/ct/create_lxc.sh
+++ b/ct/create_lxc.sh
@@ -206,9 +206,9 @@ msg_info "Creating LXC Container"
       [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
       
     msg_ok "Template integrity check completed"
-    pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
-    
+    pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||    
       { msg_error "A problem occurred while re-downloading the LXC template."; exit 208; }
+    
     msg_ok "Re-downloaded LXC Template"
     if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" &>/dev/null; then
         msg_error "A problem occurred while trying to create container after re-downloading template."

--- a/ct/create_lxc.sh
+++ b/ct/create_lxc.sh
@@ -202,19 +202,19 @@ PCT_OPTIONS=(${PCT_OPTIONS[@]:-${DEFAULT_PCT_OPTIONS[@]}})
 
 # Create container with template integrity check
 msg_info "Creating LXC Container"
-if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" >/dev/null; then
-  msg_info "Container creation failed, checking template integrity..."
-  [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
-  msg_ok "Template integrity check completed"
+  if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" &>/dev/null; then
+    msg_info "Container creation failed, checking template integrity..."
+    [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
+    msg_ok "Template integrity check completed"
+    
+    msg_info "Re-downloading LXC Template"
+    pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
+      { msg_error "A problem occurred while re-downloading the LXC template."; exit 208; }
+    msg_ok "Re-downloaded LXC Template"
   
-  msg_info "Re-downloading LXC Template"
-  pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
-    { msg_error "A problem occurred while re-downloading the LXC template."; exit 208; }
-  msg_ok "Re-downloaded LXC Template"
-
-  if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" >/dev/null; then
-    msg_error "A problem occurred while trying to create container after re-downloading template."
-    exit 200
+    if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" &>/dev/null; then
+      msg_error "A problem occurred while trying to create container after re-downloading template."
+      exit 200
+    fi
   fi
-fi
 msg_ok "LXC Container ${BL}$CTID${CL} ${GN}was successfully created."

--- a/ct/create_lxc.sh
+++ b/ct/create_lxc.sh
@@ -203,17 +203,15 @@ PCT_OPTIONS=(${PCT_OPTIONS[@]:-${DEFAULT_PCT_OPTIONS[@]}})
 # Create container with template integrity check
 msg_info "Creating LXC Container"
   if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" &>/dev/null; then
-    msg_info "Container creation failed, checking template integrity..."
-    [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
+      [[ -f "$TEMPLATE_PATH" ]] && rm -f "$TEMPLATE_PATH"
+      
     msg_ok "Template integrity check completed"
-    
-    msg_info "Re-downloading LXC Template"
     pveam download "$TEMPLATE_STORAGE" "$TEMPLATE" >/dev/null ||
+    
       { msg_error "A problem occurred while re-downloading the LXC template."; exit 208; }
     msg_ok "Re-downloaded LXC Template"
-  
     if ! pct create "$CTID" "${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE}" "${PCT_OPTIONS[@]}" &>/dev/null; then
-      msg_error "A problem occurred while trying to create container after re-downloading template."
+        msg_error "A problem occurred while trying to create container after re-downloading template."
       exit 200
     fi
   fi


### PR DESCRIPTION
## ✍️ Description

Improves robustness by automatically deleting and **re-downloading corrupted LXC** templates when container creation fails. Ensures all _msg_info_ logs have corresponding _msg_ok_ messages for consistency. Also adds validation for _subuid_ and _subgid_ to prevent permission issues.

Currently affected 1344 of 7354 failed installations. 

![image](https://github.com/user-attachments/assets/d7f34923-791c-45f6-8726-a00e3749c674)
![image](https://github.com/user-attachments/assets/e9881caf-a6f7-4802-8878-9abefc19967c)
![image](https://github.com/user-attachments/assets/9f040503-145c-482b-abe9-89424d8ca695)


now breaking an template (truncate file hard, lol ): 
```bash
truncate -s 500K /var/lib/vz/template/cache/ubuntu-24.10-standard_24.10-1_amd64.tar.zst
```

Now create an new LXC, you see on bottom you get an issue in pct create, after this the Re-Download runs.

![image](https://github.com/user-attachments/assets/39a6d164-e50e-4a23-ba93-936a0217e80a)



## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [x] New feature (non-breaking change that adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  

