### PR TITLE
fix: pulse script tar warnings and interactive prompts

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -41,7 +41,7 @@ function update_script() {
     mkdir -p /opt/pulse-proxmox
     rm -rf /opt/pulse-proxmox/*
     curl -fsSL "https://github.com/rcourtman/Pulse/releases/download/v${RELEASE}/pulse-v${RELEASE}.tar.gz" -o "$temp_file"
-    tar zxf "$temp_file" --strip-components=1 -C /opt/pulse-proxmox
+    tar zxf "$temp_file" --strip-components=1 -C /opt/pulse-proxmox 2>/dev/null
     if [[ -f /tmp/.env.backup.pulse ]]; then
       mv /tmp/.env.backup.pulse /opt/pulse-proxmox/.env
     fi


### PR DESCRIPTION
## Summary
Fixes issues with the Pulse installation script and corrects the installation workflow to follow proper community script conventions.

## Changes Made
- **Suppress tar warnings**: Added `2>/dev/null` to tar extraction commands to suppress harmless extended header warnings on macOS
- **Remove interactive prompts**: Eliminated credential prompts during LXC creation (incorrect workflow) 
- **Use existing .env.example**: Release tarball already includes detailed .env.example with comprehensive configuration options
- **Update systemd service**: Use optional EnvironmentFile with `-` prefix so service can be enabled without .env file
- **Add post-install instructions**: Clear guidance on how to configure Pulse after LXC creation

## Issues Fixed
1. Users seeing confusing tar warnings about `LIBARCHIVE.xattr.com.apple.provenance`
2. Script incorrectly prompting for Proxmox credentials during LXC creation

## Correct Workflow
The proper workflow is now:
1. Community script creates LXC and installs Pulse (with detailed .env.example already included)
2. User enters LXC and manually copies `.env.example` to `.env` 
3. User edits `.env` file with their Proxmox credentials using the detailed examples/comments
4. User starts the pulse-monitor service when ready

## Benefits
- Users get the full detailed `.env.example` from the release with all configuration options and helpful comments
- No interactive prompts during automated LXC creation
- Follows standard community script patterns
- Service is enabled but not started until user completes configuration

## Test Plan
- [x] Verified tar extraction works without warnings
- [x] Confirmed LXC creation completes without prompts  
- [x] Verified detailed .env.example is included from release tarball
- [x] Tested service can be enabled without .env file present

## Files Changed
- `ct/pulse.sh` - Added stderr redirection for tar command
- `install/pulse-install.sh` - Removed interactive prompts, use existing .env.example, updated service config

🤖 Generated with [Claude Code](https://claude.ai/code)