### PR TITLE
fix: detect all bridge types, not just vmbr prefix

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -528,7 +528,7 @@ advanced_settings() {
     exit_script
   fi
 
-  BRIDGES=$( ip link show | grep -oP '(?<=: )vmbr\d+' | sort)
+  BRIDGES=$( grep -B1 "bridge-" /etc/network/interfaces | grep "iface" | grep -Pv "^\s*#" | awk '{print $2}' | sort | uniq | while read bridge; do ip link show "$bridge" 2> /dev/null | grep -oP "$bridge"; done )
   if [[ -z "$BRIDGES" ]]; then
     BRG="vmbr0"
     echo -e "${BRIDGE}${BOLD}${DGN}Bridge: ${BGN}$BRG${CL}"


### PR DESCRIPTION
## ✍️ Description  
I found this error while installing a container

> [ERROR] in line 531: exit code 0: while executing command BRIDGES=$(ip link show | grep -oP '(?<=: )vmbr\d+' | sort)

So I decided to fix bridge detection in order to identify all bridge types in the network configuration, not just those with 'vmbr' prefix. The script now scans `/etc/network/interfaces` for any bridge configuration and verifies if they are active.


## ✅ Prerequisites  (**X** in brackets) 
- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  
---
## 🛠️ Type of Change (**X** in brackets)  
- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.