### PR TITLE
openhab: use zulu17-jdk

### DIFF
--- a/install/openhab-install.sh
+++ b/install/openhab-install.sh
@@ -16,16 +16,16 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   gnupg \
+  ca-certificates \
   apt-transport-https
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Azul Zulu21"
-curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB1998361219BD9C9" -o "/etc/apt/trusted.gpg.d/zulu-repo.asc"
-curl -fsSL "https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb" -o $(basename "https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb")
-$STD dpkg -i zulu-repo_1.0.0-3_all.deb
+msg_info "Installing Azul Zulu17"
+curl -s https://repos.azul.com/azul-repo.key | gpg --dearmor -o /usr/share/keyrings/azul.gpg
+echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" | tee /etc/apt/sources.list.d/zulu.list
 $STD apt-get update
-$STD apt-get -y install zulu21-jdk
-msg_ok "Installed Azul Zulu21"
+$STD apt-get -y install zulu17-jdk
+msg_ok "Installed Azul Zulu17"
 
 msg_info "Installing openHAB"
 curl -fsSL "https://openhab.jfrog.io/artifactory/api/gpg/key/public" | gpg --dearmor >openhab.gpg


### PR DESCRIPTION
1) Update zulu repo
2) Use zulu17-jdk (previously zulu21-jdk)

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
zulu repo credentials were not worknig anymore
zulu17-jdk has to be used for openhab 4.3.5 (temurin has issues with openhab)
## 🔗 Related PR / Issue  
Link: https://github.com/community-scripts/ProxmoxVE/discussions/1587#discussioncomment-13108418


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
