### PR TITLE
Remove old `.jar` versions of Stirling-PDF

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -39,6 +39,7 @@ function update_script() {
   cd Stirling-PDF-$RELEASE
   chmod +x ./gradlew
   $STD ./gradlew build
+  rm -rf /opt/Stirling-PDF/Stirling-PDF-*.jar
   cp -r ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
   cp -r scripts /opt/Stirling-PDF/
   cd ~


### PR DESCRIPTION
## ✍️ Description  
The update script of Stirling PDF was compiling a new `.jar` file with the source but keeping all previous versions installed on the LXC. Every version has a size of ~150Mb, which increases a lot the disk usage after a couple of updates.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [ ] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No breaking changes** – Existing functionality remains intact.  
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [ ] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
