### PR TITLE
Update Fluid Calendar for v1.2.0

### DIFF
--- a/ct/fluid-calendar.sh
+++ b/ct/fluid-calendar.sh
@@ -46,8 +46,10 @@ function update_script() {
         cp -rf ${APP}-${RELEASE}/* /opt/fluid-calendar
         cd /opt/fluid-calendar
         export NEXT_TELEMETRY_DISABLED=1
-        $STD npm run setup
-        $STD npm run build
+        $STD npm install --legacy-peer-deps
+        $STD npm run prisma:generate
+        $STD npm run prisma:migrate
+        $STD npm run build:os
         msg_ok "Updated $APP to v${RELEASE}"
 
         msg_info "Starting $APP"

--- a/install/fluid-calendar-install.sh
+++ b/install/fluid-calendar-install.sh
@@ -59,30 +59,23 @@ echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 cat <<EOF >/opt/fluid-calendar/.env
 DATABASE_URL="postgresql://${DB_USER}:${DB_PASS}@localhost:5432/${DB_NAME}"
 
-# For OAuth integration with Google Calendar
-# See https://console.cloud.google.com
-GOOGLE_CLIENT_ID=""
-GOOGLE_CLIENT_SECRET=""
-
 # Change the URL below to your external URL
 NEXTAUTH_URL="http://localhost:3000"
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
 NEXTAUTH_SECRET="${NEXTAUTH_SECRET}"
+NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 
-# For optional Outlook Calendar Integration
-# Create at https://portal.azure.com
-AZURE_AD_CLIENT_ID=""
-AZURE_AD_CLIENT_SECRET=""
-AZURE_AD_TENANT_ID=""
+NEXT_PUBLIC_ENABLE_SAAS_FEATURES=false
 
-# Logging configuration
-# Options: debug, none (check logger.js for more details)
-LOG_LEVEL="none"
-DEBUG_ENABLED=0
+RESEND_API_KEY=
+RESEND_EMAIL=
 EOF
 export NEXT_TELEMETRY_DISABLED=1
 cd /opt/fluid-calendar
-$STD npm run setup
-$STD npm run build
+$STD npm install --legacy-peer-deps
+$STD npm run prisma:generate
+$STD npm run prisma:migrate
+$STD npm run build:os
 msg_ok "Setup ${APPLICATION}"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## ✍️ Description  
This commit breaks up the `npm` commands due to some breaking changes. It also modifies the `.env` file to remove deprecated options and adds new ones.

## 🔗 Related PR / Discussion / Issue  

Link: Discussion #3047 

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [x] **Self-review performed** – Code follows established patterns and conventions.  
- [x] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
There are quite a lot of changes in this update. In the `.env` file you need to add the IP address of the LXC in three parts. And then upon navigating to the page, it looks like something may be off, but it's kind of a weird landing page? Click on "sign in" and you'll create your admin account, then you'll likely be returned to the landing page.
![image](https://github.com/user-attachments/assets/b5f4cb96-047d-4952-8250-3b30271f71b0)

You can either click 'Sign in' again or scroll down and click on 'Sign in to your instance' at the bottom and then it should actually take you to your calendar. Once signed in, when you open your URL it will go straight to the calendar.

Also, in `fluid-calendar.sh` I did not add anything to modify/replace the existing `.env` file, if someone had happened to install v1.1.0 since yesterday. I suggest they just nuke the container and reinstall.
