### PR TITLE
[core] Prevent double spinner

### DIFF
--- a/ct/create_lxc.sh
+++ b/ct/create_lxc.sh
@@ -64,6 +64,7 @@ function spinner() {
 
 # This function displays an informational message with a yellow color.
 function msg_info() {
+  if [ -n "$SPINNER_PID" ] && ps -p $SPINNER_PID > /dev/null; then kill $SPINNER_PID > /dev/null; fi
   local msg="$1"
   echo -ne "${TAB}${YW}${HOLD}${msg}${HOLD}"
   spinner &

--- a/misc/build.func
+++ b/misc/build.func
@@ -98,6 +98,7 @@ spinner() {
 
 # This function displays an informational message with a yellow color.
 msg_info() {
+  if [ -n "$SPINNER_PID" ] && ps -p $SPINNER_PID > /dev/null; then kill $SPINNER_PID > /dev/null; fi
   local msg="$1"
   echo -ne "${TAB}${YW}${HOLD}${msg}${HOLD}"
   spinner &

--- a/misc/install.func
+++ b/misc/install.func
@@ -90,6 +90,7 @@ spinner() {
 
 # This function displays an informational message with a yellow color.
 msg_info() {
+  if [ -n "$SPINNER_PID" ] && ps -p $SPINNER_PID > /dev/null; then kill $SPINNER_PID > /dev/null; fi
   local msg="$1"
   echo -ne "${TAB}${YW}${HOLD}${msg}${HOLD}"
   spinner &


### PR DESCRIPTION
## ✍️ Description

This update deletes a existing spinner if one exists befor creating a new one in msg_info. This way something like this is possible:

```bash
msg_info "Updating $APP to v${RELEASE}"
msg_info "Stopping Service"
systemctl stop service
msg_ok "Stopped Service"
#do stuff
msg_ok "Updated $APP to v${RELEASE}"
```


## ✅ Prerequisites
The following steps must be completed for the pull request to be considered:  
- [X] Self-review performed (I have reviewed my code to ensure it follows established patterns and conventions.)  
- [X] Testing performed (I have thoroughly tested my changes and verified expected functionality.)

## 🛠️ Type of Change
Please check the relevant options:  
- [] Bug fix (non-breaking change that resolves an issue)  
- [] New feature (non-breaking change that adds functionality)  
- [] Breaking change (fix or feature that would cause existing functionality to change unexpectedly)  
- [] New script (a fully functional and thoroughly tested script or set of scripts)  

---
## 📋 Additional Information (optional)
Provide any extra context or screenshots about the feature or fix here.  

