### PR TITLE
Paperless-AI: add dependency "make"

### DIFF
--- a/install/paperless-ai-install.sh
+++ b/install/paperless-ai-install.sh
@@ -17,7 +17,8 @@ $STD apt-get install -y \
 	curl \
 	sudo \
 	mc \
-	gpg
+	gpg \
+  make
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up Node.js Repository"


### PR DESCRIPTION
## ✍️ Description  

add make dependency because sometimes npm install failed

## 🔗 Related PR / Discussion / Issue  
Link: #2284



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  