### PR TITLE
gitea: Update gitea.sh to stop update failures

### DIFF
--- a/ct/gitea.sh
+++ b/ct/gitea.sh
@@ -29,10 +29,11 @@ function update_script() {
    fi
    RELEASE=$(curl -fsSL https://github.com/go-gitea/gitea/releases/latest | grep "title>Release" | cut -d " " -f 4 | sed 's/^v//')
    msg_info "Updating $APP to ${RELEASE}"
-   curl -fsSL "https://github.com/go-gitea/gitea/releases/download/v$RELEASE/gitea-$RELEASE-linux-amd64" -o $(basename "https://github.com/go-gitea/gitea/releases/download/v$RELEASE/gitea-$RELEASE-linux-amd64")
+   FILENAME="gitea-$RELEASE-linux-amd64"
+   curl -fsSL "https://github.com/go-gitea/gitea/releases/download/v$RELEASE/gitea-$RELEASE-linux-amd64" -o $FILENAME
    systemctl stop gitea
    rm -rf /usr/local/bin/gitea
-   mv gitea* /usr/local/bin/gitea
+   mv $FILENAME /usr/local/bin/gitea
    chmod +x /usr/local/bin/gitea
    systemctl start gitea
    msg_ok "Updated $APP Successfully"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

When updating gitea using the update command on Debian 12, if you have any other files or directories starting with the name gitea it will fail.

This update will make it use a set file name for the output and mv operation which resolves the issue.

To replicate the issue, create a directory like `gitea-dump` or similar, try to run the update script, and check for the failure mentioned in the below issue.


## 🔗 Related PR / Issue  
Link: #3590


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
