### PR TITLE
Immich: make changes to automatically enable QuickSync

### DIFF
--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -84,6 +84,13 @@ $STD apt-get update
 $STD apt-get install -y jellyfin-ffmpeg7
 ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
 ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
+if [[ "$CTTYPE" == "0" ]]; then
+  chgrp video /dev/dri
+  chmod 755 /dev/dri
+  chmod 660 /dev/dri/*
+  $STD adduser "$(id -u -n)" video
+  $STD adduser "$(id -u -n)" render
+fi
 msg_ok "Dependencies Installed"
 
 read -r -p "Install OpenVINO dependencies for Intel HW-accelerated machine-learning? y/N " prompt
@@ -100,13 +107,6 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   $STD popd
   rm -rf "$tmp_dir"
   dpkg -l | grep "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
-  if [[ "$CTTYPE" == "0" ]]; then
-    chgrp video /dev/dri
-    chmod 755 /dev/dri
-    chmod 660 /dev/dri/*
-    $STD adduser "$(id -u -n)" video
-    $STD adduser "$(id -u -n)" render
-  fi
   msg_ok "Installed OpenVINO dependencies"
 fi
 
@@ -360,9 +360,8 @@ msg_ok "Installed ${APPLICATION}"
 
 msg_info "Creating user, env file, scripts & services"
 $STD useradd -U -s /usr/sbin/nologin -r -M -d "$INSTALL_DIR" immich
-if [[ -f ~/.openvino ]]; then
-  usermod -aG video,render immich
-fi
+usermod -aG video,render immich
+
 cat <<EOF >"${INSTALL_DIR}"/.env
 TZ=$(cat /etc/timezone)
 IMMICH_VERSION=release


### PR DESCRIPTION
## ✍️ Description  

- In previous versions of the script, transcoding was enabled only if you chose to enable OpenVINO
- Recently that was decoupled, but a couple of things were overlooked
- Now, even if you elect to not enable OpenVINO, the necessary permission and group changes will be made to the immich user (or the root user if choosing a privileged LXC) regardless.


## 🔗 Related PR / Issue  
Link: #5558 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
