### PR TITLE
Komodo: Fix compose.env

### DIFF
--- a/install/komodo-install.sh
+++ b/install/komodo-install.sh
@@ -70,9 +70,9 @@ PASSKEY=$(openssl rand -base64 24 | tr -d '/+=')
 WEBHOOK_SECRET=$(openssl rand -base64 24 | tr -d '/+=')
 JWT_SECRET=$(openssl rand -base64 24 | tr -d '/+=')
 
-sed -i "s/^DB_USERNAME=.*/DB_USERNAME=komodo_admin/" /opt/komodo/compose.env
-sed -i "s/^DB_PASSWORD=.*/DB_PASSWORD=${DB_PASSWORD}/" /opt/komodo/compose.env
-sed -i "s/^PASSKEY=.*/PASSKEY=${PASSKEY}/" /opt/komodo/compose.env
+sed -i "s/^KOMODO_DB_USERNAME=.*/KOMODO_DB_USERNAME=komodo_admin/" /opt/komodo/compose.env
+sed -i "s/^KOMODO_DB_USERNAME=.*/KOMODO_DB_USERNAME=${DB_PASSWORD}/" /opt/komodo/compose.env
+sed -i "s/^KOMODO_PASSKEY=.*/KOMODO_PASSKEY=${PASSKEY}/" /opt/komodo/compose.env
 sed -i "s/^KOMODO_WEBHOOK_SECRET=.*/KOMODO_WEBHOOK_SECRET=${WEBHOOK_SECRET}/" /opt/komodo/compose.env
 sed -i "s/^KOMODO_JWT_SECRET=.*/KOMODO_JWT_SECRET=${JWT_SECRET}/" /opt/komodo/compose.env
 msg_ok "Setup Komodo Environment"


### PR DESCRIPTION
<!--🛑 New scripts must first be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs for new scripts that skip this process will be closed. -->  

## ✍️ Description  
<!-- Briefly describe your changes. -->  
`compose.env` changed variable names making `sed` to fail. This PR fixes it.

## 🔗 Related PR / Issue  
Link: #3465 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [x] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
