### PR TITLE
Audiobookshelf: Fix category on website

### DIFF
--- a/frontend/public/json/audiobookshelf.json
+++ b/frontend/public/json/audiobookshelf.json
@@ -2,7 +2,7 @@
     "name": "Audiobookshelf",
     "slug": "audiobookshelf",
     "categories": [
-        12
+        13
     ],
     "date_created": "2024-05-02",
     "type": "ct",


### PR DESCRIPTION
## ✍️ Description  
Change Audiobookshelf category from "Documents & Notes" to "Media & Streaming".  This is closer to Jellyfin as an audiobook streaming library than a document/note manager.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [ ] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
