### PR TITLE
Setup cron in install/freshrss-install.sh

### DIFF
--- a/install/freshrss-install.sh
+++ b/install/freshrss-install.sh
@@ -50,6 +50,13 @@ chmod -R g+rX /opt/freshrss
 chmod -R g+w /opt/freshrss/data/
 msg_ok "Installed FreshRSS"
 
+msg_info "Setting up cron job for feed refresh"
+cat <<EOF >/etc/cron.d/freshrss-actualize
+*/15 * * * * www-data /bin/php -f /opt/freshrss/app/actualize_script.php > /tmp/FreshRSS.log 2>&1
+EOF
+chmod 644 /etc/cron.d/freshrss-actualize
+msg_ok "Set up Cron - if you need to modify the timing edit file /etc/cron.d/freshrss-actualize"
+
 msg_info "Creating Service"
 cat <<EOF >/etc/apache2/sites-available/freshrss.conf
 <VirtualHost *:80>

--- a/json/freshrss.json
+++ b/json/freshrss.json
@@ -34,6 +34,10 @@
     {
       "text": "Database credentials: `cat ~/freshrss.creds`",
       "type": "info"
+    },
+    {
+      "text": "Per FreshRSS documentation, a cron job to actualize FreshRSS will be setup at `/etc/cron.d/freshrss-actualize`. This can be adjusted as needed",
+      "type": "info"
     }
   ]
 }


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  

Existing script did not set up the required mechanism that facilitates automatic updating of feeds. 

As-is, updating feeds can only happen by manually clicking the actualize (refresh) button in the web UI. 

Per [FreshRSS Admin Documentation](https://freshrss.github.io/FreshRSS/en/admins/08_FeedUpdates.html), a cron job that executes <freshrss-path>/app/actualize_script.php needs to be setup to perform this. (The automatic refresh set with the `Do not automatically refresh more often than:` setting is dependent on the actualize_script.php being ran sometime before that to work) 

The [docker container I migrated from](https://github.com/linuxserver/docker-freshrss/blob/master/root/etc/crontabs/abc) sets their’s to run every 15 minutes, so once I configured that my feeds started auto-updating again. 

(Note, this does not mean all feeds will update every 15 minutes. They will still abide by their setting in FreshRSS, this just allows them to be refreshed up to every 15 minutes)


## 🔗 Related PR / Discussion / Issue  
Link: #

Didn’t make an issue, self discovered

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
