### PR TITLE
Fix: Apache Guacamole Version Crawling - only latest Version

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -41,7 +41,7 @@ $STD apt-get install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Setup Apache Tomcat"
-RELEASE=$(wget -qO- https://dlcdn.apache.org/tomcat/tomcat-9/ | grep -oP '(?<=href=")v[^"/]+(?=/")' | sed 's/^v//')
+RELEASE=$(wget -qO- https://dlcdn.apache.org/tomcat/tomcat-9/ | grep -oP '(?<=href=")v[^"/]+(?=/")' | sed 's/^v//' | sort -V | tail -n1)
 mkdir -p /opt/apache-guacamole/tomcat9
 mkdir -p /opt/apache-guacamole/server
 wget -qO- "https://dlcdn.apache.org/tomcat/tomcat-9/v${RELEASE}/bin/apache-tomcat-${RELEASE}.tar.gz" | tar -xz -C /opt/apache-guacamole/tomcat9 --strip-components=1


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  

Old:
RELEASE=$(wget -qO- https://dlcdn.apache.org/tomcat/tomcat-9/ | grep -oP '(?<=href=")v[^"/]+(?=/")' | sed 's/^v//')
echo $RELEASE -> 9.0.98 9.0.99

New:
RELEASE=$(wget -qO- https://dlcdn.apache.org/tomcat/tomcat-9/ | grep -oP '(?<=href=")v[^"/]+(?=/")' | sed 's/^v//' | sort -V | tail -n1)
echo $RELEASE -> 9.0.99

--

## 🔗 Related PR / Discussion / Issue  
Link: #2236

--

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

--

## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  