### PR TITLE
tools.func: optimize binary installs with fetch_and_deploy helper

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -834,19 +834,30 @@ function fetch_and_deploy_gh_release() {
   elif [[ "$mode" == "binary" ]]; then
     local arch
     arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
-    [[ "$arch" == "x86_64" ]] && arch="x86_64"
+    [[ "$arch" == "x86_64" ]] && arch="amd64"
     [[ "$arch" == "aarch64" ]] && arch="arm64"
 
     local assets url_match=""
     assets=$(echo "$json" | jq -r '.assets[].browser_download_url')
 
-    for u in $assets; do
-      if [[ "$u" =~ ($arch|amd64|x86_64|aarch64|arm64).*\.deb$ ]]; then
-        url_match="$u"
-        break
-      fi
-    done
+    # If explicit filename pattern is provided (param $6), match that first
+    if [[ -n "$6" ]]; then
+      for u in $assets; do
+        [[ "$u" =~ $6 || "$u" == *"$6" ]] && url_match="$u" && break
+      done
+    fi
 
+    # If no match via explicit pattern, fall back to architecture heuristic
+    if [[ -z "$url_match" ]]; then
+      for u in $assets; do
+        if [[ "$u" =~ ($arch|amd64|x86_64|aarch64|arm64).*\.deb$ ]]; then
+          url_match="$u"
+          break
+        fi
+      done
+    fi
+
+    # Fallback: any .deb file
     if [[ -z "$url_match" ]]; then
       for u in $assets; do
         [[ "$u" =~ \.deb$ ]] && url_match="$u" && break


### PR DESCRIPTION
## ✍️ Description  
This patch extends fetch_and_deploy_gh_release() to support an optional 6th parameter (asset filename pattern) in binary mode. If provided, it prioritizes this filename over architecture heuristics to select the correct .deb asset.

**Changes:**
- Added matching logic for $6 in binary mode (optional asset name)
- Retains existing arch-based and fallback heuristics


=> needed for Librespeed-Rust from VED


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
