### PR TITLE
karakeep: use nightly channel for yt-dlp

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -33,6 +33,9 @@ function update_script() {
     msg_info "Stopping Services"
     systemctl stop karakeep-web karakeep-workers karakeep-browser
     msg_ok "Stopped Services"
+    msg_info "Updating yt-dlp"
+    $STD yt-dlp --update-to nightly
+    msg_ok "Updated yt-dlp"
     msg_info "Updating ${APP} to v${RELEASE}"
     if [[ $(corepack -v) < "0.31.0" ]]; then
       $STD npm install -g corepack@0.31.0

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -29,7 +29,7 @@ msg_ok "Installed Dependencies"
 msg_info "Installing Additional Tools"
 curl -fsSL "https://github.com/Y2Z/monolith/releases/latest/download/monolith-gnu-linux-x86_64" -o "/usr/bin/monolith"
 chmod +x /usr/bin/monolith
-curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux" -o "/usr/bin/yt-dlp"
+curl -fsSL "https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp_linux" -o "/usr/bin/yt-dlp"
 chmod +x /usr/bin/yt-dlp
 msg_ok "Installed Additional Tools"
 


### PR DESCRIPTION
## ✍️ Description  
This PR changes the Karakeep scripts to install/update to the nightly channel for yt-dlp, which is the [recommended channel](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#update).


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
