### PR TITLE
Fix HomeAsisstant LXC: Use the latest versions of runlike with --use-volume-id

### DIFF
--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -48,6 +48,7 @@ function update_script() {
       docker pull "${CONTAINER_IMAGE}"
       LATEST_IMAGE="$(docker inspect --format "{{.Id}}" --type image "${CONTAINER_IMAGE}")"
       if [[ "${RUNNING_IMAGE}" != "${LATEST_IMAGE}" ]]; then
+        pip install -U runlike
         echo "Updating ${container} image ${CONTAINER_IMAGE}"
         DOCKER_COMMAND="$(runlike --use-volume-id "${container}")"
         docker rm --force "${container}"


### PR DESCRIPTION
## ✍️ Description  
I recently added the `--use-volume-id` option, but turns out this is a newer option from a couple months ago: https://github.com/lavie/runlike/pull/122.  

Anyone that installed before then will still have the older version that now throws an error.  There may be a better place to do this, additionally it could use a pinned version instead of always getting the latest.  For now this is a quick fix to get it up and running again.

## 🔗 Related PR / Discussion / Issue  
- https://github.com/community-scripts/ProxmoxVE/pull/2160
- https://github.com/community-scripts/ProxmoxVE/issues/2321



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
