### PR TITLE
Quickfix: Crafty-Controller remove unnecessary \

### DIFF
--- a/install/crafty-controller-install.sh
+++ b/install/crafty-controller-install.sh
@@ -23,7 +23,7 @@ $STD apt-get install -y \
   lsb-release \
   apt-transport-https \
   coreutils \
-  software-properties-common \
+  software-properties-common
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up TermurinJDK"


### PR DESCRIPTION
## ✍️ Description  
remove unneeded backslash in install part 

--

## 🔗 Related PR / Discussion / Issue  
Link: #2232 

--

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

--

## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
