### PR TITLE
Install rsync in ct/commafeed.sh

### DIFF
--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -33,9 +33,12 @@ function update_script() {
     systemctl stop commafeed
     msg_ok "Stopped ${APP}"
 
-    msg_info "Installing Dependencies"
-    $STD apt-get install -y rsync
-    msg_ok "Installed Dependencies"
+    if ! [[ $(dpkg -s rsync 2>/dev/null) ]]; then
+      msg_info "Installing Dependencies"
+      $STD apt-get update
+      $STD apt-get install -y rsync
+      msg_ok "Installed Dependencies"
+    fi
 
     msg_info "Updating ${APP} to ${RELEASE}"
     curl -fsSL "https://github.com/Athou/commafeed/releases/download/${RELEASE}/commafeed-${RELEASE}-h2-jvm.zip" -o $(basename "https://github.com/Athou/commafeed/releases/download/${RELEASE}/commafeed-${RELEASE}-h2-jvm.zip")

--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -33,6 +33,10 @@ function update_script() {
     systemctl stop commafeed
     msg_ok "Stopped ${APP}"
 
+    msg_info "Installing Dependencies"
+    $STD apt-get install -y rsync
+    msg_ok "Installed Dependencies"
+
     msg_info "Updating ${APP} to ${RELEASE}"
     curl -fsSL "https://github.com/Athou/commafeed/releases/download/${RELEASE}/commafeed-${RELEASE}-h2-jvm.zip" -o $(basename "https://github.com/Athou/commafeed/releases/download/${RELEASE}/commafeed-${RELEASE}-h2-jvm.zip")
     unzip -q commafeed-"${RELEASE}"-h2-jvm.zip


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This PR installs rsync in the update script of commafeed for users who used the install script before rsync was added. This prevents users from seeing a command not found error when attempting to upgrade commafeed.

## 🔗 Related PR / Issue  


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [x] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
