### PR TITLE
qBittorrent: Accept legal notice in config file

### DIFF
--- a/install/qbittorrent-install.sh
+++ b/install/qbittorrent-install.sh
@@ -23,6 +23,9 @@ msg_info "Installing qbittorrent-nox"
 $STD apt-get install -y qbittorrent-nox
 mkdir -p /.config/qBittorrent/
 cat <<EOF >/.config/qBittorrent/qBittorrent.conf
+[LegalNotice]
+Accepted=true
+
 [Preferences]
 WebUI\Password_PBKDF2="@ByteArray(amjeuVrF3xRbgzqWQmes5A==:XK3/Ra9jUmqUc4RwzCtrhrkQIcYczBl90DJw2rT8DFVTss4nxpoRhvyxhCf87ahVE3SzD8K9lyPdpyUCfmVsUg==)"
 WebUI\Port=8090


### PR DESCRIPTION
## ✍️ Description  
Running the qbittorrent-nox without any switches or accepted legal notices in the config file, it makes you press Y to start it up. Its hidden because we run it via service file, hence why it stops.

## 🔗 Related PR / Discussion / Issue  

Link: #

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [] **Self-review performed** – Code follows established patterns and conventions.  
- [] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [] 🆕 **New script** – A fully functional and tested script or script set.
- [✅] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
