### PR TITLE
Refactor CommandMenu to prevent duplicate scripts across categories

### DIFF
--- a/frontend/src/components/CommandMenu.tsx
+++ b/frontend/src/components/CommandMenu.tsx
@@ -134,34 +134,54 @@ export default function CommandMenu() {
         <CommandInput placeholder="Search for a script..." />
         <CommandList>
           <CommandEmpty>{isLoading ? "Loading..." : "No scripts found."}</CommandEmpty>
-          {links.map((category) => (
-            <CommandGroup key={`category:${category.name}`} heading={category.name}>
-              {category.scripts.map((script) => (
-                <CommandItem
-                  key={`script:${script.slug}`}
-                  value={`${script.slug}-${script.name}`}
-                  onSelect={() => {
-                    setOpen(false);
-                    router.push(`/scripts?id=${script.slug}`);
-                  }}
-                >
-                  <div className="flex gap-2" onClick={() => setOpen(false)}>
-                    <Image
-                      src={script.logo || `/${basePath}/logo.png`}
-                      onError={(e) => ((e.currentTarget as HTMLImageElement).src = `/${basePath}/logo.png`)}
-                      unoptimized
-                      width={16}
-                      height={16}
-                      alt=""
-                      className="h-5 w-5"
-                    />
-                    <span>{script.name}</span>
-                    <span>{formattedBadge(script.type)}</span>
-                  </div>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          ))}
+          {(() => {
+            // Track seen scripts globally to avoid duplicates across all categories
+            const globalSeenScripts = new Set<string>();
+            
+            return links.map((category) => {
+              const uniqueScripts = category.scripts.filter((script) => {
+                if (globalSeenScripts.has(script.slug)) {
+                  return false;
+                }
+                globalSeenScripts.add(script.slug);
+                return true;
+              });
+
+              // Only render category if it has unique scripts
+              if (uniqueScripts.length === 0) {
+                return null;
+              }
+
+              return (
+                <CommandGroup key={`category:${category.name}`} heading={category.name}>
+                  {uniqueScripts.map((script) => (
+                    <CommandItem
+                      key={`script:${script.slug}`}
+                      value={`${script.slug}-${script.name}`}
+                      onSelect={() => {
+                        setOpen(false);
+                        router.push(`/scripts?id=${script.slug}`);
+                      }}
+                    >
+                      <div className="flex gap-2" onClick={() => setOpen(false)}>
+                        <Image
+                          src={script.logo || `/${basePath}/logo.png`}
+                          onError={(e) => ((e.currentTarget as HTMLImageElement).src = `/${basePath}/logo.png`)}
+                          unoptimized
+                          width={16}
+                          height={16}
+                          alt=""
+                          className="h-5 w-5"
+                        />
+                        <span>{script.name}</span>
+                        <span>{formattedBadge(script.type)}</span>
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              );
+            });
+          })()}
         </CommandList>
       </CommandDialog>
     </>


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This pull request refines the `CommandMenu` component in `frontend/src/components/CommandMenu.tsx` to ensure that scripts are displayed without duplicates across categories. The changes introduce a mechanism to globally track seen scripts and only render categories containing unique scripts.

Enhancements to script rendering:

* [`frontend/src/components/CommandMenu.tsx`](diffhunk://#diff-fca568a5b1db55ee0757b5deace6840f1ca415a31eab55bdc32d6601d2e8a512L137-R157): Added logic to track scripts globally using a `Set` to prevent duplicates across categories. This ensures that only unique scripts are rendered within each category.
* [`frontend/src/components/CommandMenu.tsx`](diffhunk://#diff-fca568a5b1db55ee0757b5deace6840f1ca415a31eab55bdc32d6601d2e8a512L164-R184): Modified the rendering logic to conditionally display categories based on the presence of unique scripts, improving the clarity of the menu.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  

before:
![image](https://github.com/user-attachments/assets/ee24eb4f-dd08-4911-b203-0b8b803c788a)

after:
![image](https://github.com/user-attachments/assets/2602ee44-2168-41a1-8280-35c044fee2c6)
