### PR TITLE
pihole: fix path when accessing pihole using `pct enter`

### DIFF
--- a/ct/pihole.sh
+++ b/ct/pihole.sh
@@ -29,7 +29,7 @@ function update_script() {
     fi
     msg_info "Updating ${APP}"
     set +e
-    pihole -up
+    /usr/local/bin/pihole -up
     msg_ok "Updated ${APP}"
     exit
 }


### PR DESCRIPTION
## ✍️ Description  
<!-- Provide a clear and concise description of your changes. -->  
This PR fixes an issue, where pihole command is not available when using `pct enter`.


## 🔗 Related PR / Discussion / Issue  

Link: #2916

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
