### PR TITLE
fix app/application var mapping

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -479,7 +479,7 @@ install_mongodb() {
 
 fetch_and_deploy_gh_release() {
   local repo="$1"
-  local app=$(echo ${APPLICATION,,} | tr -d ' ')
+  local app=${APP:-$(echo "${APPLICATION,,}" | tr -d ' ')}
   local api_url="https://api.github.com/repos/$repo/releases/latest"
   local header=()
   local attempt=0


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This PR fixes a bug in the fetch and deploy GH release function, that prevented the function from running inside update scripts, as in update scripts there is only the var $app and in install only the var $application.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
