### PR TITLE
BREAKING CHANGE: Fix PocketID for v1.0.0

### DIFF
--- a/ct/pocketid.sh
+++ b/ct/pocketid.sh
@@ -20,63 +20,62 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
+  header_info
+  check_container_storage
+  check_container_resources
 
-    if [[ ! -d /opt/pocket-id ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-
-    RELEASE=$(curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-    if [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]] || [[ ! -f /opt/${APP}_version.txt ]]; then
-        msg_info "Updating $APP"
-
-        msg_info "Stopping $APP"
-        systemctl stop pocketid-backend.service
-        systemctl stop pocketid-frontend.service
-        systemctl stop caddy.service
-        msg_ok "Stopped $APP"
-
-        msg_info "Updating $APP to v${RELEASE}"
-        cd /opt
-        cp -r /opt/pocket-id/backend/data /opt/data
-        cp /opt/pocket-id/backend/.env /opt/backend.env
-        cp /opt/pocket-id/frontend/.env /opt/frontend.env
-        rm -r /opt/pocket-id
-        curl -fsSL "https://github.com/pocket-id/pocket-id/archive/refs/tags/v${RELEASE}.zip" -o $(basename "https://github.com/pocket-id/pocket-id/archive/refs/tags/v${RELEASE}.zip")
-        unzip -q v${RELEASE}.zip
-        mv pocket-id-${RELEASE} /opt/pocket-id
-        mv /opt/data /opt/pocket-id/backend/data
-        mv /opt/backend.env /opt/pocket-id/backend/.env
-        mv /opt/frontend.env /opt/pocket-id/frontend/.env
-
-        cd /opt/pocket-id/backend/cmd
-        go build -o ../pocket-id-backend
-        cd ../../frontend
-        npm install
-        npm run build
-        msg_ok "Updated $APP to ${RELEASE}"
-
-        msg_info "Starting $APP"
-        systemctl start pocketid-backend.service
-        systemctl start pocketid-frontend.service
-        systemctl start caddy.service
-        sleep 2
-        msg_ok "Started $APP"
-
-        # Cleaning up
-        msg_info "Cleaning Up"
-        rm -f /opt/v${RELEASE}.zip
-        msg_ok "Cleanup Completed"
-
-        echo "${RELEASE}" >/opt/${APP}_version.txt
-        msg_ok "Update Successful"
-    else
-        msg_ok "No update required. ${APP} is already at ${RELEASE}"
-    fi
+  if [[ ! -d /opt/pocket-id ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+
+  RELEASE=$(curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  if [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]] || [[ ! -f /opt/${APP}_version.txt ]]; then
+    if [[ "$(cat /opt/${APP}_version.txt)" < "1.0.0" ]]; then
+      msg_info "Migrating ${APP} to v${RELEASE}"
+      systemctl -q disable --now pocketid-backend pocketid-frontend caddy
+      mv /etc/caddy/Caddyfile ~/Caddyfile.bak
+      $STD apt remove --purge caddy nodejs -y
+      $STD apt autoremove -y
+      rm /etc/apt/{keyrings/nodesource.gpg,sources.list.d/nodesource.list}
+      rm -r /usr/local/go
+      cp -r /opt/pocket-id/backend/data /opt/data
+      cp /opt/pocket-id/backend/.env /opt/env
+      sed -i -e 's/PUBLIC_//g' \
+        -e '/^SQLITE_DB_PATH/d' \
+        -e '/^POSTGRES/s/^/# /' \
+        -e '/^UPLOAD_PATH/d' \
+        -e 's/8080/1411/' /opt/env
+      rm -r /opt/pocket-id
+      rm /etc/systemd/system/pocketid-frontend.service
+      BACKEND="/etc/systemd/system/pocketid-backend.service"
+      sed -i -e 's/Backend/Service/' \
+        -e 's/\/backend\|-backend//g' "$BACKEND"
+      mv "$BACKEND" ${BACKEND//-backend/}
+      systemctl daemon-reload
+      systemctl -q enable pocketid
+      mkdir /opt/pocket-id
+      mv /opt/data /opt/pocket-id
+      msg_ok "Migration complete. The reverse proxy port has been changed to 1411."
+    else
+      msg_info "Updating $APP to v${RELEASE}"
+      systemctl stop pocketid
+      cp /opt/pocket-id/.env /opt/env
+    fi
+    curl -fsSL "https://github.com/pocket-id/pocket-id/releases/download/v${RELEASE}/pocket-id-linux-amd64" -o /opt/pocket-id/pocket-id
+    chmod u+x /opt/pocket-id/pocket-id
+    mv /opt/env /opt/pocket-id/.env
+
+    msg_info "Starting $APP"
+    systemctl start pocketid
+    msg_ok "Started $APP"
+
+    echo "${RELEASE}" >/opt/${APP}_version.txt
+    msg_ok "Update Successful"
+  else
+    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+  fi
+  exit
 }
 
 start
@@ -85,6 +84,6 @@ description
 
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW} Configure your reverse proxy to point to:${BGN} ${IP}:80${CL}"
+echo -e "${INFO}${YW} Configure your reverse proxy to point to:${BGN} ${IP}:1411${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
 echo -e "${TAB}${GATEWAY}${BGN}https://{PUBLIC_URL}/login/setup${CL}"

--- a/frontend/public/json/pocketid.json
+++ b/frontend/public/json/pocketid.json
@@ -8,11 +8,11 @@
   "type": "ct",
   "updateable": true,
   "privileged": false,
-  "interface_port": 80,
+  "interface_port": 1411,
   "documentation": "https://pocket-id.org/docs/",
   "website": "https://github.com/pocket-id/pocket-id",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/pocket-id.webp",
-  "config_path": "/opt/pocket-id/backend/.env and /opt/pocket-id/frontend/.env",
+  "config_path": "/opt/pocket-id/.env",
   "description": "Pocket ID is a simple OIDC provider that allows users to authenticate with their passkeys to your services.",
   "install_methods": [
     {
@@ -35,10 +35,6 @@
     {
       "text": "Pocket ID requires https to work.",
       "type": "warning"
-    },
-    {
-      "text": "Configuration Path: `/opt/pocket-id/backend/.env`, `/opt/pocket-id/frontend/.env`.",
-      "type": "info"
     }
   ]
 }

--- a/install/pocketid-install.sh
+++ b/install/pocketid-install.sh
@@ -13,12 +13,6 @@ setting_up_container
 network_check
 update_os
 
-# msg_info "Installing Dependencies"
-# $STD apt-get install -y \
-#   gpg \
-#   gcc
-# msg_ok "Installed Dependencies"
-
 read -r -p "${TAB3}What public URL do you want to use (e.g. pocketid.mydomain.com)? " public_url
 msg_info "Setup Pocket ID"
 RELEASE=$(curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')

--- a/install/pocketid-install.sh
+++ b/install/pocketid-install.sh
@@ -13,94 +13,43 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y \
-  gpg \
-  caddy \
-  gcc
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -fsSL https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-curl -fsSL "https://golang.org/dl/${golang_tarball}" -o "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-rm -f "$temp_file"
-set -o pipefail
-msg_ok "Installed Golang"
+# msg_info "Installing Dependencies"
+# $STD apt-get install -y \
+#   gpg \
+#   gcc
+# msg_ok "Installed Dependencies"
 
 read -r -p "${TAB3}What public URL do you want to use (e.g. pocketid.mydomain.com)? " public_url
 msg_info "Setup Pocket ID"
-cd /opt
 RELEASE=$(curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-curl -fsSL "https://github.com/pocket-id/pocket-id/archive/refs/tags/v${RELEASE}.zip" -o $(basename "https://github.com/pocket-id/pocket-id/archive/refs/tags/v${RELEASE}.zip")
-unzip -q v${RELEASE}.zip
-mv pocket-id-${RELEASE}/ /opt/pocket-id
+mkdir -p /opt/pocket-id
+curl -fsSL "https://github.com/pocket-id/pocket-id/releases/download/v${RELEASE}/pocket-id-linux-amd64" -o /opt/pocket-id/pocket-id
+chmod u+x /opt/pocket-id/pocket-id
 
-cd /opt/pocket-id/backend
-cp .env.example .env
-sed -i "s/PUBLIC_APP_URL=http:\/\/localhost/PUBLIC_APP_URL=https:\/\/${public_url}/" .env
-cd cmd
-CGO_ENABLED=1
-GOOS=linux
-$STD go build -o ../pocket-id-backend
-
-cd ../../frontend
-cp .env.example .env
-sed -i "s/PUBLIC_APP_URL=http:\/\/localhost/PUBLIC_APP_URL=https:\/\/${public_url}/" .env
-$STD npm install
-$STD npm run build
-
-cd ..
-cp reverse-proxy/Caddyfile /etc/caddy/Caddyfile
+cat <<EOF >/opt/pocket-id/.env
+APP_ENV=production
+APP_URL=https://${public_url}
+TRUST_PROXY=false
+# MAXMIND_LICENSE_KEY=
+PORT=1411
+HOST=0.0.0.0
+EOF
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Setup Pocket ID"
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/pocketid-backend.service
+cat <<EOF >/etc/systemd/system/pocketid.service
 [Unit]
-Description=Pocket ID Backend
+Description=Pocket ID Service
 After=network.target
 
 [Service]
 Type=simple
 User=root
 Group=root
-WorkingDirectory=/opt/pocket-id/backend
-EnvironmentFile=/opt/pocket-id/backend/.env
-ExecStart=/opt/pocket-id/backend/pocket-id-backend
-Restart=always
-RestartSec=10
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-cat <<EOF >/etc/systemd/system/pocketid-frontend.service
-[Unit]
-Description=Pocket ID Frontend
-After=network.target
-
-[Service]
-Type=simple
-User=root
-Group=root
-WorkingDirectory=/opt/pocket-id/frontend
-EnvironmentFile=/opt/pocket-id/frontend/.env
-ExecStart=/usr/bin/node build/index.js
+WorkingDirectory=/opt/pocket-id
+EnvironmentFile=/opt/pocket-id/.env
+ExecStart=/opt/pocket-id/pocket-id
 Restart=always
 RestartSec=10
 
@@ -109,17 +58,14 @@ WantedBy=multi-user.target
 EOF
 msg_ok "Created Service"
 
-msg_info "Starting Services"
-systemctl enable -q --now pocketid-backend
-systemctl enable -q --now pocketid-frontend
-systemctl restart caddy
+msg_info "Starting Service"
+systemctl enable -q --now pocketid
 msg_ok "Started Services"
 
 motd_ssh
 customize
 
 msg_info "Cleaning up"
-rm -f /opt/v${RELEASE}.zip
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"


### PR DESCRIPTION
## ✍️ Description

- remove Caddy from installation (HTTPS is still a requirement). See note about Breaking change below
- remove NodeJS and Go dependencies
- consolidate frontend & backend service into one
- update .env file
- install compiled binary instead of compiling from release source
- add migration path for versions pre-1.0.0 to pocketid.sh

## ⚠️ Breaking change

Previous versions of PocketID used Caddy to serve the frontend. Now that is no longer required. This PR will **remove** Caddy. The config has been moved to `/root/Caddyfile.bak`. If you were also using Caddy in the same LXC to generate a TLS cert and serve PocketID behind a subdomain, you will need to reinstall Caddy and fix the Caddyfile to use the updated configuration.

Users who configured Caddy on a separate LXC also need to adjust their configurations.

### Example Caddy config

```bash
@id host id.xxxx.xyz
  handle @id {
    reverse_proxy http://pocketid.internal.lan:1411
  }
```

## 🔗 Related PR / Issue  
Link: #4710 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
