### PR TITLE
Increase default RAM allocation for BunkerWeb to 8192MB

### DIFF
--- a/ct/bunkerweb.sh
+++ b/ct/bunkerweb.sh
@@ -8,7 +8,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="BunkerWeb"
 var_tags="${var_tags:-webserver}"
 var_cpu="${var_cpu:-2}"
-var_ram="${var_ram:-4096}"
+var_ram="${var_ram:-8192}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-12}"

--- a/frontend/public/json/bunkerweb.json
+++ b/frontend/public/json/bunkerweb.json
@@ -20,7 +20,7 @@
       "script": "ct/bunkerweb.sh",
       "resources": {
         "cpu": 2,
-        "ram": 4096,
+        "ram": 8192,
         "hdd": 4,
         "os": "debian",
         "version": "12"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This PR increases the default RAM allocation for BunkerWeb to **8192MB (8GB)**, aligning the configuration with the updated recommendations outlined in the latest official documentation.

This change ensures optimal performance and stability, especially during high-load scenarios or extensive operations, as detailed in the newer documentation version.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
