### PR TITLE
Fix Website - Show correct wget path for alpine

### DIFF
--- a/json/alpine-it-tools.json
+++ b/json/alpine-it-tools.json
@@ -15,7 +15,7 @@
   "description": "IT-Tools is a web-based suite of utilities designed to streamline and simplify various IT tasks, providing tools for developers and system administrators to manage their workflows efficiently.",
   "install_methods": [
       {
-          "type": "default",
+          "type": "alpine",
           "script": "ct/alpine-it-tools.sh",
           "resources": {
               "cpu": 1,

--- a/json/alpine.json
+++ b/json/alpine.json
@@ -15,7 +15,7 @@
     "description": "A security-oriented, lightweight Linux distribution based on musl and BusyBox.\r\nBy default, the root password is set to alpine. If you choose to use advanced settings, you will need to define a password, autologin is currently unavailable.",
     "install_methods": [
         {
-            "type": "default",
+            "type": "alpine",
             "script": "ct/alpine.sh",
             "resources": {
                 "cpu": 1,


### PR DESCRIPTION
## ✍️ Description  
Show correct bash path for alpine scripts

### Example
**Wrong:**
```bash
bash -c "$(wget -qLO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/alpine.sh)"
```

**Correct:**
```bash
bash -c "$(wget -qO - https://github.com/community-scripts/ProxmoxVE/raw/main/ct/alpine.sh)"
```


## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
