### PR TITLE
Alpine Transmission: Add a slight pause before stopping the service

### DIFF
--- a/install/alpine-transmission-install.sh
+++ b/install/alpine-transmission-install.sh
@@ -16,6 +16,7 @@ update_os
 msg_info "Installing Transmission"
 $STD apk add --no-cache transmission-cli transmission-daemon
 $STD rc-service transmission-daemon start
+sleep 5
 $STD rc-service transmission-daemon stop
 sed -i '{s/"rpc-whitelist-enabled": true/"rpc-whitelist-enabled": false/g; s/"rpc-host-whitelist-enabled": true,/"rpc-host-whitelist-enabled": false,/g}' /var/lib/transmission/config/settings.json
 msg_ok "Installed Transmission"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- It is possible that the script is stopping the service before the config file gets to be created by the app. We are adding a slight pause before stopping and editing the config, giving the service more time to start the application up and create the config.


## 🔗 Related PR / Issue  
Link: #4396 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
