### PR TITLE
Update clean-lxcs.sh to fix #4352

### DIFF
--- a/tools/pve/clean-lxcs.sh
+++ b/tools/pve/clean-lxcs.sh
@@ -56,7 +56,7 @@ for container in $(pct list | awk '{if(NR>1) print $1}'); do
     os=$(pct config "$container" | awk '/^ostype/ {print $2}')
     if [ "$os" != "debian" ] && [ "$os" != "ubuntu" ]; then
       header_info
-      echo -e "${BL}[Info]${GN} Skipping ${name} ${RD}$container is not Debian or Ubuntu ${CL} \n"
+      echo -e "${BL}[Info]${GN} Skipping ${RD}$container is not Debian or Ubuntu ${CL} \n"
       sleep 1
       continue
     fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
No longer try to print `name` of containers that are skipped due to not being Debian or Ubuntu, as it is not known at this point in the script. Furthermore, the container's status has not been checked, so we can not for sure get the name via `hostname` like it is done in `clean_container` function.


## 🔗 Related PR / Issue  
Link: #4352


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
