### PR TITLE
Fix: file replacement in Watcharr Update Script

### DIFF
--- a/ct/watcharr.sh
+++ b/ct/watcharr.sh
@@ -37,11 +37,12 @@ function update_script() {
 
         msg_info "Updating $APP to v${RELEASE}"
         temp_file=$(mktemp)
+        temp_folder=$(mktemp -d)
         wget -q "https://github.com/sbondCo/Watcharr/archive/refs/tags/v${RELEASE}.tar.gz" -O "$temp_file"
-        tar -xzf "$temp_file"
+        tar -xzf "$temp_file" -C "$temp_folder"
         rm -f /opt/watcharr/server/watcharr
         rm -rf /opt/watcharr/server/ui
-        mv Watcharr-${RELEASE}/ /opt/watcharr
+        cp -rf ${temp_folder}/Watcharr-${RELEASE}/* /opt/watcharr
         cd /opt/watcharr
         export GOOS=linux
         npm i &> /dev/null
@@ -58,6 +59,7 @@ function update_script() {
 
         msg_info "Cleaning Up"
         rm -f ${temp_file}
+        rm -rf ${temp_folder}
         msg_ok "Cleanup Completed"
 
         echo "${RELEASE}" >/opt/${APP}_version.txt


### PR DESCRIPTION
## ✍️ Description  
Fixes following: Updated files are moved into a subdirectory instead of replacing old files. The script won't report an error and set the new version, but Watcharr will stay on the old state.


## 🔗 Related PR / Discussion / Issue  
Fixes: #2497



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  

