### PR TITLE
Zigbee2MQTT: Fix missing directory

### DIFF
--- a/install/alpine-zigbee2mqtt-install.sh
+++ b/install/alpine-zigbee2mqtt-install.sh
@@ -14,8 +14,8 @@ network_check
 update_os
 
 msg_info "Installing Alpine-Zigbee2MQTT"
+mkdir -p /root/.z2m /etc/zigbee2mqtt
 $STD apk add zigbee2mqtt
-mkdir -p /root/.z2m
 ln -s /etc/zigbee2mqtt/ /root/.z2m
 chown -R root:root /etc/zigbee2mqtt /root/.z2m
 sed -i -e 's/#datadir="\/var\/lib\/zigbee2mqtt"/datadir="\/etc\/zigbee2mqtt"/' -e 's/#command_user="zigbee2mqtt"/command_user="root"/' /etc/conf.d/zigbee2mqtt


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- For some reason `/etc/zigbee2mqtt` directory is not created during apk installation, making `chown` to fail. Fixed now


## 🔗 Related PR / Issue  
Link: #5118 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
