### PR TITLE
Pi-hole interface port in documentation

### DIFF
--- a/json/pihole.json
+++ b/json/pihole.json
@@ -8,7 +8,7 @@
     "type": "ct",
     "updateable": true,
     "privileged": false,
-    "interface_port": 81,
+    "interface_port": 80,
     "documentation": "https://docs.pi-hole.net/",
     "website": "https://pi-hole.net/",
     "logo": "https://raw.githubusercontent.com/selfhst/icons/refs/heads/main/svg/pi-hole.svg",


### PR DESCRIPTION
## ✍️ Description  
Admin Port is 80 not 81, install summary in script already shows the correct url.  

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  