### PR TITLE
Update apt-cacher-ng-install.sh

### DIFF
--- a/install/apt-cacher-ng-install.sh
+++ b/install/apt-cacher-ng-install.sh
@@ -21,7 +21,7 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing Apt-Cacher NG"
 DEBIAN_FRONTEND=noninteractive $STD apt-get -o Dpkg::Options::="--force-confold" install -y apt-cacher-ng
-sed -i 's/# PassThroughPattern: .* # this would allow CONNECT to everything/PassThroughPattern: .*/' /etc/apt-cacher-ng/acng.conf
+sed -i 's/# PassThroughPattern: .* # this would allow CONNECT to everything/PassThroughPattern: ^(.*):443$/' /etc/apt-cacher-ng/acng.conf
 systemctl enable -q --now apt-cacher-ng
 msg_ok "Installed Apt-Cacher NG"
 


### PR DESCRIPTION
## ✍️ Description  

The current `PassThroughPattern: .*` does not work for me. I had to use `PassThroughPattern: ^(.*):443$`, found it [here](https://wiki.debian.org/AptCacherNg).

Please, someone double check if the current pattern works for anyone? I do get the following error messages when running `apt update` for `HTTPS` repos:
```
Err:11 https://pkgs.tailscale.com/stable/ubuntu focal InRelease
  Invalid response from proxy: HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)     [IP: 192.168.1.131 3142]
Err:12 https://nvidia.github.io/libnvidia-container/stable/ubuntu18.04/amd64  InRelease
  Invalid response from proxy: HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)     [IP: 192.168.1.131 3142]
Err:16 https://deb.nodesource.com/node_16.x focal InRelease
  Invalid response from proxy: HTTP/1.0 403 CONNECT denied (ask the admin to allow HTTPS tunnels)     [IP: 192.168.1.131 3142]
```

## 🔗 Related PR / Discussion / Issue  
Link: #



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
