### PR TITLE
Keep the same hass_config volume for Home Assistant

### DIFF
--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -49,7 +49,7 @@ function update_script() {
       LATEST_IMAGE="$(docker inspect --format "{{.Id}}" --type image "${CONTAINER_IMAGE}")"
       if [[ "${RUNNING_IMAGE}" != "${LATEST_IMAGE}" ]]; then
         echo "Updating ${container} image ${CONTAINER_IMAGE}"
-        DOCKER_COMMAND="$(runlike "${container}")"
+        DOCKER_COMMAND="$(runlike --use-volume-id "${container}")"
         docker rm --force "${container}"
         eval ${DOCKER_COMMAND}
       fi


### PR DESCRIPTION
## ✍️ Description

I started using the Home Assistant Container for some extra instances recently and attempted the first update today.  After pulling and restarting, I lost my config and landed at the onboarding page again.  I found that the while the installer creates the `hass_config` volume, it wasn't being used anymore.  I was able to switch it back with portainer and all is well, but then I dug in to find out what happened.
 
Tracked it down to the (generally handy) `runlike` command, which was recreating all the bind mounts but not this named volume.  The `--volume /config` option ends up creating a new one which explains the empty config.

```
$ runlike homeassistant
docker run --name=homeassistant --hostname=ha-dash --volume /etc/localtime:/etc/localtime:ro --volume /var/run/docker.sock:/var/run/docker.sock --volume /config --volume /dev:/dev <snip>
```

Looking at the options, `--use-volume-id` does the trick:

```
$ runlike --use-volume-id homeassistant
docker run --name=homeassistant --hostname=ha-dash --volume /dev:/dev --volume /etc/localtime:/etc/localtime:ro --volume /var/run/docker.sock:/var/run/docker.sock --volume hass_config:/config --volume /dev:/dev
```

- - -
- Related Issue: #
- Related PR: #
- Related Discussion: #
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

