### PR TITLE
Alpine-Wireguard: Fix for sysctl and ip_forward

### DIFF
--- a/install/alpine-wireguard-install.sh
+++ b/install/alpine-wireguard-install.sh
@@ -15,20 +15,20 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apk add \
-    newt \
-    curl \
-    openssh \
-    nano \
-    mc \
-    gpg \
-    iptables \
-    openrc
+  newt \
+  curl \
+  openssh \
+  nano \
+  mc \
+  gpg \
+  iptables \
+  openrc
 msg_ok "Installed Dependencies"
 
 msg_info "Installing WireGuard"
 $STD apk add --no-cache wireguard-tools
 if [[ ! -L /etc/init.d/wg-quick.wg0 ]]; then
-    ln -s /etc/init.d/wg-quick /etc/init.d/wg-quick.wg0
+  ln -s /etc/init.d/wg-quick /etc/init.d/wg-quick.wg0
 fi
 
 private_key=$(wg genkey)
@@ -41,32 +41,33 @@ PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACC
 PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -D FORWARD -o wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE;
 ListenPort = 51820
 EOF
+echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
+$STD rc-update add sysctl
+$STD sysctl -p /etc/sysctl.conf
 msg_ok "Installed WireGuard"
 
 read -rp "Do you want to install WGDashboard? (y/N): " INSTALL_WGD
 if [[ "$INSTALL_WGD" =~ ^[Yy]$ ]]; then
-    msg_info "Installing additional dependencies for WGDashboard"
-    $STD apk add --no-cache \
-        python3 \
-        py3-pip \
-        git \
-        sudo \
-        musl-dev \
-        linux-headers \
-        gcc \
-        python3-dev
-    msg_ok "Installed additional dependencies for WGDashboard"
-    msg_info "Installing WGDashboard"
-    git clone -q https://github.com/donaldzou/WGDashboard.git /etc/wgdashboard
-    cd /etc/wgdashboard/src || exit
-    chmod u+x wgd.sh
-    $STD ./wgd.sh install
-    $STD echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
-    sysctl -p /etc/sysctl.conf
-    msg_ok "Installed WGDashboard"
+  msg_info "Installing additional dependencies for WGDashboard"
+  $STD apk add --no-cache \
+    python3 \
+    py3-pip \
+    git \
+    sudo \
+    musl-dev \
+    linux-headers \
+    gcc \
+    python3-dev
+  msg_ok "Installed additional dependencies for WGDashboard"
+  msg_info "Installing WGDashboard"
+  git clone -q https://github.com/donaldzou/WGDashboard.git /etc/wgdashboard
+  cd /etc/wgdashboard/src || exit
+  chmod u+x wgd.sh
+  $STD ./wgd.sh install
+  msg_ok "Installed WGDashboard"
 
-    msg_info "Creating Service for WGDashboard"
-    cat <<EOF >/etc/init.d/wg-dashboard
+  msg_info "Creating Service for WGDashboard"
+  cat <<EOF >/etc/init.d/wg-dashboard
 #!/sbin/openrc-run
 
 description="WireGuard Dashboard Service"
@@ -89,10 +90,10 @@ stop() {
     eend $?
 }
 EOF
-    chmod +x /etc/init.d/wg-dashboard
-    $STD rc-update add wg-dashboard default
-    $STD rc-service wg-dashboard start
-    msg_ok "Created Service for WGDashboard"
+  chmod +x /etc/init.d/wg-dashboard
+  $STD rc-update add wg-dashboard default
+  $STD rc-service wg-dashboard start
+  msg_ok "Created Service for WGDashboard"
 
 fi
 

--- a/install/alpine-wireguard-install.sh
+++ b/install/alpine-wireguard-install.sh
@@ -41,7 +41,7 @@ PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACC
 PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -D FORWARD -o wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE;
 ListenPort = 51820
 EOF
-echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
+$STD echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
 $STD rc-update add sysctl
 $STD sysctl -p /etc/sysctl.conf
 msg_ok "Installed WireGuard"

--- a/install/alpine-wireguard-install.sh
+++ b/install/alpine-wireguard-install.sh
@@ -41,7 +41,7 @@ PostUp = iptables -A FORWARD -i wg0 -j ACCEPT; iptables -A FORWARD -o wg0 -j ACC
 PostDown = iptables -D FORWARD -i wg0 -j ACCEPT; iptables -D FORWARD -o wg0 -j ACCEPT; iptables -t nat -D POSTROUTING -o eth0 -j MASQUERADE;
 ListenPort = 51820
 EOF
-$STD echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
+echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
 $STD rc-update add sysctl
 $STD sysctl -p /etc/sysctl.conf
 msg_ok "Installed WireGuard"


### PR DESCRIPTION
<!--🛑 New scripts must first be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs for new scripts that skip this process will be closed. -->  

## ✍️ Description  
<!-- Briefly describe your changes. --> 
Peers had no internet connection when installing without verbose. net.ipv4.ip_forward = 1 was not set. Removed the silent function before echo fixed it.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  

Peers did not have internet connection (handshake was ok) in alpine-wireguard LXC when installed with verbose OFF. silent function probbably was not working with this line.  

"$STD echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf"

So the config was mising in LXC. I removed it to test and now it works.

- I also moved related code to wg install, since you need this also if you dont install wgdash.
- I also added rc-update add sysctl for reboot persistance. recommended [here](https://wiki.alpinelinux.org/wiki/Configure_a_Wireguard_interface_(wg))

Bug only happened on running the script with NO verbose.