### PR TITLE
Fix: duplicate 'VM' name in opnsense-vm.json

### DIFF
--- a/json/opnsense-vm.json
+++ b/json/opnsense-vm.json
@@ -1,5 +1,5 @@
 {
-  "name": "OPNsense-VM",
+  "name": "OPNsense",
   "slug": "opnsense-vm",
   "categories": [
     4


### PR DESCRIPTION
## ✍️ Description  
Fixes name showing as 'OPNsense-VM VM' in json.

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  

