### PR TITLE
Fix: Actualbudget - salvage the `.migrate` file when upgrading

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -48,6 +48,7 @@ function update_script() {
         mv *ctual-server-* /opt/actualbudget
         rm -rf /opt/actualbudget/.env
         mv /opt/actualbudget_bak/.env /opt/actualbudget
+        mv /opt/actualbudget_bak/.migrate /opt/actualbudget
         mv /opt/actualbudget_bak/server-files /opt/actualbudget/server-files
         cd /opt/actualbudget
         yarn install &>/dev/null


### PR DESCRIPTION
## ✍️ Description

Recent Actual Budget update made it mandatory to persist the `.migrate` file before upgrading, or else the SQLite migrations fail:

> Up until recently the migrations that were running were always backwards compatible, so re-running them again and again didn't cause issues. But recently we introduced a migration that can only be ran once. Which is fine - migrations are expected to be ran once.
>
> But because the .migrate file is not persisted in some machines... things blow up.
 
https://github.com/actualbudget/actual-server/issues/521#issuecomment-2536985283

- - -
- Related Issue: #2168 
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

