### PR TITLE
Fix gpg Repo for nzbget

### DIFF
--- a/install/nzbget-install.sh
+++ b/install/nzbget-install.sh
@@ -31,7 +31,7 @@ msg_ok "Installed Dependencies"
 msg_info "Installing NZBGet"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://nzbgetcom.github.io/nzbgetcom.asc | gpg --dearmor -o /etc/apt/keyrings/nzbgetcom.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nzbgetcom.gpg] https://nzbgetcom.github.io/deb stable main" >/etc/apt/sources.list.d/nzbgetcom.list
+echo "deb [arch=all signed-by=/etc/apt/keyrings/nzbgetcom.asc] https://nzbgetcom.github.io/deb stable main" >/etc/apt/sources.list.d/nzbgetcom.list
 $STD apt-get update
 $STD apt-get install -y nzbget
 msg_ok "Installed NZBGet"

--- a/install/nzbget-install.sh
+++ b/install/nzbget-install.sh
@@ -31,7 +31,7 @@ msg_ok "Installed Dependencies"
 msg_info "Installing NZBGet"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://nzbgetcom.github.io/nzbgetcom.asc | gpg --dearmor -o /etc/apt/keyrings/nzbgetcom.gpg
-echo "deb [arch=all signed-by=/etc/apt/keyrings/nzbgetcom.asc] https://nzbgetcom.github.io/deb stable main" >/etc/apt/sources.list.d/nzbgetcom.list
+echo "deb [arch=all signed-by=/etc/apt/keyrings/nzbgetcom.gpg] https://nzbgetcom.github.io/deb stable main" >/etc/apt/sources.list.d/nzbgetcom.list
 $STD apt-get update
 $STD apt-get install -y nzbget
 msg_ok "Installed NZBGet"


### PR DESCRIPTION
Added [arch=all] to the nzbget repo line to fix apt update errors.

## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  

## 🔗 Related PR / Discussion / Issue  

Link: #2773

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
With the updated line, the error while running `apt update` goes away:
```
root@nzbget:/etc/apt/sources.list.d# cat nzbgetcom.list 
deb [arch=all signed-by=/etc/apt/keyrings/nzbgetcom.gpg] https://nzbgetcom.github.io/deb stable main
root@nzbget:/etc/apt/sources.list.d# apt update
Hit:1 http://deb.debian.org/debian bookworm InRelease
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]       
Hit:3 http://security.debian.org bookworm-security InRelease                  
Hit:4 https://nzbgetcom.github.io/deb stable InRelease                        
Fetched 55.4 kB in 8s (7,323 B/s)                                                                                                  
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
root@nzbget:/etc/apt/sources.list.d# 
```
