### PR TITLE
Outline - Remove app/components/Fade.ts (#3831)

### DIFF
--- a/ct/outline.sh
+++ b/ct/outline.sh
@@ -36,7 +36,10 @@ function update_script() {
         msg_info "Updating ${APP} to ${RELEASE}"
         temp_file=$(mktemp)
         rm -rf /opt/outline/node_modules
-curl -fsSL "https://github.com/outline/outline/archive/refs/tags/v${RELEASE}.tar.gz" -o "$temp_file"
+        if [ -f /opt/outline/app/components/Fade.ts ]; then
+          rm -f /opt/outline/app/components/Fade.ts
+        fi
+        curl -fsSL "https://github.com/outline/outline/archive/refs/tags/v${RELEASE}.tar.gz" -o "$temp_file"
         tar zxf $temp_file
         cp -rf outline-${RELEASE}/* /opt/outline
         cd /opt/outline


### PR DESCRIPTION
## ✍️ Description  
The new version of Outline replaces the `app/components/Fade.ts` by `app/components/Fade.tsx` in outline/outline#8594. `Fade.ts` must be deleted to allow `yarn build` to resolve the tsx file instead.


## 🔗 Related PR / Issue  
Link: #3831


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No breaking changes** – Existing functionality remains intact.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

---

## 🔍 Code & Security Review  (**X** in brackets) 

- [X] **Follows `Code_Audit.md` & `CONTRIBUTING.md` guidelines**


## 📋 Additional Information (optional)  
<!-- Add any extra context, screenshots, or references. -->  
