### PR TITLE
core: persist /usr/local/bin via profile.d helper

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -758,8 +758,7 @@ import_local_ip() {
 }
 
 function setup_uv() {
-    msg_info "Checking uv installation..."
-
+    $STD msg_info "Checking uv installation..."
     UV_BIN="/usr/local/bin/uv"
     TMP_DIR=$(mktemp -d)
     ARCH=$(uname -m)
@@ -786,7 +785,7 @@ function setup_uv() {
     if [[ -x "$UV_BIN" ]]; then
         INSTALLED_VERSION=$($UV_BIN -V | awk '{print $2}')
         if [[ "$INSTALLED_VERSION" == "$LATEST_VERSION" ]]; then
-            msg_ok "uv is already at the latest version ($INSTALLED_VERSION)"
+            $STD msg_ok "uv is already at the latest version ($INSTALLED_VERSION)"
             rm -rf "$TMP_DIR"
             # set path
             if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
@@ -794,10 +793,10 @@ function setup_uv() {
             fi
             return 0
         else
-            msg_info "Updating uv from $INSTALLED_VERSION to $LATEST_VERSION"
+            $STD msg_info "Updating uv from $INSTALLED_VERSION to $LATEST_VERSION"
         fi
     else
-        msg_info "uv not found. Installing version $LATEST_VERSION"
+        $STD msg_info "uv not found. Installing version $LATEST_VERSION"
     fi
 
     # install or update uv
@@ -807,9 +806,15 @@ function setup_uv() {
     rm -rf "$TMP_DIR"
 
     # set path
-    if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
-        export PATH="/usr/local/bin:$PATH"
-    fi
-
+    ensure_usr_local_bin_persist
     msg_ok "uv installed/updated to $LATEST_VERSION"
+}
+
+function ensure_usr_local_bin_persist() {
+    local PROFILE_FILE="/etc/profile.d/custom_path.sh"
+
+    if [[ ! -f "$PROFILE_FILE" ]] && ! command -v pveversion &>/dev/null; then
+        echo 'export PATH="/usr/local/bin:$PATH"' >"$PROFILE_FILE"
+        chmod +x "$PROFILE_FILE"
+    fi
 }


### PR DESCRIPTION
## ✍️ Description  
### What does this PR do?
- Replaces inline PATH manipulation in `setup_uv()` with a new helper function `ensure_usr_local_bin_persist()`.
- This function ensures that `/usr/local/bin` is included in the `$PATH`, both for the current shell session and persistently via `/etc/profile.d/custom_path.sh`.

### Why?
- In some environments (especially containers), `/usr/local/bin` is not included in `$PATH` by default.
- The previous solution appended the path at runtime, but did not persist it across logins or reboots.
- This change makes `uv` and other binaries reliably executable without requiring re-export or login shell restarts.

### Additional considerations
- The function checks if `pveversion` exists and skips changes on Proxmox nodes to avoid affecting system-level behavior.


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
