### PR TITLE
EOF not detected

### DIFF
--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -14,6 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
+export DEBIAN_FRONTEND=noninteractive
 $STD apt-get -y install --no-install-recommends \
   curl \
   sudo \

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -108,7 +108,7 @@ $STD yarn build --production
 msg_ok "Built Web-Check"
 
 msg_info "Creating Service"
-cat <<EOF > /opt/run_web-check.sh
+cat > /opt/run_web-check.sh << 'EOF'
 #!/bin/bash
 SCREEN_RESOLUTION="1280x1024x24"
 if ! systemctl is-active --quiet dbus; then
@@ -122,7 +122,7 @@ cd /opt/web-check
 exec yarn start
 EOF
 chmod +x /opt/run_web-check.sh
-cat <<EOF > /etc/systemd/system/web-check.service
+cat > /etc/systemd/system/web-check.service << 'EOF' 
 [Unit]
 Description=Web Check Service
 After=network.target

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -77,7 +77,7 @@ wget -q "https://github.com/CrazyWolf13/web-check/archive/refs/heads/${RELEASE}.
 tar xzf $temp_file
 mv web-check-${RELEASE} /opt/web-check
 cd /opt/web-check
-cat <<EOF > /opt/web-check/.env
+cat <<'EOF' > /opt/web-check/.env
 CHROME_PATH=/usr/bin/chromium
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 HEADLESS=true
@@ -108,7 +108,7 @@ $STD yarn build --production
 msg_ok "Built Web-Check"
 
 msg_info "Creating Service"
-cat > /opt/run_web-check.sh << 'EOF'
+cat <<'EOF' > /opt/run_web-check.sh
 #!/bin/bash
 SCREEN_RESOLUTION="1280x1024x24"
 if ! systemctl is-active --quiet dbus; then
@@ -122,7 +122,7 @@ cd /opt/web-check
 exec yarn start
 EOF
 chmod +x /opt/run_web-check.sh
-cat > /etc/systemd/system/web-check.service << 'EOF' 
+cat <<'EOF' > /etc/systemd/system/web-check.service
 [Unit]
 Description=Web Check Service
 After=network.target

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -78,7 +78,7 @@ wget -q "https://github.com/CrazyWolf13/web-check/archive/refs/heads/${RELEASE}.
 tar xzf $temp_file
 mv web-check-${RELEASE} /opt/web-check
 cd /opt/web-check
-cat <<EOF > /opt/web-check/.env
+cat <<'EOF' > /opt/web-check/.env
 CHROME_PATH=/usr/bin/chromium
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 HEADLESS=true
@@ -109,21 +109,21 @@ $STD yarn build --production
 msg_ok "Built Web-Check"
 
 msg_info "Creating Service"
-cat <<EOF > /opt/run_web-check.sh
+cat <<'EOF' > /opt/run_web-check.sh
 #!/bin/bash
 SCREEN_RESOLUTION="1280x1024x24"
 if ! systemctl is-active --quiet dbus; then
   echo "Warning: dbus service is not running. Some features may not work properly."
 fi
-[[ -z "\${DISPLAY}" ]] && export DISPLAY=":99"
-Xvfb "\${DISPLAY}" -screen 0 "\${SCREEN_RESOLUTION}" &
+[[ -z "${DISPLAY}" ]] && export DISPLAY=":99"
+Xvfb "${DISPLAY}" -screen 0 "${SCREEN_RESOLUTION}" &
 XVFB_PID=$!
 sleep 2
 cd /opt/web-check
 exec yarn start
 EOF
 chmod +x /opt/run_web-check.sh
-cat <<EOF > /etc/systemd/system/web-check.service
+cat <<'EOF' > /etc/systemd/system/web-check.service
 [Unit]
 Description=Web Check Service
 After=network.target

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -78,7 +78,7 @@ wget -q "https://github.com/CrazyWolf13/web-check/archive/refs/heads/${RELEASE}.
 tar xzf $temp_file
 mv web-check-${RELEASE} /opt/web-check
 cd /opt/web-check
-cat <<'EOF' > /opt/web-check/.env
+cat <<EOF > /opt/web-check/.env
 CHROME_PATH=/usr/bin/chromium
 PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 HEADLESS=true
@@ -109,21 +109,21 @@ $STD yarn build --production
 msg_ok "Built Web-Check"
 
 msg_info "Creating Service"
-cat <<'EOF' > /opt/run_web-check.sh
+cat <<EOF > /opt/run_web-check.sh
 #!/bin/bash
 SCREEN_RESOLUTION="1280x1024x24"
 if ! systemctl is-active --quiet dbus; then
   echo "Warning: dbus service is not running. Some features may not work properly."
 fi
-[[ -z "${DISPLAY}" ]] && export DISPLAY=":99"
-Xvfb "${DISPLAY}" -screen 0 "${SCREEN_RESOLUTION}" &
+[[ -z "\${DISPLAY}" ]] && export DISPLAY=":99"
+Xvfb "\${DISPLAY}" -screen 0 "${SCREEN_RESOLUTION}" &
 XVFB_PID=$!
 sleep 2
 cd /opt/web-check
 exec yarn start
 EOF
 chmod +x /opt/run_web-check.sh
-cat <<'EOF' > /etc/systemd/system/web-check.service
+cat <<EOF > /etc/systemd/system/web-check.service
 [Unit]
 Description=Web Check Service
 After=network.target

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -116,7 +116,7 @@ if ! systemctl is-active --quiet dbus; then
   echo "Warning: dbus service is not running. Some features may not work properly."
 fi
 [[ -z "\${DISPLAY}" ]] && export DISPLAY=":99"
-Xvfb "\${DISPLAY}" -screen 0 "${SCREEN_RESOLUTION}" &
+Xvfb "\${DISPLAY}" -screen 0 "\${SCREEN_RESOLUTION}" &
 XVFB_PID=$!
 sleep 2
 cd /opt/web-check


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  
@tremor021 Suggested to change 
`cat > /opt/run_web-check.sh << 'EOF'`
to
`cat <<EOF >/opt/run_web-check.sh`
at https://github.com/community-scripts/ProxmoxVE/pull/2662#discussion_r1971967983

Though this breaks the script.

## 🔗 Related PR / Discussion / Issue  

Link: #2662

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
