### PR TITLE
Make apt-cacher-ng a client of its own server

### DIFF
--- a/install/apt-cacher-ng-install.sh
+++ b/install/apt-cacher-ng-install.sh
@@ -16,6 +16,9 @@ update_os
 msg_info "Installing Apt-Cacher NG"
 DEBIAN_FRONTEND=noninteractive $STD apt-get -o Dpkg::Options::="--force-confold" install -y apt-cacher-ng
 sed -i 's/# PassThroughPattern: .* # this would allow CONNECT to everything/PassThroughPattern: .*/' /etc/apt-cacher-ng/acng.conf
+cat << EOF >/etc/apt/apt.conf.d/00aptproxy.conf
+Acquire::http::Proxy "http://localhost:3142";
+EOF
 systemctl enable -q --now apt-cacher-ng
 msg_ok "Installed Apt-Cacher NG"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
When installing apt-cacher-ng into a CT, in addition to being a caching server, I think it would be good to also be a client of its own cache. From https://askubuntu.com/questions/1503184/apt-cacher-ng-not-caching-packages-installed-on-the-server it changes this

![image](https://github.com/user-attachments/assets/fe129acf-67e1-4f35-a2c3-3b856a2bf253)

to this

![image](https://github.com/user-attachments/assets/7e565253-32bc-4f72-a6f1-b1a3752f36c4)

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [X] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
