### PR TITLE
Alpine IT-Tools fix typo "unexpected EOF while looking for matching `"'

### DIFF
--- a/ct/alpine-it-tools.sh
+++ b/ct/alpine-it-tools.sh
@@ -30,7 +30,7 @@ if [ ! -d /usr/share/nginx/html ]; then
 fi
 
 RELEASE=$(curl -s https://api.github.com/repos/CorentinTh/it-tools/releases/latest | grep '"tag_name":' | cut -d '"' -f4)
-if [ "${RELEASE}" != "$(cat /opt/${APP}_version.txt" ] || [ ! -f /opt/${APP}_version.txt ]; then
+if [ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ] || [ ! -f /opt/${APP}_version.txt ]; then
     DOWNLOAD_URL="https://github.com/CorentinTh/it-tools/releases/download/${RELEASE}/it-tools-${RELEASE#v}.zip"
     msg_info "Updating ${APP} LXC"
     curl -fsSL -o it-tools.zip "$DOWNLOAD_URL"


### PR DESCRIPTION
## ✍️ Description  
Fix: unexpected EOF while looking for matching `"'


## 🔗 Related PR / Discussion / Issue  
Link: #2642



## ✅ Prerequisites  
Before this PR can be reviewed, the following must be completed:  
- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  


## 🛠️ Type of Change  
Select all that apply:  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  