### PR TITLE
Add make installation dependency to Actual Budget script

### DIFF
--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -13,6 +13,11 @@ setting_up_container
 network_check
 update_os
 
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  make
+msg_ok "Installed Dependencies"
+
 msg_info "Installing Actual Budget"
 cd /opt
 RELEASE=$(curl -fsSL https://api.github.com/repos/actualbudget/actual/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Added `make` as dependency for this script (based on other example where `make` is also installed) to mitigate this error during actual installation:

```
npm error gyp ERR! stack Error: not found: make
```

I did test installation from my fork and got success (main on the left, my fork on the right):

![obraz](https://github.com/user-attachments/assets/90a3fb48-91bf-4f5d-9529-ceef3d6c8604)


## 🔗 Related PR / Issue  
Link: #4484


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
