### PR TITLE
Update build.func

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -528,7 +528,7 @@ advanced_settings() {
     exit_script
   fi
 
-  BRIDGES=$( ip link show | grep -oP '(?<=: )vmbr\d+' | sort)
+  BRIDGES=$( ip link show | grep -oP '(?<=: )vmbr\d+(\.\d+)?' | sort)
   if [[ -z "$BRIDGES" ]]; then
     BRG="vmbr0"
     echo -e "${BRIDGE}${BOLD}${DGN}Bridge: ${BGN}$BRG${CL}"


### PR DESCRIPTION
doesn't cater for Proxmox recommended network vlan layout:

https://pve.proxmox.com/wiki/Network_Configuration

where a fullstop is used to delineate a vlan e.g. : auto vmbr0.5


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  



## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [ ] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
