### PR TITLE
Big NodeJS Update: Use Helper Function on all Install-Scripts

### DIFF
--- a/install/adventurelog-install.sh
+++ b/install/adventurelog-install.sh
@@ -24,25 +24,11 @@ $STD apt-get install -y \
   python3-pip
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Setting up PostgreSQL Repository"
-curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-echo "deb https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" >/etc/apt/sources.list.d/pgdg.list
-msg_ok "Set up PostgreSQL Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g pnpm
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Install/Set up PostgreSQL Database"
-$STD apt-get install -y postgresql-16 postgresql-16-postgis
+$STD apt-get install -y postgresql-16-postgis
 DB_NAME="adventurelog_db"
 DB_USER="adventurelog_user"
 DB_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"

--- a/install/archivebox-install.sh
+++ b/install/archivebox-install.sh
@@ -33,16 +33,7 @@ $STD apt-get install -y \
   python3-regex
 msg_ok "Installed Python Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Playwright"
 $STD pip install playwright

--- a/install/bytestash-install.sh
+++ b/install/bytestash-install.sh
@@ -13,21 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y \
-  gnupg
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing ByteStash"
 JWT_SECRET=$(openssl rand -base64 32 | tr -d '/+=')

--- a/install/changedetection-install.sh
+++ b/install/changedetection-install.sh
@@ -52,16 +52,7 @@ $STD apt-get install -y \
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Setup Python3"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Change Detection"
 mkdir /opt/changedetection

