### PR TITLE
Fix wikijs update issue while backing up data

### DIFF
--- a/ct/wikijs.sh
+++ b/ct/wikijs.sh
@@ -32,8 +32,11 @@ function update_script() {
     msg_ok "Stopped ${APP}"
 
     msg_info "Backing up Data"
+    rm -rf ~/data-backup
     mkdir -p ~/data-backup
-    cp -R /opt/wikijs/{db.sqlite,config.yml,/data} ~/data-backup
+    [ -f /opt/wikijs/db.sqlite ] && cp /opt/wikijs/db.sqlite ~/data-backup
+    [ -f /opt/wikijs/config.yml ] && cp /opt/wikijs/config.yml ~/data-backup
+    [ -d /opt/wikijs/data ] && cp -R /opt/wikijs/data ~/data-backup
     msg_ok "Backed up Data"
 
     msg_info "Updating ${APP}"


### PR DESCRIPTION
## ✍️ Description  
Wikijs update script fails when `db.sqlite` file does not exist

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
