### PR TITLE
zipline: fix old upload copy from v3 to v4

### DIFF
--- a/ct/zipline.sh
+++ b/ct/zipline.sh
@@ -41,7 +41,9 @@ function update_script() {
     msg_info "Updating ${APP} to ${RELEASE}"
     cp /opt/zipline/.env /opt/
     mkdir -p /opt/zipline-upload
-    cp -R /opt/zipline/upload/* /opt/zipline-upload/
+    if [ -d /opt/zipline/upload ] && [ "$(ls -A /opt/zipline/upload)" ]; then
+      cp -R /opt/zipline/upload/* /opt/zipline-upload/
+    fi
     curl -fsSL "https://github.com/diced/zipline/archive/refs/tags/v${RELEASE}.zip" -o $(basename "https://github.com/diced/zipline/archive/refs/tags/v${RELEASE}.zip")
     $STD unzip v"${RELEASE}".zip
     rm -R /opt/zipline

--- a/install/zipline-install.sh
+++ b/install/zipline-install.sh
@@ -78,6 +78,7 @@ msg_ok "Created Service"
 motd_ssh
 customize
 msg_info "Cleaning up"
+rm -f /opt/v${RELEASE}.zip
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
check if old folder (v3) exist, if yes, copy files to new folder, if not, ignore

'+ remove install zip after initial install

## 🔗 Related PR / Issue  
Link: #5013


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
