### PR TITLE
Filebrowser: Fix hardcoded port in Debian service file

### DIFF
--- a/misc/filebrowser.sh
+++ b/misc/filebrowser.sh
@@ -150,8 +150,8 @@ After=network-online.target
 User=root
 WorkingDirectory=/usr/local/community-scripts
 ExecStartPre=/bin/touch /usr/local/community-scripts/filebrowser.db
-ExecStartPre=/usr/local/bin/filebrowser config set -a "0.0.0.0" -p 9000 -d /usr/local/community-scripts/filebrowser.db
-ExecStart=/usr/local/bin/filebrowser -r / -d /usr/local/community-scripts/filebrowser.db -p 9000
+ExecStartPre=/usr/local/bin/filebrowser config set -a "0.0.0.0" -p ${PORT} -d /usr/local/community-scripts/filebrowser.db
+ExecStart=/usr/local/bin/filebrowser -r / -d /usr/local/community-scripts/filebrowser.db -p ${PORT}
 Restart=always
 
 [Install]


### PR DESCRIPTION
## ✍️ Description  
- Change Debian service file to use ${PORT} instead of hard-coding port 9000.
- This will fix issues with users being unable to access FileBrowser after installation.

## 🔗 Related PR / Discussion / Issue  

Link: #https://github.com/community-scripts/ProxmoxVE/issues/3096

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
In issue 3096 - user had issues with navigating to FileBrowser after installing an LXC container.
After running `systemctl status filebrowser` he noticed that it was using port 9000.
After looking at the installation script, I noticed port 9000 was hard-coded into the Debian service file.
