### PR TITLE
Docmost: Bump NodeJS to 22 & fixed pnpm

### DIFF
--- a/ct/docmost.sh
+++ b/ct/docmost.sh
@@ -26,6 +26,23 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  if command -v node >/dev/null; then
+    NODE_MAJOR=$(/usr/bin/env node -v | grep -oP '^v\K[0-9]+')
+    if [[ "$NODE_MAJOR" != "22" ]]; then
+      $STD apt-get purge -y nodejs
+      rm -f /etc/apt/sources.list.d/nodesource.list
+      rm -f /etc/apt/keyrings/nodesource.gpg
+    else
+      return
+    fi
+  fi
+  mkdir -p /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+  $STD apt-get update
+  $STD apt-get install -y nodejs
+  $STD npm install -g pnpm@10.4.0
+  export NODE_OPTIONS="--max_old_space_size=4096"
   RELEASE=$(curl -s https://api.github.com/repos/docmost/docmost/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
   if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
     msg_info "Stopping ${APP}"

--- a/install/docmost-install.sh
+++ b/install/docmost-install.sh
@@ -24,13 +24,13 @@ msg_ok "Installed Dependencies"
 msg_info "Setting up Node.js Repository"
 mkdir -p /etc/apt/keyrings
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
 msg_ok "Set up Node.js Repository"
 
 msg_info "Installing Node.js"
 $STD apt-get update
 $STD apt-get install -y nodejs
-$STD npm install -g pnpm
+$STD npm install -g pnpm@10.4.0
 msg_ok "Installed Node.js"
 
 msg_info "Setting up PostgreSQL"


### PR DESCRIPTION
## ✍️ Description  
Bump Docmost to NodeJS 22
Bump Pnpm to fixed 10.4


## 🔗 Related PR / Issue  
Link: #3435


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No breaking changes** – Existing functionality remains intact.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  