### PR TITLE
Fix: Pingvin wrong variable used for version tracking

### DIFF
--- a/ct/pingvin.sh
+++ b/ct/pingvin.sh
@@ -34,7 +34,7 @@ function update_script() {
     fi
    
     RELEASE=$(curl -s https://api.github.com/repos/stonith404/pingvin-share/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-    if [[ ! -f /opt/$pingvin_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/pingvin_version.txt)" ]]; then
+    if [[ ! -f /opt/pingvin_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/pingvin_version.txt)" ]]; then
       
       msg_info "Stopping Pingvin Share"
       systemctl stop pm2-root.service


### PR DESCRIPTION
Fix Pingvin Share update, check for a file named pingvin_version, not a variable with the same name

## ✍️ Description  

See #2301 


## 🔗 Related PR / Discussion / Issue  
Link: #2301 



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
