### PR TITLE
Pelican-panel: back-up database if using sqlite

### DIFF
--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -40,7 +40,6 @@ function update_script() {
       php8.4 \
       php8.4-{gd,mysql,mbstring,bcmath,xml,curl,zip,intl,fpm} \
       libapache2-mod-php8.4
-
     msg_ok "Migrated PHP $CURRENT_PHP to 8.4"
   fi
 
@@ -53,10 +52,13 @@ function update_script() {
 
     msg_info "Updating ${APP} to v${RELEASE}"
     cp -r /opt/pelican-panel/.env /opt/
+    SQLITE_INSTALL=$(ls /opt/pelican-panel/database/*.sqlite 1> /dev/null 2>&1 && echo "true" || echo "false")
+    $SQLITE_INSTALL && cp -r /opt/pelican-panel/database/*.sqlite /opt/
     rm -rf * .*
     curl -fsSL "https://github.com/pelican-dev/panel/releases/download/v${RELEASE}/panel.tar.gz" -o $(basename "https://github.com/pelican-dev/panel/releases/download/v${RELEASE}/panel.tar.gz")
     tar -xzf "panel.tar.gz"
     mv /opt/.env /opt/pelican-panel/
+    $SQLITE_INSTALL && mv /opt/*.sqlite /opt/pelican-panel/database/
     $STD composer install --no-dev --optimize-autoloader --no-interaction
     $STD php artisan p:environment:setup
     $STD php artisan view:clear


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Users who selected SQlite during the initial Pelican Panel installation experienced an issue where the database was not backed up running the update script. As a result, the database was lost after an update and the user cannot login.

## 🔗 Related PR / Issue  
Link: #4613 


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
