### PR TITLE
Move VaultWarden service stop until after compilation to reduce downtime while updating

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -47,15 +47,17 @@ function update_script() {
     3>&1 1>&2 2>&3)
 
   if [ "$UPD" == "1" ]; then
-    msg_info "Stopping Vaultwarden"
-    systemctl stop vaultwarden.service
-    msg_ok "Stopped Vaultwarden"
 
     msg_info "Updating VaultWarden to $VAULT (Patience)"
     cd ~ && rm -rf vaultwarden
     git clone https://github.com/dani-garcia/vaultwarden &>/dev/null
     cd vaultwarden
     cargo build --features "sqlite,mysql,postgresql" --release &>/dev/null
+
+    msg_info "Stopping Vaultwarden"
+    systemctl stop vaultwarden.service
+    msg_ok "Stopped Vaultwarden"
+
     DIR=/usr/bin/vaultwarden
     if [ -d "$DIR" ]; then
       cp target/release/vaultwarden /usr/bin/


### PR DESCRIPTION
## ✍️ Description  
To minimize the downtime of the vaultwarden service, this change moves the service stop until after the new release is compiled and ready to be copied in place.


## 🔗 Related PR / Discussion / Issue  
Link: #

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  

For a quick characterization of downtime, on a container with recommended hardware requirements in proxmox running on a i5-6500 with disk backed by ceph, I observed that the `cargo build` step took 13m8.347s of wall/real time.