### PR TITLE
Fix clean-lxcs.sh type categorization

### DIFF
--- a/frontend/public/json/clean-lxcs.json
+++ b/frontend/public/json/clean-lxcs.json
@@ -5,7 +5,7 @@
     1
   ],
   "date_created": "2024-04-29",
-  "type": "addon",
+  "type": "pve",
   "updateable": false,
   "privileged": false,
   "interface_port": null,


### PR DESCRIPTION
## ✍️ Description  

`clean-lxcs.sh` was tagged as an `addon` rather than `pve` causing the links Source Code button to 404 at https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/tools/addon/clean-lxcs.sh rather than to the expected https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/tools/pve/clean-lxcs.sh

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
