### PR TITLE
Use HTML button element for copying to clipboard

### DIFF
--- a/frontend/src/components/ui/code-copy-button.tsx
+++ b/frontend/src/components/ui/code-copy-button.tsx
@@ -37,10 +37,6 @@ export default function CodeCopyButton({
         );
       }, 500);
     }
-
-    // toast.success(`copied ${type} to clipboard`, {
-    //   icon: <ClipboardCheck className="h-4 w-4" />,
-    // });
   };
 
   return (
@@ -49,17 +45,17 @@ export default function CodeCopyButton({
         <div className="overflow-x-auto whitespace-pre-wrap text-nowrap break-all pr-4 text-sm">
           {!isMobile && children ? children : "Copy install command"}
         </div>
-        <div
-          className={cn(" right-0 cursor-pointer bg-muted px-3 py-4")}
+        <button
           onClick={() => handleCopy("install command", children)}
+          className={cn("bg-muted px-3 py-4")}
+          title="Copy"
         >
           {hasCopied ? (
             <CheckIcon className="h-4 w-4" />
           ) : (
             <ClipboardIcon className="h-4 w-4" />
           )}
-          <span className="sr-only">Copy</span>
-        </div>
+        </button>
       </Card>
     </div>
   );


### PR DESCRIPTION
## ✍️ Description  

It's much more semantic to use the `<button />` HTML component rather than trying to build the same functionality out of a `<div />` so that's what is updated here.

This also updates some of the classes that were on the button as they're no longer required and removes some commented out code that doesn't need to be left around.

There was also a `<span />` with the contents "Copy" that I couldn't work out when it was meant to be displayed, so I swapped that over to an HTML tooltip on the `<button />`.

Note, I didn't create a ticket for this initially as I just discovered it when I was going through the site and couldn't copy to clipboard using Vimium (it couldn't find the button).

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Manual QA has been done 

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [X] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  
