### PR TITLE
Fix script category name text alignment in ScriptAccordion

### DIFF
--- a/frontend/src/app/scripts/_components/ScriptAccordion.tsx
+++ b/frontend/src/app/scripts/_components/ScriptAccordion.tsx
@@ -72,7 +72,7 @@ export default function ScriptAccordion({
             )}
           >
             <div className="mr-2 flex w-full items-center justify-between">
-              <span className="pl-2">{category.name} </span>
+              <span className="pl-2 text-left">{category.name} </span>
               <span className="rounded-full bg-gray-200 px-2 py-1 text-xs text-muted-foreground hover:no-underline dark:bg-blue-800/20">
                 {category.scripts.length}
               </span>


### PR DESCRIPTION
## ✍️ Description  
This pull request includes a small change to the `ScriptAccordion` component in the `frontend/src/app/scripts/_components/ScriptAccordion.tsx` file. The change adds a `text-left` class to the category name span to ensure the text is left-aligned.

* [`frontend/src/app/scripts/_components/ScriptAccordion.tsx`](diffhunk://#diff-8737df428a29f2d126056300690f99402e331e7f03d3143bd6afdda418cf95b5L75-R75): Added `text-left` class to the category name span for left alignment. 


## 🔗 Related PR / Discussion / Issue  
Link: #

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
