### PR TITLE
Fix: Wireguard - Restart wgdashboard automatically after update

### DIFF
--- a/ct/wireguard.sh
+++ b/ct/wireguard.sh
@@ -32,6 +32,7 @@ function update_script() {
     sleep 2
     cd /etc/wgdashboard/src
     ./wgd.sh update
+    ./wgd.sh start
     exit
 }
 


### PR DESCRIPTION
Fix: Restart wgdashboard automatically after update

## ✍️ Description  
After updating, wgdashboard was not starting automatically due to a missing `./wgd.sh start`. This fix ensures that the service is correctly restarted after an update.


## 🔗 Related PR / Discussion / Issue  
Link: #



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
