### PR TITLE
fix: fetch_release_and_deploy function

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -568,6 +568,7 @@ fetch_and_deploy_gh_release() {
     fi
 
     tag=$(echo "$api_response" | jq -r '.tag_name // .name // empty')
+    [[ "$tag" =~ ^v[0-9] ]] && tag="${tag:1}"
     version="${tag#v}"
 
     if [[ -z "$tag" ]]; then
@@ -586,8 +587,8 @@ fetch_and_deploy_gh_release() {
   fi
 
   # Version comparison (if we already have this version, skip)
-  if [[ "$current_version" == "$version" ]]; then
-    $STD msg_info "Already running the latest version ($version). Skipping update."
+  if [[ "$current_version" == "$tag" ]]; then
+    $STD msg_info "Already running the latest version ($tag). Skipping update."
     return 0
   fi
 
@@ -650,8 +651,15 @@ fetch_and_deploy_gh_release() {
 
   # Final fallback to GitHub source tarball
   if [[ -z "$url" ]]; then
-    url="https://github.com/$repo/archive/refs/tags/$version.tar.gz"
-    $STD msg_info "Trying GitHub source tarball fallback: $url"
+    # Use tarball_url directly from API response instead of constructing our own URL
+    url=$(echo "$api_response" | jq -r '.tarball_url // empty')
+
+    # If tarball_url is empty for some reason, fall back to a constructed URL as before
+    if [[ -z "$url" ]]; then
+      url="https://github.com/$repo/archive/refs/tags/v$version.tar.gz"
+    fi
+
+    $STD msg_info "Using GitHub source tarball: $url"
   fi
 
   local filename="${url##*/}"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This PR aims to fix the fetch_release_and_deploy_gh_release which failed to deploy if the tag contained a "v" like in homarr.

## 🔗 Related PR / Issue  
Link: #3778


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
