### PR TITLE
Fix: "read -p" does not support color formatting

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -956,7 +956,8 @@ check_container_resources() {
   if [[ "$current_ram" -lt "$var_ram" ]] || [[ "$current_cpu" -lt "$var_cpu" ]]; then
     echo -e "\n${INFO}${HOLD} ${GN}Required: ${var_cpu} CPU, ${var_ram}MB RAM ${CL}| ${RD}Current: ${current_cpu} CPU, ${current_ram}MB RAM${CL}"
     echo -e "${YWB}Please ensure that the ${APP} LXC is configured with at least ${var_cpu} vCPU and ${var_ram} MB RAM for the build process.${CL}\n"
-    read -r -p "${INFO}${HOLD} May cause data loss! ${INFO} Continue update with under-provisioned LXC? <yes/No>  " prompt
+    echo -ne "${INFO}${HOLD} May cause data loss! ${INFO} Continue update with under-provisioned LXC? <yes/No>  "
+    read -r prompt
     # Check if the input is 'yes', otherwise exit with status 1
     if [[ ! ${prompt,,} =~ ^(yes)$ ]]; then
       echo -e "${CROSS}${HOLD} ${YWB}Exiting based on user input.${CL}"

--- a/misc/build.func
+++ b/misc/build.func
@@ -976,7 +976,8 @@ check_container_storage() {
   if (( usage > 80 )); then
     # Prompt the user for confirmation to continue
     echo -e "${INFO}${HOLD} ${YWB}Warning: Storage is dangerously low (${usage}%).${CL}"
-    read -r -p "Continue anyway? <y/N>  " prompt
+    echo -ne "Continue anyway? <y/N>  "
+    read -r prompt
     # Check if the input is 'y' or 'yes', otherwise exit with status 1
     if [[ ! ${prompt,,} =~ ^(y|yes)$ ]]; then
       echo -e "${CROSS}${HOLD}${YWB}Exiting based on user input.${CL}"


### PR DESCRIPTION
## ✍️ Description

Fix #2190.
Use `echo -ne` here to print the message with colors and keep the cursor on the same line.

- - -
- Related Issue: #2190
- - - 


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [x] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [x] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [x] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

Test with my test branch:
```
bash -c "$(wget -qLO - https://github.com/PhoenixEmik/ProxmoxVE/raw/test/ct/forgejo.sh)"
```

![screenshot](https://github.com/user-attachments/assets/cfa476f8-c0c0-4129-9355-5f34aa5b498b)


