### PR TITLE
Headscale: Re-enable Service after Update

### DIFF
--- a/ct/headscale.sh
+++ b/ct/headscale.sh
@@ -41,7 +41,7 @@ function update_script() {
     msg_ok "Updated $APP to ${RELEASE}"
 
     msg_info "Starting ${APP}"
-    systemctl start headscale
+    systemctl enable --now headscale
     msg_ok "Started ${APP}"
     msg_ok "Updated Successfully"
   else

--- a/ct/headscale.sh
+++ b/ct/headscale.sh
@@ -42,8 +42,7 @@ function update_script() {
 
     msg_info "Starting ${APP}"
     # Temporary fix until headscale project resolves service getting disabled on updates.
-    systemctl -q enable headscale
-    systemctl start headscale
+    systemctl enable -q --now headscale
     msg_ok "Started ${APP}"
     msg_ok "Updated Successfully"
   else

--- a/ct/headscale.sh
+++ b/ct/headscale.sh
@@ -41,7 +41,9 @@ function update_script() {
     msg_ok "Updated $APP to ${RELEASE}"
 
     msg_info "Starting ${APP}"
-    systemctl enable --now headscale
+    # Temporary fix until headscale project resolves service getting disabled on updates.
+    systemctl -q enable headscale
+    systemctl start headscale
     msg_ok "Started ${APP}"
     msg_ok "Updated Successfully"
   else


### PR DESCRIPTION
## ✍️ Description  
Change service to enable --now after updating since the source package disables the service when updating...

See Issue:
https://github.com/juanfont/headscale/issues/2311

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

