### PR TITLE
[core]: Feature - Check Quorum Status in create_lxc to prevent issues

### DIFF
--- a/.github/CONTRIBUTOR_AND_GUIDES/CODE-AUDIT.md
+++ b/.github/CONTRIBUTOR_AND_GUIDES/CODE-AUDIT.md
@@ -5,10 +5,10 @@
 
 1) [adguard.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/ct/adguard.sh): This script collects system parameters. (Also holds the function to update the application.)
 2) [build.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/build.func): Adds user settings and integrates collected information.
-3) [create_lxc.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/ct/create_lxc.sh): Constructs the LXC container.
+3) [create_lxc.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/create_lxc.sh): Constructs the LXC container.
 4) [adguard-install.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/install/adguard-install.sh): Executes functions from [install.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/install.func), and installs the application.
 5) [adguard.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/ct/adguard.sh) (again): To display the completion message.
 
-The installation process uses reusable scripts: [build.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/build.func), [create_lxc.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/ct/create_lxc.sh), and [install.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/install.func), which are not specific to any particular application.
+The installation process uses reusable scripts: [build.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/build.func), [create_lxc.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/create_lxc.sh), and [install.func](https://github.com/community-scripts/ProxmoxVE/blob/main/misc/install.func), which are not specific to any particular application.
 
 To gain a better understanding, focus on reviewing [adguard-install.sh](https://github.com/community-scripts/ProxmoxVE/blob/main/install/adguard-install.sh). This script contains the commands and configurations for installing and configuring AdGuard Home within the LXC container.

--- a/.github/autolabeler-config.json
+++ b/.github/autolabeler-config.json
@@ -2,21 +2,43 @@
   "new script": [
     {
       "fileStatus": "added",
-      "includeGlobs": ["ct/**", "install/**", "misc/**", "turnkey/**", "vm/**"],
+      "includeGlobs": [
+        "ct/**",
+        "install/**",
+        "misc/**",
+        "turnkey/**",
+        "vm/**"
+      ],
       "excludeGlobs": []
     }
   ],
   "update script": [
     {
       "fileStatus": "modified",
-      "includeGlobs": ["ct/**", "install/**", "misc/**", "turnkey/**", "vm/**"],
-      "excludeGlobs": ["misc/build.func", "misc/install.func", "misc/api.func"]
+      "includeGlobs": [
+        "ct/**",
+        "install/**",
+        "misc/**",
+        "turnkey/**",
+        "vm/**"
+      ],
+      "excludeGlobs": [
+        "misc/build.func",
+        "misc/install.func",
+        "misc/api.func"
+      ]
     }
   ],
   "delete script": [
     {
       "fileStatus": "removed",
-      "includeGlobs": ["ct/**", "install/**", "misc/**", "turnkey/**", "vm/**"],
+      "includeGlobs": [
+        "ct/**",
+        "install/**",
+        "misc/**",
+        "turnkey/**",
+        "vm/**"
+      ],
       "excludeGlobs": []
     }
   ],
@@ -27,7 +49,7 @@
         "*.md",
         ".github/**",
         "misc/*.func",
-        "ct/create_lxc.sh",
+        "misc/create_lxc.sh",
         "api/**"
       ],
       "excludeGlobs": []
@@ -36,46 +58,57 @@
   "core": [
     {
       "fileStatus": null,
-      "includeGlobs": ["misc/*.func", "ct/create_lxc.sh"],
+      "includeGlobs": [
+        "misc/*.func",
+        "misc/create_lxc.sh"
+      ],
       "excludeGlobs": []
     }
   ],
   "website": [
     {
       "fileStatus": null,
-      "includeGlobs": ["frontend/**"],
+      "includeGlobs": [
+        "frontend/**"
+      ],
       "excludeGlobs": []
     }
   ],
   "api": [
     {
       "fileStatus": null,
-      "includeGlobs": ["api/**", "misc/api.func"],
+      "includeGlobs": [
+        "api/**",
+        "misc/api.func"
+      ],
       "excludeGlobs": []
     }
   ],
   "github": [
     {
       "fileStatus": null,
-      "includeGlobs": [".github/**"],
+      "includeGlobs": [
+        ".github/**"
+      ],
       "excludeGlobs": []
     }
   ],
   "json": [
     {
       "fileStatus": "modified",
-      "includeGlobs": ["frontend/public/json/**"],
+      "includeGlobs": [
+        "frontend/public/json/**"
+      ],
       "excludeGlobs": []
     }
   ],
-
   "high risk": [
     {
       "fileStatus": null,
       "includeGlobs": [
         "misc/build.func",
         "misc/install.func",
-        "ct/create_lxc.sh"
+        "misc/create_lxc.sh"
       ],
       "excludeGlobs": []
     }
@@ -83,7 +116,9 @@
   "documentation": [
     {
       "fileStatus": null,
-      "includeGlobs": ["*.md"],
+      "includeGlobs": [
+        "*.md"
+      ],
       "excludeGlobs": []
     }
   ]

--- a/.github/workflows/validate-filenames.yml
+++ b/.github/workflows/validate-filenames.yml
@@ -51,8 +51,8 @@ jobs:
 
           NON_COMPLIANT_FILES=""
           for FILE in $CHANGED_FILES; do
-            # Datei "ct/create_lxc.sh" explizit überspringen
-            if [[ "$FILE" == "ct/create_lxc.sh" ]]; then
+            # Skip File "misc/create_lxc.sh"
+            if [[ "$FILE" == "misc/create_lxc.sh" ]]; then
               continue
             fi
             BASENAME=$(echo "$(basename "${FILE%.*}")")

--- a/misc/build.func
+++ b/misc/build.func
@@ -1124,7 +1124,7 @@ build_container() {
     $PW
   "
   # This executes create_lxc.sh and creates the container and .conf file
-  bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/create_lxc.sh)" $?
+  bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/create_lxc.sh)" $?
 
   LXC_CONFIG=/etc/pve/lxc/${CTID}.conf
   if [ "$CT_TYPE" == "0" ]; then

--- a/misc/create_lxc.sh
+++ b/misc/create_lxc.sh
@@ -207,6 +207,17 @@ msg_ok "Using ${BL}$TEMPLATE_STORAGE${CL} ${GN}for Template Storage."
 CONTAINER_STORAGE=$(select_storage container)
 msg_ok "Using ${BL}$CONTAINER_STORAGE${CL} ${GN}for Container Storage."
 
+# Check Cluster Quorum if in Cluster
+if [ -f /etc/pve/corosync.conf ]; then
+  msg_info "Checking Proxmox cluster quorum status"
+  if ! pvecm status | awk -F':' '/^Quorate/ { exit ($2 ~ /Yes/) ? 0 : 1 }'; then
+    printf "\e[?25h"
+    msg_error "Cluster is not quorate. Start all nodes or configure quorum device (QDevice)."
+    exit 210
+  fi
+  msg_ok "Cluster is quorate"
+fi
+
 # Update LXC template list
 msg_info "Updating LXC Template List"
 #check_network


### PR DESCRIPTION
## ✍️ Description  
In a Proxmox VE cluster, it is not allowed to make changes to the cluster configuration (such as creating a CT or VM) if the cluster is not “quorate”. This means: If the cluster does not reach a quorum (e.g. with a 2-node cluster and only one node is online), actions such as pct create, qm create, etc. are not allowed - even if you are directly on the working node.

In the same stage, i move "create_lxc" from ct-Folder to misc-Folder

Related to this:
=> https://github.com/community-scripts/ProxmoxVE/discussions/5245

if an cluster (node) is offline, create_lxc failed, because proxmox need an quorum for clusters.
[ERROR] in line 1127 #5169 
=> User-Feedback: https://github.com/community-scripts/ProxmoxVE/discussions/5169#discussioncomment-13517784


Output:
![image](https://github.com/user-attachments/assets/10eddaff-421a-4f71-9d99-2cb6f0556acf)


## 🔗 Related PR / Issue  
Link: #5169 #5245


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
