### PR TITLE
Ollama: Clean up old Ollama files before running update

### DIFF
--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -38,6 +38,8 @@ function update_script() {
     TMP_TAR=$(mktemp --suffix=.tgz)
     curl -fL# -o "${TMP_TAR}" "https://github.com/ollama/ollama/releases/download/${RELEASE}/ollama-linux-amd64.tgz"
     msg_info "Updating Ollama to ${RELEASE}"
+    rm -rf /usr/local/lib/ollama
+    rm -rf /usr/local/bin/ollama
     tar -xzf "${TMP_TAR}" -C /usr/local/lib/ollama
     ln -sf /usr/local/lib/ollama/bin/ollama /usr/local/bin/ollama
     echo "${RELEASE}" >/opt/Ollama_version.txt

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -30,6 +30,8 @@ function update_script() {
 
   if [ -x "/usr/bin/ollama" ]; then
     msg_info "Updating Ollama"
+    rm -rf /usr/lib/ollama
+    rm -rf /usr/bin/ollama
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Apparently they moved some libraries around in newest update, so the proper way of updating is to clean up all traces of old Ollama version in the LXC. Fixed now
https://github.com/ollama/ollama/issues/11211#issuecomment-3014572069

## 🔗 Related PR / Issue  
Link: #5530 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
