### PR TITLE
Fix: Homarr - Manually correct db-migration wrong-folder

### DIFF
--- a/ct/homarr.sh
+++ b/ct/homarr.sh
@@ -49,6 +49,11 @@ set +a
 export DB_DIALECT='sqlite'
 export AUTH_SECRET=$(openssl rand -base64 32)
 node /opt/homarr_db/migrations/$DB_DIALECT/migrate.cjs /opt/homarr_db/migrations/$DB_DIALECT
+for dir in $(find /opt/homarr_db/migrations/migrations -mindepth 1 -maxdepth 1 -type d); do
+  dirname=$(basename "$dir")
+  mkdir -p "/opt/homarr_db/migrations/$dirname"
+  cp -r "$dir"/* "/opt/homarr_db/migrations/$dirname/" 2>/dev/null || true
+done
 export HOSTNAME=$(ip route get 1.1.1.1 | grep -oP 'src \K[^ ]+')
 envsubst '${HOSTNAME}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
 nginx -g 'daemon off;' &
@@ -97,6 +102,11 @@ set +a
 export DB_DIALECT='sqlite'
 export AUTH_SECRET=$(openssl rand -base64 32)
 node /opt/homarr_db/migrations/$DB_DIALECT/migrate.cjs /opt/homarr_db/migrations/$DB_DIALECT
+for dir in $(find /opt/homarr_db/migrations/migrations -mindepth 1 -maxdepth 1 -type d); do
+  dirname=$(basename "$dir")
+  mkdir -p "/opt/homarr_db/migrations/$dirname"
+  cp -r "$dir"/* "/opt/homarr_db/migrations/$dirname/" 2>/dev/null || true
+done
 export HOSTNAME=$(ip route get 1.1.1.1 | grep -oP 'src \K[^ ]+')
 envsubst '${HOSTNAME}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
 nginx -g 'daemon off;' &

--- a/install/homarr-install.sh
+++ b/install/homarr-install.sh
@@ -92,6 +92,11 @@ set +a
 export DB_DIALECT='sqlite'
 export AUTH_SECRET=$(openssl rand -base64 32)
 node /opt/homarr_db/migrations/$DB_DIALECT/migrate.cjs /opt/homarr_db/migrations/$DB_DIALECT
+for dir in $(find /opt/homarr_db/migrations/migrations -mindepth 1 -maxdepth 1 -type d); do
+  dirname=$(basename "$dir")
+  mkdir -p "/opt/homarr_db/migrations/$dirname"
+  cp -r "$dir"/* "/opt/homarr_db/migrations/$dirname/" 2>/dev/null || true
+done
 export HOSTNAME=$(ip route get 1.1.1.1 | grep -oP 'src \K[^ ]+')
 envsubst '${HOSTNAME}' < /etc/nginx/templates/nginx.conf > /etc/nginx/nginx.conf
 nginx -g 'daemon off;' &


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  
Out of any weird reason, homarr outputs the migration into a seperate subolder /migration, which then ends up with /opt/homarr_db/migration/migration instead of /opt/homarr_db/migration a sinple cp with recursive did not work, unless manually executed. 

Will talk to homarr-devs and inform them about this bug in the migration.

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
