### PR TITLE
make Pulse installation non-interactive

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -23,7 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -d /opt/pulse-proxmox ]]; then
+  if [[ ! -d /opt/pulse ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
@@ -34,25 +34,18 @@ function update_script() {
     msg_ok "Stopped ${APP}"
 
     msg_info "Updating Pulse"
-    if [[ -f /opt/pulse-proxmox/.env ]]; then
-      cp /opt/pulse-proxmox/.env /tmp/.env.backup.pulse
-    fi
     temp_file=$(mktemp)
-    mkdir -p /opt/pulse-proxmox
-    rm -rf /opt/pulse-proxmox/*
+    mkdir -p /opt/pulse
+    rm -rf /opt/pulse/*
     curl -fsSL "https://github.com/rcourtman/Pulse/releases/download/v${RELEASE}/pulse-v${RELEASE}.tar.gz" -o "$temp_file"
-    tar zxf "$temp_file" --strip-components=1 -C /opt/pulse-proxmox
-    if [[ -f /tmp/.env.backup.pulse ]]; then
-      mv /tmp/.env.backup.pulse /opt/pulse-proxmox/.env
-    fi
+    tar zxf "$temp_file" --strip-components=1 -C /opt/pulse
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated Pulse to ${RELEASE}"
 
-    msg_info "Setting permissions for /opt/pulse-proxmox..."
-    chown -R pulse:pulse "/opt/pulse-proxmox"
-    find "/opt/pulse-proxmox" -type d -exec chmod 755 {} \;
-    find "/opt/pulse-proxmox" -type f -exec chmod 644 {} \;
-    chmod 600 /opt/pulse-proxmox/.env
+    msg_info "Setting permissions for /opt/pulse..."
+    chown -R pulse:pulse "/opt/pulse"
+    find "/opt/pulse" -type d -exec chmod 755 {} \;
+    find "/opt/pulse" -type f -exec chmod 644 {} \;
     msg_ok "Set permissions."
 
     msg_info "Starting ${APP}"

--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2025 community-scripts ORG
 # Author: rcourtman
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
@@ -27,10 +27,14 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  if [[ -d /opt/pulse-monitor ]]; then
+  msg_error "An old installation was detected. Please recreate the LXC from scratch (https://github.com/community-scripts/ProxmoxVE/pull/4848)"
+  exit 1
+  fi
   RELEASE=$(curl -fsSL https://api.github.com/repos/rcourtman/Pulse/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
   if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
     msg_info "Stopping ${APP}"
-    systemctl stop pulse-monitor
+    systemctl stop pulse
     msg_ok "Stopped ${APP}"
 
     msg_info "Updating Pulse"
@@ -49,7 +53,7 @@ function update_script() {
     msg_ok "Set permissions."
 
     msg_info "Starting ${APP}"
-    systemctl start pulse-monitor
+    systemctl start pulse
     msg_ok "Started ${APP}"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}."

--- a/frontend/public/json/pulse.json
+++ b/frontend/public/json/pulse.json
@@ -12,7 +12,7 @@
   "documentation": null,
   "website": "https://github.com/rcourtman/Pulse",
   "logo": "https://raw.githubusercontent.com/rcourtman/Pulse/main/src/public/logos/pulse-logo-256x256.png",
-  "config_path": "/opt/pulse-proxmox/.env",
+  "config_path": "/opt/pulse/.env",
   "description": "A lightweight monitoring application for Proxmox VE that displays real-time status for VMs and containers via a simple web interface.",
   "install_methods": [
     {
@@ -34,6 +34,10 @@
   "notes": [
     {
       "text": "Create Proxmox-API-Token first: `https://github.com/rcourtman/Pulse?tab=readme-ov-file#creating-a-proxmox-api-token`",
+      "type": "Info"
+    },
+    {
+      "text": "After installation, access the web interface to configure your Proxmox connection details through the built-in setup wizard",
       "type": "Info"
     }
   ]

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -32,32 +32,17 @@ NODE_VERSION="20" install_node_and_modules
 msg_info "Setup Pulse"
 RELEASE=$(curl -fsSL https://api.github.com/repos/rcourtman/Pulse/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
 temp_file=$(mktemp)
-mkdir -p /opt/pulse-proxmox
+mkdir -p /opt/pulse
 curl -fsSL "https://github.com/rcourtman/Pulse/releases/download/v${RELEASE}/pulse-v${RELEASE}.tar.gz" -o "$temp_file"
-tar zxf "$temp_file" --strip-components=1 -C /opt/pulse-proxmox
+tar zxf "$temp_file" --strip-components=1 -C /opt/pulse
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Installed Pulse"
 
-read -rp "${TAB3}Proxmox Host (z. B. https://proxmox.example.com:8006): " PROXMOX_HOST
-read -rp "${TAB3}Proxmox Token ID (z. B. user@pam!mytoken): " PROXMOX_TOKEN_ID
-read -rp "${TAB3}Proxmox Token Secret: " PROXMOX_TOKEN_SECRET
-read -rp "${TAB3}Port (default: 7655): " PORT
-PORT="${PORT:-7655}"
 
-msg_info "Creating .env file"
-cat <<EOF >/opt/pulse-proxmox/.env
-PROXMOX_HOST=${PROXMOX_HOST}
-PROXMOX_TOKEN_ID=${PROXMOX_TOKEN_ID}
-PROXMOX_TOKEN_SECRET=${PROXMOX_TOKEN_SECRET}
-PORT=${PORT}
-EOF
-msg_ok "Created .env file"
-
-msg_info "Setting permissions for /opt/pulse-proxmox..."
-chown -R pulse:pulse "/opt/pulse-proxmox"
-find "/opt/pulse-proxmox" -type d -exec chmod 755 {} \;
-find "/opt/pulse-proxmox" -type f -exec chmod 644 {} \;
-chmod 600 /opt/pulse-proxmox/.env
+msg_info "Setting permissions for /opt/pulse..."
+chown -R pulse:pulse "/opt/pulse"
+find "/opt/pulse" -type d -exec chmod 755 {} \;
+find "/opt/pulse" -type f -exec chmod 644 {} \;
 msg_ok "Set permissions."
 
 msg_info "Creating Service"
@@ -70,8 +55,8 @@ After=network.target
 Type=simple
 User=pulse
 Group=pulse
-WorkingDirectory=/opt/pulse-proxmox
-EnvironmentFile=/opt/pulse-proxmox/.env
+WorkingDirectory=/opt/pulse
+EnvironmentFile=/opt/pulse/.env
 ExecStart=/usr/bin/npm run start
 Restart=on-failure
 RestartSec=5
@@ -86,6 +71,7 @@ msg_ok "Created Service"
 
 motd_ssh
 customize
+
 
 msg_info "Cleaning up"
 rm -f "$temp_file"

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -17,7 +17,7 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
   diffutils
-msg_ok "Installed Core Dependencies"
+msg_ok "Installed Dependencies"
 
 msg_info "Creating dedicated user pulse..."
 if useradd -r -m -d /opt/pulse-home -s /bin/bash pulse; then
@@ -46,7 +46,7 @@ find "/opt/pulse" -type f -exec chmod 644 {} \;
 msg_ok "Set permissions."
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/pulse-monitor.service
+cat <<EOF >/etc/systemd/system/pulse.service
 [Unit]
 Description=Pulse Monitoring Application
 After=network.target
@@ -66,12 +66,11 @@ StandardError=journal
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now pulse-monitor
+systemctl enable -q --now pulse
 msg_ok "Created Service"
 
 motd_ssh
 customize
-
 
 msg_info "Cleaning up"
 rm -f "$temp_file"


### PR DESCRIPTION
## Description
Streamline Pulse installation to leverage its new web-based configuration system, removing all interactive prompts and manual configuration steps.

**Related PR/Issue**: #4827 (previous discussion about making Pulse non-interactive)

## Prerequisites
- [x] **Self-review** – The code follows the project standards
- [x] **Tested** – Changes work as expected (removes prompts, uses web config)
- [x] **No security risks** – No hardcoded secrets or permission issues

## Type of Change
- [x] 🐞 **Bug fix** – Resolves the issue of interactive prompts during LXC creation
- [x] ✨ **New feature** – Leverages Pulse's web-based configuration system
- [x] 🌍 **Website update** – Updates JSON note to reflect new configuration method
- [x] 🔧 **Refactoring / Code Cleanup** – Simplifies installation process

## Changes Made
1. **Removed all interactive prompts** - Installation runs completely unattended
2. **Removed .env setup** - No longer needed as Pulse handles configuration through web UI
3. **Removed configuration messages** - Users configure through the web interface
4. **Changed install directory** - From `/opt/pulse-proxmox` to `/opt/pulse` for cleaner paths
5. **Updated JSON note** - Now mentions web-based setup wizard instead of manual .env editing

## Context
Pulse v3.13.0+ features a complete web-based configuration system with automatic setup detection. When users navigate to the URL after installation, Pulse automatically shows a setup wizard for entering Proxmox credentials. No SSH or manual file editing required.

This provides the ideal community script experience - completely hands-off installation with all configuration handled through the modern web interface.