### PR TITLE
Trilium: Name of directory inside of the downloaded tar changed

### DIFF
--- a/ct/trilium.sh
+++ b/ct/trilium.sh
@@ -42,7 +42,7 @@ function update_script() {
     cd /tmp
     wget -q https://github.com/TriliumNext/Notes/releases/download/${RELEASE}/TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
     tar -xf TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
-    mv TriliumNextNotes-Server-$RELEASE-linux-x64 /opt/trilium
+    mv TriliumNextNotes-Server-${RELEASE}-linux-x64 /opt/trilium
     cp -r /opt/trilium_backup/{db,dump-db} /opt/trilium/
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated to ${RELEASE}"

--- a/ct/trilium.sh
+++ b/ct/trilium.sh
@@ -29,6 +29,7 @@ function update_script() {
     fi
     if [[ ! -f /opt/${APP}_version.txt ]]; then touch /opt/${APP}_version.txt; fi
     RELEASE=$(curl -s https://api.github.com/repos/TriliumNext/Notes/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
+    EXTRACTED_DIR=$(echo ${RELEASE} | sed 's/^v//')
     if [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]] || [[ ! -f /opt/${APP}_version.txt ]]; then
     msg_info "Stopping ${APP}"
     systemctl stop trilium
@@ -42,7 +43,7 @@ function update_script() {
     cd /tmp
     wget -q https://github.com/TriliumNext/Notes/releases/download/${RELEASE}/TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
     tar -xf TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
-    mv TriliumNextNotes-Server-${RELEASE}-linux-x64 /opt/trilium
+    mv TriliumNextNotes-Server-${EXTRACTED_DIR}-linux-x64 /opt/trilium
     cp -r /opt/trilium_backup/{db,dump-db} /opt/trilium/
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated to ${RELEASE}"

--- a/install/trilium-install.sh
+++ b/install/trilium-install.sh
@@ -23,9 +23,10 @@ msg_ok "Installed Dependencies"
 msg_info "Setup TriliumNext"
 cd /opt
 RELEASE=$(curl -s https://api.github.com/repos/TriliumNext/Notes/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
+EXTRACTED_DIR=$(echo ${RELEASE} | sed 's/^v//')
 wget -q https://github.com/TriliumNext/Notes/releases/download/${RELEASE}/TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
 tar -xf TriliumNextNotes-Server-${RELEASE}-linux-x64.tar.xz
-mv TriliumNextNotes-Server-$RELEASE-linux-x64 /opt/trilium
+mv TriliumNextNotes-Server-${EXTRACTED_DIR}-linux-x64 /opt/trilium
 echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
 msg_ok "Setup TriliumNext"
 


### PR DESCRIPTION
## ✍️ Description  
The directory name changed inside of the downloaded tar file, before the folder had the version number with a "v" in front of it, now it's only the number without a "v".

I've tested the change locally by copy pasting the commands into my shell.

## 🔗 Related PR / Discussion / Issue  

Link: #3151 & #3152 

## ✅ Prerequisites  

Before this PR can be reviewed, the following must be completed:  

- [X] **Self-review performed** – Code follows established patterns and conventions.  
- [X] **Testing performed** – Changes have been thoroughly tested and verified.  

## 🛠️ Type of Change  

Select all that apply:

- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [X] 🐞 **Bug fix**  – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature**  – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change**  – Alters existing functionality in a way that may require updates.  

## 📋 Additional Information (optional)  
<!-- Provide extra context, screenshots, or references if needed. -->  
