### PR TITLE
Display default password even if there isn't a default username

### DIFF
--- a/frontend/src/app/scripts/_components/ScriptItems/DefaultPassword.tsx
+++ b/frontend/src/app/scripts/_components/ScriptItems/DefaultPassword.tsx
@@ -5,7 +5,7 @@ import { Script } from "@/lib/types";
 
 export default function DefaultPassword({ item }: { item: Script }) {
   const { username, password } = item.default_credentials;
-  const hasDefaultLogin = username && password;
+  const hasDefaultLogin = username || password;
 
   if (!hasDefaultLogin) return null;
 
@@ -23,14 +23,17 @@ export default function DefaultPassword({ item }: { item: Script }) {
         <p className="mb-2 text-sm">
           You can use the following credentials to login to the {item.name} {item.type}.
         </p>
-        {["username", "password"].map((type) => (
-          <div key={type} className="text-sm">
-            {type.charAt(0).toUpperCase() + type.slice(1)}:{" "}
-            <Button variant="secondary" size="null" onClick={() => copyCredential(type as "username" | "password")}>
-              {item.default_credentials[type as "username" | "password"]}
-            </Button>
-          </div>
-        ))}
+        {["username", "password"].map((type) => {
+          const value = item.default_credentials[type as "username" | "password"];
+          return value && value.trim() !== "" ? (
+            <div key={type} className="text-sm">
+              {type.charAt(0).toUpperCase() + type.slice(1)}:{" "}
+              <Button variant="secondary" size="null" onClick={() => copyCredential(type as "username" | "password")}>
+                {value}
+              </Button>
+            </div>
+          ) : null;
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## ✍️ Description  

Display the default credentials even if there is only a username *or* a password, rather than requiring both. This fixes the display of the Deluge install script.

Before:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/360b967a-7429-4f93-8b60-86a208b7ed54" />

After:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1675d38c-e4f9-4db8-a5fd-ad918b14d50d" />

## 🔗 Related PR / Issue  
N/A


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
