### PR TITLE
Fix: PATH env and file handling in Watcharr Update Script

### DIFF
--- a/ct/watcharr.sh
+++ b/ct/watcharr.sh
@@ -43,7 +43,7 @@ function update_script() {
         rm -rf /opt/watcharr/server/ui
         mv Watcharr-${RELEASE}/ /opt/watcharr
         cd /opt/watcharr
-        export GOOS=linux
+        export GOOS=linux PATH="/usr/local/bin:$PATH"
         npm i &> /dev/null
         npm run build &> /dev/null
         mv ./build ./server/ui

--- a/ct/watcharr.sh
+++ b/ct/watcharr.sh
@@ -37,11 +37,12 @@ function update_script() {
 
         msg_info "Updating $APP to v${RELEASE}"
         temp_file=$(mktemp)
+        temp_folder=$(mktemp -d)
         wget -q "https://github.com/sbondCo/Watcharr/archive/refs/tags/v${RELEASE}.tar.gz" -O "$temp_file"
-        tar -xzf "$temp_file"
+        tar -xzf "$temp_file" -C "$temp_folder"
         rm -f /opt/watcharr/server/watcharr
         rm -rf /opt/watcharr/server/ui
-        mv Watcharr-${RELEASE}/ /opt/watcharr
+        cp -rf ${temp_folder}/Watcharr-${RELEASE}/* /opt/watcharr
         cd /opt/watcharr
         export GOOS=linux PATH="/usr/local/bin:$PATH"
         npm i &> /dev/null
@@ -58,6 +59,7 @@ function update_script() {
 
         msg_info "Cleaning Up"
         rm -f ${temp_file}
+        rm -rf ${temp_folder}
         msg_ok "Cleanup Completed"
 
         echo "${RELEASE}" >/opt/${APP}_version.txt


### PR DESCRIPTION
## ✍️ Description  
I've found and fixed two small bugs inside the Watcharr update function.

1. golang binary was in /urs/local/bin, which wasn't present in PATH environment -> see #2478
2. command to replace new files over old files did not work


## 🔗 Related PR / Discussion / Issue  
Fixes #2478



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
![Screenshot 2025-02-18 200205](https://github.com/user-attachments/assets/0d26b776-f952-4996-b7b9-2765f54bedd8)
