### PR TITLE
Fix: Authentik Embedded Outpost Upgrade

### DIFF
--- a/ct/authentik.sh
+++ b/ct/authentik.sh
@@ -52,6 +52,13 @@ function update_script() {
     npm run build &>/dev/null
     msg_ok "Built ${APP} website"
 
+    msg_info "Building ${APP} server"
+    cd /opt/authentik
+    go mod download
+    go build -o /go/authentik ./cmd/server
+    go build -o /opt/authentik/authentik-server /opt/authentik/cmd/server/
+    msg_ok "Built ${APP} server"
+
     msg_info "Installing Python Dependencies"
     cd /opt/authentik
     poetry install --only=main --no-ansi --no-interaction --no-root &>/dev/null


### PR DESCRIPTION
## ✍️ Description  
Authentik contains an embedded proxy outpost bundled with the main server deployment. The CT update helper script failed to update this outpost, as it was missing a rebuild of the server during upgrade. This PR adds the server rebuild and resolves the issue.


## 🔗 Related PR / Discussion / Issue  
Link: #2037



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
If someone has already attempted to upgrade and encountered this issue, subsequent upgrades will fail as the script identifies the version of the application as up-to-date. Because this is true and there is no easy way to check for the embedded outpost version, I recommend anyone stuck in this limbo to:
- log into your Authentik CT console
- run the following command: `bash -c "$(wget -qLO - https://github.com/vidonnus/ProxmoxVE/raw/bugfix/2037-force-upgrade/ct/authentik.sh)"`