### PR TITLE
Apache Guacamole: Install auth-jdbc component that matches release version

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -67,9 +67,9 @@ cd /root
 curl -fsSL "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.26.tar.gz" -o "/root/mysql-connector-java-8.0.26.tar.gz"
 $STD tar -xf ~/mysql-connector-java-8.0.26.tar.gz
 mv ~/mysql-connector-java-8.0.26/mysql-connector-java-8.0.26.jar /etc/guacamole/lib/
-curl -fsSL "https://downloads.apache.org/guacamole/1.5.5/binary/guacamole-auth-jdbc-1.5.5.tar.gz" -o "/root/guacamole-auth-jdbc-1.5.5.tar.gz"
-$STD tar -xf ~/guacamole-auth-jdbc-1.5.5.tar.gz
-mv ~/guacamole-auth-jdbc-1.5.5/mysql/guacamole-auth-jdbc-mysql-1.5.5.jar /etc/guacamole/extensions/
+curl -fsSL "https://downloads.apache.org/guacamole/${RELEASE_SERVER}/binary/guacamole-auth-jdbc-${RELEASE_SERVER}.tar.gz" -o "/root/guacamole-auth-jdbc-${RELEASE_SERVER}.tar.gz"
+$STD tar -xf ~/guacamole-auth-jdbc-$RELEASE_SERVER.tar.gz
+mv ~/guacamole-auth-jdbc-$RELEASE_SERVER/mysql/guacamole-auth-jdbc-mysql-$RELEASE_SERVER.jar /etc/guacamole/extensions/
 msg_ok "Setup Apache Guacamole"
 
 msg_info "Setup Database"
@@ -148,7 +148,7 @@ customize
 
 msg_info "Cleaning up"
 rm -rf ~/mysql-connector-java-8.0.26{,.tar.gz}
-rm -rf ~/guacamole-auth-jdbc-1.5.5{,.tar.gz}
+rm -rf ~/guacamole-auth-jdbc-$RELEASE_SERVER{,.tar.gz}
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean
 msg_ok "Cleaned"

--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -64,9 +64,9 @@ $STD ldconfig
 RELEASE_CLIENT=$(curl -fsSL https://api.github.com/repos/apache/guacamole-client/tags | jq -r '.[].name' | grep -v -- '-RC' | head -n 1)
 curl -fsSL "https://downloads.apache.org/guacamole/${RELEASE_CLIENT}/binary/guacamole-${RELEASE_CLIENT}.war" -o "/opt/apache-guacamole/tomcat9/webapps/guacamole.war"
 cd /root
-curl -fsSL "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.26.tar.gz" -o "/root/mysql-connector-java-8.0.26.tar.gz"
-$STD tar -xf ~/mysql-connector-java-8.0.26.tar.gz
-mv ~/mysql-connector-java-8.0.26/mysql-connector-java-8.0.26.jar /etc/guacamole/lib/
+curl -fsSL "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-j-9.3.0.tar.gz" -o "/root/mysql-connector-j-9.3.0.tar.gz"
+$STD tar -xf ~/mysql-connector-j-9.3.0.tar.gz
+mv ~/mysql-connector-j-9.3.0.tar.gz/mysql-connector-j-9.3.0.tar.gz /etc/guacamole/lib/
 curl -fsSL "https://downloads.apache.org/guacamole/${RELEASE_SERVER}/binary/guacamole-auth-jdbc-${RELEASE_SERVER}.tar.gz" -o "/root/guacamole-auth-jdbc-${RELEASE_SERVER}.tar.gz"
 $STD tar -xf ~/guacamole-auth-jdbc-$RELEASE_SERVER.tar.gz
 mv ~/guacamole-auth-jdbc-$RELEASE_SERVER/mysql/guacamole-auth-jdbc-mysql-$RELEASE_SERVER.jar /etc/guacamole/extensions/
@@ -147,7 +147,7 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-rm -rf ~/mysql-connector-java-8.0.26{,.tar.gz}
+rm -rf ~/mysql-connector-j-9.3.0{,.tar.gz}
 rm -rf ~/guacamole-auth-jdbc-$RELEASE_SERVER{,.tar.gz}
 $STD apt-get -y autoremove
 $STD apt-get -y autoclean


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Script now installs the auth-jdbc component that matches release version


## 🔗 Related PR / Issue  
Link: #5479 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
