### PR TITLE
Fix/stirling pdf script

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -40,7 +40,7 @@ function update_script() {
   chmod +x ./gradlew
   $STD ./gradlew build -x spotlessApply -x spotlessCheck -x test -x sonarqube
   rm -rf /opt/Stirling-PDF/Stirling-PDF-*.jar
-  cp -r ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
+  cp -r ./stirling-pdf/build/libs/*.jar /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar
   cp -r scripts /opt/Stirling-PDF/
   cp -r pipeline /opt/Stirling-PDF/
   cp -r stirling-pdf/src/main/resources/static/fonts/*.ttf /usr/share/fonts/opentype/noto/

--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -42,6 +42,8 @@ function update_script() {
   rm -rf /opt/Stirling-PDF/Stirling-PDF-*.jar
   cp -r ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
   cp -r scripts /opt/Stirling-PDF/
+  cp -r pipeline /opt/Stirling-PDF/
+  cp -r stirling-pdf/src/main/resources/static/fonts/*.ttf /usr/share/fonts/opentype/noto/
   cd ~
   rm -rf Stirling-PDF-$RELEASE v$RELEASE.tar.gz
   ln -sf /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar /opt/Stirling-PDF/Stirling-PDF.jar

--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -38,7 +38,7 @@ function update_script() {
   tar -xzf v$RELEASE.tar.gz
   cd Stirling-PDF-$RELEASE
   chmod +x ./gradlew
-  $STD ./gradlew build
+  $STD ./gradlew build -x spotlessApply -x spotlessCheck -x test -x sonarqube
   rm -rf /opt/Stirling-PDF/Stirling-PDF-*.jar
   cp -r ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
   cp -r scripts /opt/Stirling-PDF/

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -83,7 +83,7 @@ chmod +x ./gradlew
 $STD ./gradlew build -x spotlessApply -x spotlessCheck -x test -x sonarqube
 mkdir -p /opt/Stirling-PDF
 touch /opt/Stirling-PDF/.env
-mv ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
+mv ./stirling-pdf/build/libs/*.jar /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar
 mv scripts /opt/Stirling-PDF/
 mv pipeline /opt/Stirling-PDF/
 mv stirling-pdf/src/main/resources/static/fonts/*.ttf /usr/share/fonts/opentype/noto/

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -80,7 +80,7 @@ curl -fsSL "https://github.com/Stirling-Tools/Stirling-PDF/archive/refs/tags/v${
 tar -xzf v${RELEASE}.tar.gz
 cd Stirling-PDF-$RELEASE
 chmod +x ./gradlew
-$STD ./gradlew build
+$STD ./gradlew build -x spotlessApply -x spotlessCheck -x test -x sonarqube
 mkdir -p /opt/Stirling-PDF
 touch /opt/Stirling-PDF/.env
 mv ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -85,6 +85,8 @@ mkdir -p /opt/Stirling-PDF
 touch /opt/Stirling-PDF/.env
 mv ./build/libs/Stirling-PDF-*.jar /opt/Stirling-PDF/
 mv scripts /opt/Stirling-PDF/
+mv pipeline /opt/Stirling-PDF/
+mv stirling-pdf/src/main/resources/static/fonts/*.ttf /usr/share/fonts/opentype/noto/
 ln -s /opt/Stirling-PDF/Stirling-PDF-$RELEASE.jar /opt/Stirling-PDF/Stirling-PDF.jar
 ln -s /usr/share/tesseract-ocr/5/tessdata/ /usr/share/tessdata
 msg_ok "Installed Stirling-PDF"


### PR DESCRIPTION
## ✍️ Description  
The StirlingPDF project's structure has been updated to Gradle Multimodule and the `.jar` file is in a different path.
I have updated the Install and the Update scripts.
Apart of that, there are some extra files needed that weren't copied on previous config.
I have found those extra needed files on the [Dockerfile](https://github.com/Stirling-Tools/Stirling-PDF/blob/main/Dockerfile) of the project 

On the other hand, I have excluded test and checkstyles tasks on the compilation process to decrease the compilation time our script wastes on the initial installation and any following update.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [ ] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
