### PR TITLE
Beszel: restarting service after update

### DIFF
--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -28,7 +28,9 @@ function update_script() {
         exit
     fi
     /opt/beszel/beszel update
+    msg_info "Stopping Service from $APP"
     systemctl start beszel.service
+    msg_ok "Successfully started the $APP service."
     exit
 }
 

--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -28,11 +28,13 @@ function update_script() {
         exit
     fi
     msg_info "Stopping $APP"
-    systemctl stop beszel-hub.service
+    systemctl stop beszel-hub
     msg_ok "Stopped $APP"
+    
     msg_info "Updating $APP"
-    /opt/beszel/beszel update
+    $STD /opt/beszel/beszel update
     msg_ok "Updated $APP"
+    
     msg_info "Starting $APP"
     systemctl start beszel-hub.service
     msg_ok "Successfully started $APP"

--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -27,12 +27,16 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
-    /opt/beszel/beszel update
-    msg_info "Stopping Service from $APP"
+    msg_info "Stopping $APP"
     systemctl stop beszel-hub.service
-    msg_info "Starting Service from $APP"
+    msg_ok "Stopped $APP"
+    msg_info "Updating $APP"
+    /opt/beszel/beszel update
+    msg_ok "Updated $APP"
+    msg_info "Starting $APP"
     systemctl start beszel-hub.service
-    msg_ok "Successfully started the $APP service."
+    msg_ok "Successfully started $APP"
+    msg_ok "Update Successful"
     exit
 }
 

--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -29,7 +29,9 @@ function update_script() {
     fi
     /opt/beszel/beszel update
     msg_info "Stopping Service from $APP"
-    systemctl start beszel.service
+    systemctl stop beszel-hub.service
+    msg_info "Starting Service from $APP"
+    systemctl start beszel-hub.service
     msg_ok "Successfully started the $APP service."
     exit
 }

--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -28,7 +28,7 @@ function update_script() {
         exit
     fi
     /opt/beszel/beszel update
-    msg_error "Currently we don't provide an update function for this ${APP}."
+    systemctl start beszel.service
     exit
 }
 

--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -36,7 +36,7 @@ function update_script() {
     msg_ok "Updated $APP"
     
     msg_info "Starting $APP"
-    systemctl start beszel-hub.service
+    systemctl start beszel-hub
     msg_ok "Successfully started $APP"
     msg_ok "Update Successful"
     exit


### PR DESCRIPTION


## ✍️ Description  
Added systemctl command to start beszel.service. This ensures the new version is applied immediately; otherwise, the old version remains in operation until the next restart
