### PR TITLE
Update add-tailscale-lxc.sh

### DIFF
--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -62,7 +62,7 @@ msg "Installing Tailscale..."
 pct exec "$CTID" -- bash -c '
 ID=$(grep "^ID=" /etc/os-release | cut -d"=" -f2)
 VER=$(grep "^VERSION_CODENAME=" /etc/os-release | cut -d"=" -f2)
-curl -fsSL https://pkgs.tailscale.com/stable/$ID/$VER.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+wget -q -O - --no-check-certificate https://pkgs.tailscale.com/stable/$ID/$VER.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
 echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/$ID $VER main" >/etc/apt/sources.list.d/tailscale.list
 apt-get update &>/dev/null
 apt-get install -y tailscale &>/dev/null


### PR DESCRIPTION
Replaced curl call with equivalent wget command as latest Debian 12 LXC template (debian-12-standard_12.7-1_amd64.tar.zst) available on PVE 8.4.1 does not ship with curl.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

curl command is failing when using latest debian-12-standard_12.7-1_amd64.tar.zst LXC template on PVE 8.4.1. This PR replaces curl with an equivalent wget call. Tested on a new LXC build.

Tested by removing old .gpg keyring and running `apt update` and getting the expected failure. Then ran wget command and again ran `apt update` with success:

```
root@tailscale01:~# rm /usr/share/keyrings/tailscale-archive-keyring.gpg
root@tailscale01:~#
root@tailscale01:~# apt update
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://security.debian.org bookworm-security InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Get:4 https://pkgs.tailscale.com/stable/debian bookworm InRelease
Err:4 https://pkgs.tailscale.com/stable/debian bookworm InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 458CA832957F5868
Fetched 6581 B in 1s (6429 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
72 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://pkgs.tailscale.com/stable/debian bookworm InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 458CA832957F5868
W: Failed to fetch https://pkgs.tailscale.com/stable/debian/dists/bookworm/InRelease  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 458CA832957F5868
W: Some index files failed to download. They have been ignored, or old ones used instead.
root@tailscale01:~#
root@tailscale01:~#
root@tailscale01:~# wget -q -O - --no-check-certificate https://pkgs.tailscale.com/stable/$ID/$VER.noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
root@tailscale01:~# apt update
Hit:1 http://security.debian.org bookworm-security InRelease
Hit:2 http://deb.debian.org/debian bookworm InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Get:4 https://pkgs.tailscale.com/stable/debian bookworm InRelease
Fetched 6581 B in 1s (6701 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
72 packages can be upgraded. Run 'apt list --upgradable' to see them.
root@tailscale01:~#
```

All templates come with wget so should be no issue moving forward.

## 🔗 Related PR / Issue  
Link: #

https://github.com/community-scripts/ProxmoxVE/issues/4863

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
