### PR TITLE
Update zigbee2mqtt.json - make sure link is clickable

### DIFF
--- a/json/zigbee2mqtt.json
+++ b/json/zigbee2mqtt.json
@@ -43,7 +43,7 @@
     },
     "notes": [
         {
-            "text": "You can find the post-install guide here: https://github.com/community-scripts/ProxmoxVE/discussions/410",
+            "text": "You can find the post-install guide here: `https://github.com/community-scripts/ProxmoxVE/discussions/410`",
             "type": "info"
         }
     ]


### PR DESCRIPTION
## ✍️ Description  
I noticed that the link for post-install info is not clickable, this should fix that

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
