### PR TITLE
Fix update script for Mafl: ensure directory is removed recursively

### DIFF
--- a/ct/mafl.sh
+++ b/ct/mafl.sh
@@ -37,7 +37,7 @@ function update_script() {
     msg_info "Performing backup"
     mkdir -p /opt/mafl-backup/data
     mv /opt/mafl/data /opt/mafl-backup/data
-    rm /opt/mafl
+    rm -rf /opt/mafl
     msg_ok "Backup complete"
     
     fetch_and_deploy_gh_release "mafl" "hywax/mafl"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This fixes an issue where the mafl update script fails with `rm: cannot remove '/opt/mafl': Is a directory`.
Replacing it with `rm -rf `solves the problem and ensures smoother updates.
Related to #5700 and #5702.


## 🔗 Related PR / Issue  
Link: #5758


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
