### PR TITLE
Zitadel-install.sh: Remove one version file and update to our standard

### DIFF
--- a/install/zitadel-install.sh
+++ b/install/zitadel-install.sh
@@ -46,7 +46,6 @@ msg_info "Installing Zitadel"
 RELEASE=$(curl -si https://github.com/zitadel/zitadel/releases/latest | grep location: | cut -d '/' -f 8 | tr -d '\r')
 wget -qc https://github.com/zitadel/zitadel/releases/download/$RELEASE/zitadel-linux-amd64.tar.gz -O - | tar -xz
 mv zitadel-linux-amd64/zitadel /usr/local/bin
-echo "${RELEASE}" >"/opt/zitadel_version.txt"
 msg_ok "Installed Zitadel"
 
 msg_info "Setting up Zitadel Environments"
@@ -126,7 +125,7 @@ zitadel start-from-init --masterkeyFile /opt/zitadel/.masterkey --config /opt/zi
 sleep 60
 kill $(lsof -i | awk '/zitadel/ {print $2}' | head -n1)
 useradd zitadel
-echo -e "$(zitadel -v | grep -oP 'v\d+\.\d+\.\d+')" > /opt/Zitadel_version.txt
+echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Zitadel initialized"
 
 msg_info "Set ExternalDomain to current IP and restart Zitadel"


### PR DESCRIPTION
## ✍️ Description  
The current Zitadel script generates two version files: /opt/Zitadel_version.txt and /opt/zitadel_version.txt. This PR addresses that issue and ensures the file creation process aligns with our standards.

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
![image](https://github.com/user-attachments/assets/a1237f23-ae2b-4c95-ae53-46a83ee8df6f)
