### PR TITLE
fix: improve bridge detection in all network interface configuration files

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -528,57 +528,33 @@ advanced_settings() {
     exit_script
   fi
 
-  # List of network interface configuration files
-  # Considers both the main /etc/network/interfaces file and all files in the /etc/network/interfaces.d/ directory
-  IFACE_FILEPATH_LIST="/etc/network/interfaces"$'\n'$(find "/etc/network/interfaces.d/" -type f)
 
-  # Initialize the variable that will contain bridge names
   BRIDGES=""
+  IFACE_FILEPATH_LIST="/etc/network/interfaces"$'\n'$(find "/etc/network/interfaces.d/" -type f)
+  OLD_IFS=$IFS; IFS=$'\n'
 
-  # Save the original value of the internal field separator (IFS)...
-  OLD_IFS=$IFS
-  # ...then IFS to newline to iterate over complete lines
-  IFS=$'\n'
-
-  # Iterate over each network interface configuration file
   for iface_filepath in ${IFACE_FILEPATH_LIST}; do
-    # Create a unique temporary filename to store interface indexes
     iface_indexes_tmpfile=$(mktemp -q -u '.iface-XXXX')
 
-    # This block processes the file to create start:end pairs for each 'iface' block
-    # 1. Find all lines starting with 'iface' and store their line numbers
-    # 2. Get the total number of lines in the file
-    # 3. Use awk to create line ranges for each iface section (start:end)
     ( grep -Pn '^\s*iface' "${iface_filepath}" | cut -d':' -f1 && wc -l "${iface_filepath}" | cut -d' ' -f1 ) | \
     awk 'FNR==1 {line=$0; next} {print line":"$0-1; line=$0}' > "${iface_indexes_tmpfile}"
 
-    # Check if the indexes file exists, hence has been created
     if [ -f "${iface_indexes_tmpfile}" ]; then
-        # Iterate over each start:end pair in the indexes file
         while read -r pair; do
-            # Extract the starting line number of the interface block
             start=$(echo "${pair}" | cut -d':' -f1)
-            # Extract the ending line number of the interface block
             end=$(echo "${pair}" | cut -d':' -f2)
 
-            # Check if the block contains bridge configurations
-            # Looks for lines containing bridge parameters like bridge-ports, bridge-stp, etc.
             if awk "NR >= ${start} && NR <= ${end}" "${iface_filepath}" | grep -qP '^\s*bridge[-_](ports|stp|fd|vlan-aware|vids)\s+'; then
-                # Extract the interface name from the first line of the block
                 iface_name=$(sed "${start}q;d" "${iface_filepath}" | awk '{print $2}')
-                # Add the interface name to the list of bridges
                 BRIDGES="${iface_name}"$'\n'"${BRIDGES}"
             fi
 
         done < "${iface_indexes_tmpfile}"
-
-        # Clean up the temporary file
         rm -f "${iface_indexes_tmpfile}"
     fi
 
   done
 
-  # Restore the original IFS value
   IFS=$OLD_IFS
 
   # Filter the bridge list to remove empty lines and duplicates, then sort alphabetically

--- a/misc/build.func
+++ b/misc/build.func
@@ -557,7 +557,6 @@ advanced_settings() {
 
   IFS=$OLD_IFS
 
-  # Filter the bridge list to remove empty lines and duplicates, then sort alphabetically
   BRIDGES=$(echo "$BRIDGES" | grep -v '^\s*$' | sort | uniq)
 
   if [[ -z "$BRIDGES" ]]; then

--- a/misc/build.func
+++ b/misc/build.func
@@ -528,7 +528,62 @@ advanced_settings() {
     exit_script
   fi
 
-  BRIDGES=$( ip link show | grep -oP '(?<=: )vmbr\d+' | sort)
+  # List of network interface configuration files
+  # Considers both the main /etc/network/interfaces file and all files in the /etc/network/interfaces.d/ directory
+  IFACE_FILEPATH_LIST="/etc/network/interfaces"$'\n'$(find "/etc/network/interfaces.d/" -type f)
+
+  # Initialize the variable that will contain bridge names
+  BRIDGES=""
+
+  # Save the original value of the internal field separator (IFS)...
+  OLD_IFS=$IFS
+  # ...then IFS to newline to iterate over complete lines
+  IFS=$'\n'
+
+  # Iterate over each network interface configuration file
+  for iface_filepath in ${IFACE_FILEPATH_LIST}; do
+    # Create a unique temporary filename to store interface indexes
+    iface_indexes_tmpfile=$(mktemp -q -u '.iface-XXXX')
+
+    # This block processes the file to create start:end pairs for each 'iface' block
+    # 1. Find all lines starting with 'iface' and store their line numbers
+    # 2. Get the total number of lines in the file
+    # 3. Use awk to create line ranges for each iface section (start:end)
+    ( grep -Pn '^\s*iface' "${iface_filepath}" | cut -d':' -f1 && wc -l "${iface_filepath}" | cut -d' ' -f1 ) | \
+    awk 'FNR==1 {line=$0; next} {print line":"$0-1; line=$0}' > "${iface_indexes_tmpfile}"
+
+    # Check if the indexes file exists, hence has been created
+    if [ -f "${iface_indexes_tmpfile}" ]; then
+        # Iterate over each start:end pair in the indexes file
+        while read -r pair; do
+            # Extract the starting line number of the interface block
+            start=$(echo "${pair}" | cut -d':' -f1)
+            # Extract the ending line number of the interface block
+            end=$(echo "${pair}" | cut -d':' -f2)
+
+            # Check if the block contains bridge configurations
+            # Looks for lines containing bridge parameters like bridge-ports, bridge-stp, etc.
+            if awk "NR >= ${start} && NR <= ${end}" "${iface_filepath}" | grep -qP '^\s*bridge[-_](ports|stp|fd|vlan-aware|vids)\s+'; then
+                # Extract the interface name from the first line of the block
+                iface_name=$(sed "${start}q;d" "${iface_filepath}" | awk '{print $2}')
+                # Add the interface name to the list of bridges
+                BRIDGES="${iface_name}"$'\n'"${BRIDGES}"
+            fi
+
+        done < "${iface_indexes_tmpfile}"
+
+        # Clean up the temporary file
+        rm -f "${iface_indexes_tmpfile}"
+    fi
+
+  done
+
+  # Restore the original IFS value
+  IFS=$OLD_IFS
+
+  # Filter the bridge list to remove empty lines and duplicates, then sort alphabetically
+  BRIDGES=$(echo "$BRIDGES" | grep -v '^\s*$' | sort | uniq)
+
   if [[ -z "$BRIDGES" ]]; then
     BRG="vmbr0"
     echo -e "${BRIDGE}${BOLD}${DGN}Bridge: ${BGN}$BRG${CL}"
@@ -1399,7 +1454,7 @@ description() {
       <img src='https://img.shields.io/badge/&#x2615;-Buy us a coffee-blue' alt='spend Coffee' />
     </a>
   </p>
-  
+
   <span style='margin: 0 10px;'>
     <i class="fa fa-github fa-fw" style="color: #f5f5f5;"></i>
     <a href='https://github.com/community-scripts/ProxmoxVE' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>


### PR DESCRIPTION
## ✍️ Description  

This pull request provides a more robust and comprehensive solution to the bridge detection issue, replacing the previous attempt that proved insufficient. 

The new implementation:
- Uses a more sophisticated parsing method to analyze entire interface configuration blocks
- Processes both the main /etc/network/interfaces file and all files in interfaces.d/ directory
- Detects bridges based on bridge-related parameters regardless of naming convention
- Handles both hyphenated (bridge-ports) and underscore (bridge_ports) syntax variations
- Works with SDN (Software-Defined Networking) configurations

Unlike the previous fix attempt, this solution has been tested with various network configurations and correctly identifies bridge interfaces regardless of their naming patterns. The script includes detailed comments for better maintainability and future enhancements.

This PR replaces PR #4351 addresses the issue reported in #4360 (and in #4351 too) and should also work for #4354.

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
