### PR TITLE
clean-lxc.sh: cancel/no whiptail support

### DIFF
--- a/tools/pve/clean-lxcs.sh
+++ b/tools/pve/clean-lxcs.sh
@@ -16,6 +16,7 @@ function header_info() {
 
 EOF
 }
+set -eEuo pipefail
 BL=$(echo "\033[36m")
 RD=$(echo "\033[01;31m")
 CM='\xE2\x9C\x94\033'
@@ -34,6 +35,10 @@ while read -r TAG ITEM; do
 done < <(pct list | awk 'NR>1')
 excluded_containers=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Containers on $NODE" --checklist "\nSelect containers to skip from cleaning:\n" \
   16 $((MSG_MAX_LENGTH + 23)) 6 "${EXCLUDE_MENU[@]}" 3>&1 1>&2 2>&3 | tr -d '"')
+
+if [ $? -ne 0 ]; then
+  exit
+fi  
 
 function clean_container() {
   container=$1


### PR DESCRIPTION
Shell option missing, needed to be able to NO/CANCEL the whiptail dialog box. Without it NO/CANCEL is without function and the script will proceed.

This shell option is used in the other scripts, but here it is missing.

Also the needed if-statement is missing.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  



## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
