### PR TITLE
Fixed wrong PHP values to match default part-db size (100M)

### DIFF
--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -29,6 +29,11 @@ $STD apt-get install -y \
   postgresql
 msg_ok "Installed Dependencies"
 
+msg_info "Setting up PHP"
+sed -i "s@post_max_size = 8M@post_max_size = 100M@g" /etc/php/8.2/apache2/php.ini 
+sed -i "s@upload_max_filesize = 2M@upload_max_filesize = 100M@g" /etc/php/8.2/apache2/php.ini
+msg_ok "Setting up PHP"
+
 msg_info "Setting up PostgreSQL"
 DB_NAME=partdb
 DB_USER=partdb

--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -30,8 +30,9 @@ $STD apt-get install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up PHP"
-sed -i "s@post_max_size = 8M@post_max_size = 100M@g" /etc/php/8.2/apache2/php.ini 
-sed -i "s@upload_max_filesize = 2M@upload_max_filesize = 100M@g" /etc/php/8.2/apache2/php.ini
+PHPVER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "\n";')
+sed -i "s@post_max_size = 8M@post_max_size = 100M@g" /etc/php/${PHPVER}/apache2/php.ini 
+sed -i "s@upload_max_filesize = 2M@upload_max_filesize = 100M@g" /etc/php/${PHPVER}/apache2/php.ini
 msg_ok "Setting up PHP"
 
 msg_info "Setting up PostgreSQL"


### PR DESCRIPTION
## ✍️ Description  
Fixed wrong PHP values to match default part-db size (100M)
The default Uploadsize is 100M but PHP is limited to 2M (Upload) and 8M (Post) by default, this commit fixed that.

## 🔗 Related PR / Discussion / Issue  
--

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
--