--- a/install/cronicle-install.sh
+++ b/install/cronicle-install.sh
@@ -13,20 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gnupg
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Cronicle Primary Server"
 LATEST=$(curl -fsSL https://api.github.com/repos/jhuckaby/Cronicle/releases/latest | grep '"tag_name":' | cut -d'"' -f4)

--- a/install/cross-seed-install.sh
+++ b/install/cross-seed-install.sh
@@ -13,20 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gnupg
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_23.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Setup Node.js Repository"
-
-msg_info "Setting up Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup Cross-Seed"
 $STD npm install cross-seed@latest -g

--- a/install/cryptpad-install.sh
+++ b/install/cryptpad-install.sh
@@ -15,16 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gnupg \
   git
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
-
-msg_info "Setup Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 read -p "${TAB3}Install OnlyOffice components instead of CKEditor? (Y/N): " onlyoffice
 

--- a/install/cryptpad-install.sh
+++ b/install/cryptpad-install.sh
@@ -19,11 +19,7 @@ $STD apt-get install -y \
   git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setup Node.js"
 $STD apt-get update

--- a/install/dashy-install.sh
+++ b/install/dashy-install.sh
@@ -13,20 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gpg
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 RELEASE=$(curl -fsSL https://api.github.com/repos/Lissy93/dashy/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
 msg_info "Installing Dashy ${RELEASE} (Patience)"

--- a/install/docmost-install.sh
+++ b/install/docmost-install.sh
@@ -15,23 +15,12 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gpg \
   redis \
-  make \
-  postgresql
+  make
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g pnpm@10.4.0
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/docmost/docmost/main/package.json | jq -r '.packageManager | split("@")[1]')" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setting up PostgreSQL"
 DB_NAME="docmost_db"

--- a/install/elementsynapse-install.sh
+++ b/install/elementsynapse-install.sh
@@ -17,21 +17,10 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y \
   lsb-release \
   apt-transport-https \
-  debconf-utils \
-  gpg
+  debconf-utils
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 read -p "${TAB3}Please enter the name for your server: " servername
 

--- a/install/excalidraw-install.sh
+++ b/install/excalidraw-install.sh
@@ -15,21 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gnupg \
   xdg-utils
 msg_ok "Installed Dependencies"
 
-msg_info "Setup Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Setup Node.js Repository"
-
-msg_info "Setup Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Setup Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setup Excalidraw"
 temp_file=$(mktemp)

--- a/install/flowiseai-install.sh
+++ b/install/flowiseai-install.sh
@@ -13,17 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gpg
-msg_ok "Installed Dependencies"
-
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing FlowiseAI (Patience)"
 $STD npm install -g flowise \

--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -23,13 +23,7 @@ $STD apt-get install -y {python3,python3-dev,python3-setuptools,python3-distutil
 $STD pip install --upgrade pip
 msg_ok "Setup Python3"
 
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing go2rtc"
 mkdir -p /usr/local/go2rtc/bin

--- a/install/ghost-install.sh
+++ b/install/ghost-install.sh
@@ -17,8 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y \
   nginx \
   mariadb-server \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
 msg_info "Configuring Database"
@@ -37,16 +36,7 @@ mariadb -u root -e "GRANT ALL ON $DB_NAME.* TO '$DB_USER'@'localhost'; FLUSH PRI
 } >>~/ghost.creds
 msg_ok "Configured MySQL"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Setup Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+NODE_VERSION="20" install_node_and_modules
 
 msg_info "Installing Ghost CLI"
 $STD npm install ghost-cli@latest -g

--- a/install/gomft-install.sh
+++ b/install/gomft-install.sh
@@ -19,30 +19,11 @@ $STD apt-get install -y \
   rclone \
   tzdata \
   ca-certificates \
-  build-essential \
-  gnupg
+  build-essential
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -s https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-wget -q https://golang.org/dl/"$golang_tarball" -O "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-set -o pipefail
-msg_ok "Setup Golang"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_go
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup ${APPLICATION} (Patience)"
 temp_file=$(mktemp)

--- a/install/grist-install.sh
+++ b/install/grist-install.sh
@@ -16,20 +16,12 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   make \
-  gnupg \
   ca-certificates \
   unzip \
   python3.11-venv
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Installing Grist"
 RELEASE=$(curl -fsSL https://api.github.com/repos/gristlabs/grist-core/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')

--- a/install/habitica-install.sh
+++ b/install/habitica-install.sh
@@ -15,24 +15,14 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-    libkrb5-dev \
-    gnupg \
-    build-essential \
-    git
+  libkrb5-dev \
+  build-essential \
+  git
 curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb" -o $(basename "http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb")
 $STD dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Setup Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup ${APPLICATION}"
 temp_file=$(mktemp)

--- a/install/homepage-install.sh
+++ b/install/homepage-install.sh
@@ -17,17 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y gpg jq
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g pnpm
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
 
 LOCAL_IP=$(hostname -I | awk '{print $1}')
 RELEASE=$(curl -fsSL https://api.github.com/repos/gethomepage/homepage/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')

--- a/install/iobroker-install.sh
+++ b/install/iobroker-install.sh
@@ -18,16 +18,7 @@ $STD apt-get install -y ca-certificates
 $STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing ioBroker (Patience)"
 $STD bash <(curl -fsSL https://iobroker.net/install.sh)

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -49,14 +49,8 @@ sed -i \
   /etc/meilisearch.toml
 msg_ok "Installed Meilisearch"
 
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 $STD npm install -g corepack@0.31.0
-msg_ok "Installed Node.js"
 
 msg_info "Installing karakeep"
 cd /opt

--- a/install/koillection-install.sh
+++ b/install/koillection-install.sh
@@ -15,10 +15,12 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gnupg2 postgresql \
   apache2 \
   lsb-release
 msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setup PHP8.4 Repository"
 $STD curl -fsSLo /tmp/debsuryorg-archive-keyring.deb https://packages.sury.org/debsuryorg-archive-keyring.deb
@@ -48,16 +50,6 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER TEMP
   echo "Koillection Database Name: $DB_NAME"
 } >>~/koillection.creds
 msg_ok "Set up PostgreSQL"
-
-msg_info "Setting up Node.js/Yarn"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g npm@latest
-$STD npm install -g yarn
-msg_ok "Installed Node.js/Yarn"
 
 msg_info "Installing Koillection"
 RELEASE=$(curl -fsSL https://api.github.com/repos/benjaminjonard/koillection/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')

--- a/install/mafl-install.sh
+++ b/install/mafl-install.sh
@@ -18,21 +18,9 @@ $STD apt-get install -y make
 $STD apt-get install -y g++
 $STD apt-get install -y gcc
 $STD apt-get install -y ca-certificates
-$STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g npm@latest
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 RELEASE=$(curl -fsSL https://api.github.com/repos/hywax/mafl/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 msg_info "Installing Mafl v${RELEASE}"

--- a/install/magicmirror-install.sh
+++ b/install/magicmirror-install.sh
@@ -13,20 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gnupg
-msg_ok "Installed Dependencies"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup MagicMirror"
 temp_file=$(mktemp)

--- a/install/meilisearch-install.sh
+++ b/install/meilisearch-install.sh
@@ -40,17 +40,7 @@ msg_ok "Setup ${APPLICATION}"
 
 read -r -p "${TAB3}Do you want add meilisearch-ui? [y/n]: " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
-  msg_info "Setting up Node.js Repository"
-  mkdir -p /etc/apt/keyrings
-  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-  msg_ok "Set up Node.js Repository"
-
-  msg_info "Installing Node.js"
-  $STD apt-get update
-  $STD apt-get install -y nodejs
-  $STD npm install -g pnpm
-  msg_ok "Installed Node.js"
+  NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
 
   msg_info "Setup ${APPLICATION}-ui"
   tmp_file=$(mktemp)

--- a/install/memos-install.sh
+++ b/install/memos-install.sh
@@ -21,31 +21,8 @@ $STD apt-get install -y \
   tzdata
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing pnpm"
-$STD npm install -g pnpm
-msg_ok "Installed pnpm"
-
-msg_info "Installing Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -fsSL https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-curl -fsSL "https://golang.org/dl/${golang_tarball}" -o "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-rm -f "$temp_file"
-set -o pipefail
-msg_ok "Installed Golang"
+NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
+install_go
 
 msg_info "Installing Memos (Patience)"
 mkdir -p /opt/memos_data

--- a/install/meshcentral-install.sh
+++ b/install/meshcentral-install.sh
@@ -15,19 +15,9 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y ca-certificates
-$STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing MeshCentral"
 mkdir /opt/meshcentral

--- a/install/metube-install.sh
+++ b/install/metube-install.sh
@@ -25,7 +25,6 @@ $STD apt-get install -y --no-install-recommends \
   ffmpeg \
   git \
   make \
-  gnupg \
   ca-certificates
 msg_ok "Installed Dependencies"
 
@@ -37,16 +36,7 @@ $STD apt-get install -y \
   python3-venv
 msg_ok "Setup Python3"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing MeTube"
 $STD git clone https://github.com/alexta69/metube /opt/metube

--- a/install/monica-install.sh
+++ b/install/monica-install.sh
@@ -15,12 +15,14 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-    gnupg2 mariadb-server \
-    apache2 \
-    libapache2-mod-php \
-    php-{bcmath,curl,dom,gd,gmp,iconv,intl,json,mbstring,mysqli,opcache,pdo-mysql,redis,tokenizer,xml,zip} \
-    composer
+  mariadb-server \
+  apache2 \
+  libapache2-mod-php \
+  php-{bcmath,curl,dom,gd,gmp,iconv,intl,json,mbstring,mysqli,opcache,pdo-mysql,redis,tokenizer,xml,zip} \
+  composer
 msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setting up MariaDB"
 DB_NAME=monica
@@ -30,22 +32,12 @@ $STD mysql -u root -e "CREATE DATABASE $DB_NAME;"
 $STD mysql -u root -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED WITH mysql_native_password AS PASSWORD('$DB_PASS');"
 $STD mysql -u root -e "GRANT ALL ON $DB_NAME.* TO '$DB_USER'@'localhost'; FLUSH PRIVILEGES;"
 {
-    echo "monica-Credentials"
-    echo "monica Database User: $DB_USER"
-    echo "monica Database Password: $DB_PASS"
-    echo "monica Database Name: $DB_NAME"
+  echo "monica-Credentials"
+  echo "monica Database User: $DB_USER"
+  echo "monica Database Password: $DB_PASS"
+  echo "monica Database Name: $DB_NAME"
 } >>~/monica.creds
 msg_ok "Set up MariaDB"
-
-msg_info "Setting up Node.js/Yarn"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g npm@latest
-$STD npm install -g yarn
-msg_ok "Installed Node.js/Yarn"
 
 msg_info "Installing monica"
 RELEASE=$(curl -fsSL https://api.github.com/repos/monicahq/monica/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
@@ -57,9 +49,9 @@ cd /opt/monica
 cp /opt/monica/.env.example /opt/monica/.env
 HASH_SALT=$(openssl rand -base64 32)
 sed -i -e "s|^DB_USERNAME=.*|DB_USERNAME=${DB_USER}|" \
-    -e "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASS}|" \
-    -e "s|^HASH_SALT=.*|HASH_SALT=${HASH_SALT}|" \
-    /opt/monica/.env
+  -e "s|^DB_PASSWORD=.*|DB_PASSWORD=${DB_PASS}|" \
+  -e "s|^HASH_SALT=.*|HASH_SALT=${HASH_SALT}|" \
+  /opt/monica/.env
 $STD composer install --no-dev -o --no-interaction
 $STD yarn install
 $STD yarn run production

--- a/install/myspeed-install.sh
+++ b/install/myspeed-install.sh
@@ -16,20 +16,10 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   build-essential \
-  gpg \
   ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing MySpeed"
 RELEASE=$(curl -fsSL https://github.com/gnmyt/myspeed/releases/latest | grep "title>Release" | cut -d " " -f 5)

--- a/install/n8n-install.sh
+++ b/install/n8n-install.sh
@@ -15,20 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing n8n (Patience)"
 $STD npm install --global patch-package

--- a/install/node-red-install.sh
+++ b/install/node-red-install.sh
@@ -16,20 +16,10 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   git \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Node-Red"
 $STD npm install -g --unsafe-perm node-red

--- a/install/nodebb-install.sh
+++ b/install/nodebb-install.sh
@@ -15,32 +15,14 @@ update_os
 
 msg_info "Installing Dependencies (Patience)"
 $STD apt-get install -y \
-    build-essential \
-    redis-server \
-    expect \
-    gnupg \
-    ca-certificates
+  build-essential \
+  redis-server \
+  expect \
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js & MongoDB Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-
-curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
-echo "deb [arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" >/etc/apt/sources.list.d/mongodb-org-8.0.list
-$STD apt-get update
-msg_ok "Set up Repositories"
-
-msg_info "Installing Node.js"
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing MongoDB"
-$STD apt-get install -y mongodb-org
-systemctl enable -q --now mongod
-sleep 10 # MongoDB needs some secounds to start, if not sleep it collide with following mongosh
-msg_ok "Installed MongoDB"
+install_mongodb
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Configure MongoDB"
 MONGO_ADMIN_USER="admin"
@@ -50,12 +32,12 @@ NODEBB_PWD="$(openssl rand -base64 18 | cut -c1-13)"
 MONGO_CONNECTION_STRING="mongodb://${NODEBB_USER}:${NODEBB_PWD}@localhost:27017/nodebb"
 NODEBB_SECRET=$(uuidgen)
 {
-    echo "NodeBB-Credentials"
-    echo "Mongo Database User: $MONGO_ADMIN_USER"
-    echo "Mongo Database Password: $MONGO_ADMIN_PWD"
-    echo "NodeBB User: $NODEBB_USER"
-    echo "NodeBB Password: $NODEBB_PWD"
-    echo "NodeBB Secret: $NODEBB_SECRET"
+  echo "NodeBB-Credentials"
+  echo "Mongo Database User: $MONGO_ADMIN_USER"
+  echo "Mongo Database Password: $MONGO_ADMIN_PWD"
+  echo "NodeBB User: $NODEBB_USER"
+  echo "NodeBB Password: $NODEBB_PWD"
+  echo "NodeBB Secret: $NODEBB_SECRET"
 } >>~/nodebb.creds
 
 $STD mongosh <<EOF

--- a/install/openwebui-install.sh
+++ b/install/openwebui-install.sh
@@ -16,7 +16,6 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gpg \
   git \
   ffmpeg
 msg_ok "Installed Dependencies"
@@ -27,16 +26,7 @@ $STD apt-get install -y --no-install-recommends \
   python3-pip
 msg_ok "Setup Python3"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Open WebUI (Patience)"
 $STD git clone https://github.com/open-webui/open-webui.git /opt/open-webui

--- a/install/outline-install.sh
+++ b/install/outline-install.sh
@@ -21,25 +21,10 @@ $STD apt-get install -y \
   redis
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="20" NODE_MODULE="yarn@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
-msg_info "Setting up PostgreSQL Repository"
-curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-echo "deb https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" >/etc/apt/sources.list.d/pgdg.list
-msg_ok "Set up PostgreSQL Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
-
-msg_info "Install/Set up PostgreSQL Database"
-$STD apt-get install -y postgresql-16
+msg_info "Set up PostgreSQL Database"
 DB_NAME="outline"
 DB_USER="outline"
 DB_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"
@@ -48,7 +33,13 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER ENCO
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET client_encoding TO 'utf8';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET default_transaction_isolation TO 'read committed';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET timezone TO 'UTC';"
-msg_ok "Set up PostgreSQL"
+{
+  echo "Outline-Credentials"
+  echo "Outline Database User: $DB_USER"
+  echo "Outline Database Password: $DB_PASS"
+  echo "Outline Database Name: $DB_NAME"
+} >>~/outline.creds
+msg_ok "Set up PostgreSQL Database"
 
 msg_info "Setup Outline (Patience)"
 SECRET_KEY="$(openssl rand -hex 32)"

--- a/install/overseerr-install.sh
+++ b/install/overseerr-install.sh
@@ -16,24 +16,10 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   git \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing Yarn"
-$STD npm install -g yarn
-msg_ok "Installed Yarn"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Installing Overseerr (Patience)"
 git clone -q https://github.com/sct/overseerr.git /opt/overseerr

--- a/install/pairdrop-install.sh
+++ b/install/pairdrop-install.sh
@@ -15,16 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  git \
-  gpg
+  git
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing PairDrop"
 git clone -q https://github.com/schlagmichdoch/PairDrop.git /opt/pairdrop

--- a/install/pairdrop-install.sh
+++ b/install/pairdrop-install.sh
@@ -19,11 +19,7 @@ $STD apt-get install -y \
   gpg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Installing Node.js"
 $STD apt-get update

--- a/install/paperless-gpt-install.sh
+++ b/install/paperless-gpt-install.sh
@@ -16,7 +16,6 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   gcc \
-  gnupg \
   ca-certificates \
   musl-dev \
   mupdf \
@@ -24,23 +23,8 @@ $STD apt-get install -y \
   musl-tools
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -fsSL https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-curl -fsSL "https://golang.org/dl/${golang_tarball}" -o "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-rm -f "$temp_file"
-set -o pipefail
-msg_ok "Installed Golang"
+NODE_VERSION="22" install_node_and_modules
+install_go
 
 msg_info "Setup Paperless-GPT"
 temp_file=$(mktemp)

--- a/install/paperless-gpt-install.sh
+++ b/install/paperless-gpt-install.sh
@@ -24,11 +24,7 @@ $STD apt-get install -y \
   musl-tools
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Installing Node.js"
 $STD apt-get update

--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -21,9 +21,11 @@ $STD apt-get install -y \
   lsb-release \
   php-{opcache,curl,gd,mbstring,xml,bcmath,intl,zip,xsl,pgsql} \
   libapache2-mod-php \
-  composer \
-  postgresql
+  composer
 msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setting up PHP"
 PHPVER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION . "\n";')
@@ -44,16 +46,6 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER TEMP
   echo "Part-DB Database Name: $DB_NAME"
 } >>~/partdb.creds
 msg_ok "Set up PostgreSQL"
-
-msg_info "Setting up Node.js/Yarn"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g npm@latest
-$STD npm install -g yarn
-msg_ok "Installed Node.js/Yarn"
 
 msg_info "Installing Part-DB (Patience)"
 cd /opt

--- a/install/peanut-install.sh
+++ b/install/peanut-install.sh
@@ -14,17 +14,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gpg
-msg_ok "Installed Dependencies"
-
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing NUT"
 $STD apt-get install -y nut-client

--- a/install/pf2etools-install.sh
+++ b/install/pf2etools-install.sh
@@ -16,21 +16,11 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   apache2 \
-  gpg \
   ca-certificates \
   git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup Pf2eTools"
 cd /opt

--- a/install/pingvin-install.sh
+++ b/install/pingvin-install.sh
@@ -16,26 +16,14 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  git \
-  gnupg
+  git
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install pm2 -g
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pm2" install_node_and_modules
 
 msg_info "Installing Pingvin Share (Patience)"
 cd /opt
 RELEASE=$(curl -fsSL https://api.github.com/repos/stonith404/pingvin-share/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
 curl -fsSL "https://github.com/stonith404/pingvin-share/archive/refs/tags/v${RELEASE}.zip" -o $(basename "https://github.com/stonith404/pingvin-share/archive/refs/tags/v${RELEASE}.zip")
 unzip -q v${RELEASE}.zip
 echo "${RELEASE}" >"/opt/pingvin_version.txt"
@@ -49,10 +37,9 @@ sed -i '/"admin.config.smtp.allow-unauthorized-certificates":\|admin.config.smtp
 $STD npm install
 $STD npm run build
 $STD pm2 start --name="pingvin-share-frontend" npm -- run start
-# create and enable pm2-root systemd script
 $STD pm2 startup systemd
-# save running pm2 processes so pingvin-share can survive reboots
 $STD pm2 save
+echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
 msg_ok "Installed Pingvin Share"
 
 motd_ssh

--- a/install/ps5-mqtt-install.sh
+++ b/install/ps5-mqtt-install.sh
@@ -16,21 +16,10 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   jq \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm i -g playactor
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="playactor" install_node_and_modules
 
 msg_info "Installing PS5-MQTT"
 RELEASE=$(curl -fsSL https://api.github.com/repos/FunkeyFlo/ps5-mqtt/releases/latest | jq -r '.tag_name')

--- a/install/revealjs-install.sh
+++ b/install/revealjs-install.sh
@@ -13,16 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y gnupg
-msg_ok "Installed Dependencies"
-
-NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
-
-msg_info "Setup Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup ${APPLICATION}"
 temp_file=$(mktemp)

--- a/install/revealjs-install.sh
+++ b/install/revealjs-install.sh
@@ -17,11 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setup Node.js"
 $STD apt-get update

--- a/install/seelf-install.sh
+++ b/install/seelf-install.sh
@@ -16,30 +16,11 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   make \
-  gcc \
-  gpg
+  gcc
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -fsSL https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-curl -fsSL "https://golang.org/dl/${golang_tarball}" -o "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-set -o pipefail
-msg_ok "Installed Golang"
-
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+install_go
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setting up seelf. Patience"
 RELEASE=$(curl -fsSL https://api.github.com/repos/YuukanOO/seelf/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')

--- a/install/shinobi-install.sh
+++ b/install/shinobi-install.sh
@@ -17,19 +17,9 @@ msg_info "Installing Dependencies"
 $STD apt-get install -y make zip net-tools git
 $STD apt-get install -y gcc g++ cmake
 $STD apt-get install -y ca-certificates
-$STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing FFMPEG"
 $STD apt-get install -y ffmpeg

--- a/install/tandoor-install.sh
+++ b/install/tandoor-install.sh
@@ -24,7 +24,6 @@ $STD apt-get install -y --no-install-recommends \
   libsasl2-dev \
   libldap2-dev \
   libssl-dev \
-  gpg \
   git \
   make \
   pkg-config \
@@ -43,17 +42,7 @@ $STD apt-get install -y \
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Setup Python3"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
+NODE_VERSION="20" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Installing Tandoor (Patience)"
 $STD git clone https://github.com/TandoorRecipes/recipes -b master /opt/tandoor

--- a/install/tasmocompiler-install.sh
+++ b/install/tasmocompiler-install.sh
@@ -15,7 +15,6 @@ update_os
 
 msg_info "Installing Dependencies. Patience"
 $STD apt-get install -y \
-  gnupg \
   git
 msg_ok "Installed Dependencies"
 
@@ -23,14 +22,7 @@ msg_info "Setup Python3"
 $STD apt-get install -y python3-venv
 msg_ok "Setup Python3"
 
-msg_info "Setup Node.js & yarn"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Setup Node.js & yarn"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setup Platformio"
 curl -fsSL -o get-platformio.py https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py

--- a/install/the-lounge-install.sh
+++ b/install/the-lounge-install.sh
@@ -15,22 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gpg \
   build-essential
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install --global yarn
-$STD npm install --global node-gyp
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest,node-gyp" install_node_and_modules
 
 msg_info "Installing The Lounge"
 cd /opt

--- a/install/tianji-install.sh
+++ b/install/tianji-install.sh
@@ -16,26 +16,17 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  postgresql \
   python3 \
   cmake \
   g++ \
   build-essential \
   git \
   make \
-  gnupg \
   ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g pnpm@9.7.1
-export NODE_OPTIONS="--max_old_space_size=4096"
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/msgbyte/tianji/master/package.json | jq -r '.packageManager | split("@")[1]')" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setting up PostgreSQL"
 DB_NAME=tianji_db

--- a/install/umami-install.sh
+++ b/install/umami-install.sh
@@ -15,21 +15,10 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y git
-$STD apt-get install -y gpg
-$STD apt-get install -y postgresql
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setting up postgresql"
 DB_NAME=umamidb
@@ -41,12 +30,13 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER ENCO
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET client_encoding TO 'utf8';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET default_transaction_isolation TO 'read committed';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET timezone TO 'UTC'"
-echo "" >~/umami.creds
-echo "Umami Database Credentials" >>~/umami.creds
-echo "" >>~/umami.creds
-echo -e "umami Database User: \e[32m$DB_USER\e[0m" >>~/umami.creds
-echo -e "umami Database Password: \e[32m$DB_PASS\e[0m" >>~/umami.creds
-echo -e "umami Database Name: \e[32m$DB_NAME\e[0m" >>~/umami.creds
+{
+  echo "Umami-Credentials"
+  echo "Umami Database User: $DB_USER"
+  echo "Umami Database Password: $DB_PASS"
+  echo "Umami Database Name: $DB_NAME"
+  echo "Umami Secret Key: $SECRET_KEY"
+} >>~/umami.creds
 msg_ok "Set up postgresql"
 
 msg_info "Installing Umami (Patience)"

--- a/install/uptimekuma-install.sh
+++ b/install/uptimekuma-install.sh
@@ -16,19 +16,9 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y git
 $STD apt-get install -y ca-certificates
-$STD apt-get install -y gnupg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Installing Uptime Kuma"
 $STD git clone https://github.com/louislam/uptime-kuma.git

--- a/install/watcharr-install.sh
+++ b/install/watcharr-install.sh
@@ -15,28 +15,11 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  gcc \
-  gnupg
+  gcc
 msg_ok "Installed Dependencies"
 
-msg_info "Setup Golang"
-set +o pipefail
-temp_file=$(mktemp)
-golang_tarball=$(curl -fsSL https://go.dev/dl/ | grep -oP 'go[\d\.]+\.linux-amd64\.tar\.gz' | head -n 1)
-curl -fsSL "https://golang.org/dl/${golang_tarball}" -o "$temp_file"
-tar -C /usr/local -xzf "$temp_file"
-ln -sf /usr/local/go/bin/go /usr/local/bin/go
-rm -f "$temp_file"
-set -o pipefail
-msg_ok "Setup Golang"
-
-msg_info "Setup Node.js"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Setup Node.js"
+install_go
+NODE_VERSION="22" install_node_and_modules
 
 msg_info "Setup Watcharr"
 temp_file=$(mktemp)

--- a/install/web-check-install.sh
+++ b/install/web-check-install.sh
@@ -17,7 +17,6 @@ msg_info "Installing Dependencies"
 export DEBIAN_FRONTEND=noninteractive
 $STD apt-get -y install --no-install-recommends \
   git \
-  gnupg \
   traceroute \
   make \
   g++ \
@@ -36,11 +35,7 @@ $STD apt-get -y install --no-install-recommends \
   x11-apps
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
+NODE_VERSION="22" NODE_MODULE="yarn@latest" install_node_and_modules
 
 msg_info "Setup Python3"
 $STD apt-get install -y python3
@@ -56,12 +51,6 @@ $STD apt-get -y install \
   libxss1 \
   lsb-release
 msg_ok "Installed Chromium"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn
-msg_ok "Installed Node.js"
 
 msg_info "Setting up Chromium"
 /usr/bin/chromium --no-sandbox --version >/etc/chromium-version

--- a/install/wger-install.sh
+++ b/install/wger-install.sh
@@ -16,7 +16,6 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   git \
-  gnupg \
   apache2 \
   libapache2-mod-wsgi-py3
 msg_ok "Installed Dependencies"
@@ -26,17 +25,7 @@ $STD apt-get install -y python3-pip
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Installed Python"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g yarn sass
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="yarn@latest,sass" install_node_and_modules
 
 msg_info "Setting up wger"
 $STD adduser wger --disabled-password --gecos ""

--- a/install/wikijs-install.sh
+++ b/install/wikijs-install.sh
@@ -19,26 +19,10 @@ $STD apt-get install -y \
   gpg
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Setting up PostgreSQL Repository"
-curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
-echo "deb https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" >/etc/apt/sources.list.d/pgdg.list
-msg_ok "Set up PostgreSQL Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install --global yarn
-$STD npm install -g node-gyp
-msg_ok "Installed Node.js"
+NODE_VERSION="20" NODE_MODULE="yarn@latest,node-gyp" install_node_and_modules
+PG_VERSION="17" install_postgresql
 
 msg_info "Set up PostgreSQL"
-$STD apt-get install -y postgresql-17
 DB_NAME="wiki"
 DB_USER="wikijs_user"
 DB_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)"

--- a/install/zigbee2mqtt-install.sh
+++ b/install/zigbee2mqtt-install.sh
@@ -19,24 +19,10 @@ $STD apt-get install -y \
   make \
   g++ \
   gcc \
-  ca-certificates \
-  gnupg
+  ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-msg_ok "Installed Node.js"
-
-msg_info "Installing pnpm"
-$STD npm install -g pnpm
-msg_ok "Installed pnpm"
+NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
 
 msg_info "Setting up Zigbee2MQTT"
 cd /opt

--- a/install/zipline-install.sh
+++ b/install/zipline-install.sh
@@ -16,21 +16,11 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  postgresql \
-  gpg
+  postgresql
 msg_ok "Installed Dependencies"
 
-msg_info "Setting up Node.js Repository"
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" >/etc/apt/sources.list.d/nodesource.list
-msg_ok "Set up Node.js Repository"
-
-msg_info "Installing Node.js"
-$STD apt-get update
-$STD apt-get install -y nodejs
-$STD npm install -g pnpm
-msg_ok "Installed Node.js"
+NODE_VERSION="22" NODE_MODULE="pnpm@latest" install_node_and_modules
+PG_VERSION="16" install_postgresql
 
 msg_info "Setting up PostgreSQL"
 DB_NAME=ziplinedb
@@ -42,11 +32,13 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER ENCO
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET client_encoding TO 'utf8';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET default_transaction_isolation TO 'read committed';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET timezone TO 'UTC'"
-echo "" >>~/zipline.creds
-echo -e "Zipline Database User: $DB_USER" >>~/zipline.creds
-echo -e "Zipline Database Password: $DB_PASS" >>~/zipline.creds
-echo -e "Zipline Database Name: $DB_NAME" >>~/zipline.creds
-echo -e "Zipline Secret: $SECRET_KEY" >>~/zipline.creds
+{
+  echo "Zipline-Credentials"
+  echo "Zipline Database User: $DB_USER"
+  echo "Zipline Database Password: $DB_PASS"
+  echo "Zipline Database Name: $DB_NAME"
+  echo "Zipline Secret Key: $SECRET_KEY"
+} >>~/zipline.creds
 msg_ok "Set up PostgreSQL"
 
 msg_info "Installing Zipline (Patience)"

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -32,6 +32,15 @@ install_node_and_modules() {
     NEED_NODE_INSTALL=true
   fi
 
+  if ! command -v jq &>/dev/null; then
+    $STD msg_info "Installing jq..."
+    $STD apt-get update -qq &>/dev/null
+    $STD apt-get install -y jq &>/dev/null || {
+      msg_error "Failed to install jq"
+      return 1
+    }
+  fi
+
   # Install Node.js if required
   if [[ "$NEED_NODE_INSTALL" == true ]]; then
     $STD apt-get purge -y nodejs


### PR DESCRIPTION
## ✍️ Description  
- remove all nodejs parts in install scripts
- use the tools.func for nodejs installs
- remove gpg / gnupg deps

add jq in install_nodes_and_modules function (for crawling special pnpm, yarn versions)

Need to test after merge:
1. NodeBB
2. PingvinShare
3. ps5mqtt
4. wikijs


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
