### PR TITLE
Jellyfin GPU Passthrough NVIDIA Note

### DIFF
--- a/frontend/public/json/jellyfin.json
+++ b/frontend/public/json/jellyfin.json
@@ -39,6 +39,10 @@
     {
       "text": "FFmpeg path: /usr/lib/jellyfin-ffmpeg/ffmpeg",
       "type": "info"
+    },
+     {
+      "text": "For NVIDIA graphics cards, you'll need to install the same drivers in the container that you did on the host. In the container, run the driver installation script and add the CLI arg --no-kernel-module",
+      "type": "info"
     }
   ]
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Adds a note to Jellyfin script installation when using nvidia graphics cards.

While the Jellyfin script handles the PCI passthrough and ID mappings correctly, the container still requires the same graphics drivers be present in the container that are also on the host. This PR adds an explicit call out to do so after script completion with the CLI arg that allows it to occur.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
