### PR TITLE
MySQL phpMyAdmin Access Information

### DIFF
--- a/frontend/public/json/mysql.json
+++ b/frontend/public/json/mysql.json
@@ -41,7 +41,7 @@
             "type": "info"
         },
         {
-            "text": "With an option to install phpMyAdmin. If installed, URL is case sensitive - {$containerIpAddress}/phpMyAdmin",
+            "text": "If installed, access phpMyAdmin at `http://<LXC_IP>/phpMyAdmin`, case sensitive.",
             "type": "info"
         }
     ]

--- a/frontend/public/json/mysql.json
+++ b/frontend/public/json/mysql.json
@@ -39,6 +39,10 @@
         {
             "text": "With an option to install the MySQL 8.4 LTS release instead of MySQL 8.0",
             "type": "info"
+        },
+        {
+            "text": "With an option to install phpMyAdmin. If installed, URL is case sensitive - {$containerIpAddress}/phpMyAdmin",
+            "type": "info"
         }
     ]
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This PR updates the front-end MySQL CT page to include an information section about the installation of phpMyAdmin along MySQL. The MySQL install script includes a question that optionally allows for phpMyAdmin + apache to be installed. The script does not print out the URL to access phpMyAdmin, however, it is case sensitive. Added an info banner to make it easily accessible to the installing user.

[Link](https://github.com/community-scripts/ProxmoxVE/blob/main/install/mysql-install.sh#L66) to script Apache directory setup.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
