### PR TITLE
Fix Docmost: default upload size and saving data when updating

### DIFF
--- a/ct/docmost.sh
+++ b/ct/docmost.sh
@@ -34,6 +34,7 @@ function update_script() {
 
     msg_info "Updating ${APP} to v${RELEASE}"
     cp /opt/docmost/.env /opt/
+    cp -r /opt/docmost/data /opt/
     rm -rf /opt/docmost
     temp_file=$(mktemp)
     wget -q "https://github.com/docmost/docmost/archive/refs/tags/v${RELEASE}.tar.gz" -O "$temp_file"
@@ -41,6 +42,7 @@ function update_script() {
     mv docmost-${RELEASE} /opt/docmost
     cd /opt/docmost
     mv /opt/.env /opt/docmost/.env
+    mv /opt/data /opt/docmost/data
     $STD pnpm install --force
     $STD pnpm build
     echo "${RELEASE}" >/opt/${APP}_version.txt

--- a/install/docmost-install.sh
+++ b/install/docmost-install.sh
@@ -61,8 +61,11 @@ tar -xzf "$temp_file"
 mv docmost-${RELEASE} /opt/docmost
 cd /opt/docmost
 mv .env.example .env
-sed -i "s|APP_SECRET=.*|APP_SECRET=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-32)|" /opt/docmost/.env
-sed -i "s|DATABASE_URL=.*|DATABASE_URL=postgres://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME|" /opt/docmost/.env
+mkdir data
+sed -i -e "s|APP_SECRET=.*|APP_SECRET=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-32)|" \
+       -e "s|DATABASE_URL=.*|DATABASE_URL=postgres://$DB_USER:$DB_PASS@localhost:5432/$DB_NAME|" \
+       -e "s|FILE_UPLOAD_SIZE_LIMIT=.*|FILE_UPLOAD_SIZE_LIMIT=50mb|" \
+       /opt/docmost/.env
 export NODE_OPTIONS="--max-old-space-size=2048"
 $STD pnpm install
 $STD pnpm build


### PR DESCRIPTION
## ✍️ Description  
This fixes:

- Default upload size set to default 50mb
- Backups uploaded data in update script

## 🔗 Related PR / Discussion / Issue  
https://github.com/community-scripts/ProxmoxVE/issues/2580
https://github.com/community-scripts/ProxmoxVE/discussions/2559

## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [] ✨ **New feature** – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [] 🆕 **New script** – A fully functional and tested script or script set.  


## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
