### PR TITLE
Apache Guacamole: Fix typo in install script

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -85,7 +85,7 @@ $STD mariadb -u root -e "GRANT ALL ON $DB_NAME.* TO '$DB_USER'@'localhost'; FLUS
   echo "Database Password: $DB_PASS"
   echo "Database Name: $DB_NAME"
 } >>~/guacamole.creds
-cd guacamole-auth-jdbc-1.5.5/mysql/schema
+cd guacamole-auth-jdbc-${RELEASE_SERVER}/mysql/schema
 cat *.sql | mariadb -u root ${DB_NAME}
 {
   echo "mysql-hostname: 127.0.0.1"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- When switching to newest release, one reference to v1.5.5 remained in the install script. Fixed now


## 🔗 Related PR / Issue  
Link: #5479 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
