### PR TITLE
bump scripts (Installer) from Ubuntu 22.04 to Ubuntu 24.04 (agentdvr, emby, jellyfin, plex, shinobi)

### DIFF
--- a/ct/agentdvr.sh
+++ b/ct/agentdvr.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-22.04}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-0}"
 
 header_info "$APP"
@@ -20,15 +20,15 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/agentdvr ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    msg_error "Currently we don't provide an update function for this ${APP}."
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/agentdvr ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  msg_error "Currently we don't provide an update function for this ${APP}."
+  exit
 }
 
 start

--- a/ct/emby.sh
+++ b/ct/emby.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-22.04}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-22.04}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -20,19 +20,19 @@ color
 catch_errors
 
 function update_script() {
-     header_info
-     check_container_storage
-     check_container_resources
-     if [[ ! -d /usr/lib/jellyfin ]]; then
-          msg_error "No ${APP} Installation Found!"
-          exit
-     fi
-     msg_info "Updating ${APP} LXC"
-     $STD apt-get update
-     $STD apt-get -y upgrade
-     $STD apt-get -y --with-new-pkgs upgrade jellyfin jellyfin-server
-     msg_ok "Updated ${APP} LXC"
-     exit
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /usr/lib/jellyfin ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+  msg_info "Updating ${APP} LXC"
+  $STD apt-get update
+  $STD apt-get -y upgrade
+  $STD apt-get -y --with-new-pkgs upgrade jellyfin jellyfin-server
+  msg_ok "Updated ${APP} LXC"
+  exit
 }
 
 start

--- a/ct/plex.sh
+++ b/ct/plex.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-22.04}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/shinobi.sh
+++ b/ct/shinobi.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-22.04}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-0}"
 
 header_info "$APP"

--- a/frontend/public/json/agentdvr.json
+++ b/frontend/public/json/agentdvr.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "ubuntu",
-        "version": "22.04"
+        "version": "24.04"
       }
     }
   ],

--- a/frontend/public/json/emby.json
+++ b/frontend/public/json/emby.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "ubuntu",
-        "version": "22.04"
+        "version": "24.04"
       }
     }
   ],

--- a/frontend/public/json/jellyfin.json
+++ b/frontend/public/json/jellyfin.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "ubuntu",
-        "version": "22.04"
+        "version": "24.04"
       }
     }
   ],

--- a/frontend/public/json/plex.json
+++ b/frontend/public/json/plex.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "ubuntu",
-        "version": "22.04"
+        "version": "24.04"
       }
     }
   ],

--- a/frontend/public/json/shinobi.json
+++ b/frontend/public/json/shinobi.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "ubuntu",
-        "version": "22.04"
+        "version": "24.04"
       }
     }
   ],

--- a/frontend/public/json/ubuntu.json
+++ b/frontend/public/json/ubuntu.json
@@ -23,7 +23,7 @@
                 "ram": 512,
                 "hdd": 2,
                 "os": "ubuntu",
-                "version": "22.04"
+                "version": "24.04"
             }
         }
     ],


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- old installations still 22.04 and can be manually upgraded:
-> Guide: https://www.cyberciti.biz/faq/how-to-upgrade-from-ubuntu-22-04-lts-to-ubuntu-24-04-lts/

- new installations are now 24.04 LTS (expect sqlserver, that failed with 24.04, microsoft lol) 

## 🔗 Related PR / Issue  
Link: #5408


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
