### PR TITLE
Tianji: Bump NodeJS to V22

### DIFF
--- a/ct/tianji.sh
+++ b/ct/tianji.sh
@@ -26,6 +26,22 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+    if command -v node >/dev/null; then
+    NODE_MAJOR=$(/usr/bin/env node -v | grep -oP '^v\K[0-9]+')
+    if [[ "$NODE_MAJOR" != "22" ]]; then
+      $STD apt-get purge -y nodejs
+      rm -f /etc/apt/sources.list.d/nodesource.list
+      rm -f /etc/apt/keyrings/nodesource.gpg
+    else
+      return
+    fi
+  fi
+  mkdir -p /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+  $STD apt-get update
+  $STD apt-get install -y nodejs
+  $STD npm install -g pnpm@9.7.1
   RELEASE=$(curl -s https://api.github.com/repos/msgbyte/tianji/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
   if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
     msg_info "Stopping ${APP} Service"

--- a/install/tianji-install.sh
+++ b/install/tianji-install.sh
@@ -30,7 +30,7 @@ msg_ok "Installed Dependencies"
 msg_info "Installing Node.js"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 $STD apt-get update
 $STD apt-get install -y nodejs
 $STD npm install -g pnpm@9.7.1


### PR DESCRIPTION
## ✍️ Description  
Bump NodeJS to 22.

In Next Time an new PR needed, he experimenting with PNPM 10.x*
https://github.com/msgbyte/tianji/commit/15d575d954627fbd4ea1b626c837cdff8962ab60


## 🔗 Related PR / Issue  
Link: #3461 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
