### PR TITLE
Pulse: add polkit for sudoless web updates

### DIFF
--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -16,7 +16,8 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  diffutils
+  diffutils \
+  policykit-1
 msg_ok "Installed Dependencies"
 
 msg_info "Creating dedicated user pulse..."


### PR DESCRIPTION
## Summary
Adds policykit-1 to enable sudoless updates through Pulse's web interface.

Currently, web updates fail during service restart in LXC containers due to missing polkit.
This small addition enables seamless one-click updates without manual SSH intervention.

## Changes
- Adds `policykit-1` to dependency installation
- Enables Pulse's built-in sudoless update system
- Improves user experience for web-based updates
- Minimal size impact (~1.4MB)

## Test plan
- [x] Verify installation completes successfully with new dependency
- [x] Test web-based updates work without sudo prompts
- [x] Confirm service restarts properly during updates

🤖 Generated with [Claude Code](https://claude.ai/code)