### PR TITLE
karakeep-install: Disable Playwright browser download, remove MCP build

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -58,7 +58,6 @@ function update_script() {
   fi
   MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
   NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
-
   
   msg_info "Updating ${APP} to v${RELEASE}"
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -36,10 +36,12 @@ function update_script() {
   msg_info "Stopping Services"
   systemctl stop karakeep-web karakeep-workers karakeep-browser
   msg_ok "Stopped Services"
+  
   msg_info "Updating yt-dlp"
   $STD yt-dlp --update-to nightly
   msg_ok "Updated yt-dlp"
-  msg_info "Updating ${APP} to v${RELEASE}"
+  
+  msg_info "Prepare update"
   if [[ -f /opt/${APP}_version.txt && "$(cat /opt/${APP}_version.txt)" < "0.23.0" ]]; then
     $STD apt-get install -y graphicsmagick ghostscript
   fi
@@ -48,12 +50,17 @@ function update_script() {
     mv /opt/karakeep/.env /etc/karakeep/karakeep.env
   fi
   rm -rf /opt/karakeep
+  msg_ok "Update prepared"
+  
   fetch_and_deploy_gh_release "karakeep" "karakeep-app/karakeep"
   if command -v corepack; then
     $STD corepack disable
   fi
   MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
   NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
+
+  
+  msg_info "Updating ${APP} to v${RELEASE}"
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
   export NEXT_TELEMETRY_DISABLED=1
   export CI="true"
@@ -75,6 +82,7 @@ function update_script() {
   msg_info "Starting Services"
   systemctl start karakeep-browser karakeep-workers karakeep-web
   msg_ok "Started Services"
+  
   msg_info "Cleaning up"
   $STD apt-get autoremove -y
   $STD apt-get autoclean -y

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -60,6 +60,7 @@ function update_script() {
   NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
   
   msg_info "Updating ${APP} to v${RELEASE}"
+  export PUPPETEER_SKIP_DOWNLOAD="true"
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
   export NEXT_TELEMETRY_DISABLED=1
   export CI="true"

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -27,59 +27,59 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  RELEASE=$(curl -fsSL https://api.github.com/repos/karakeep-app/karakeep/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-  PREV_RELEASE=$(cat /opt/${APP}_version.txt)
-  if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "${PREV_RELEASE}" ]]; then
-    msg_info "Stopping Services"
-    systemctl stop karakeep-web karakeep-workers karakeep-browser
-    msg_ok "Stopped Services"
-    msg_info "Updating yt-dlp"
-    $STD yt-dlp --update-to nightly
-    msg_ok "Updated yt-dlp"
-    msg_info "Updating ${APP} to v${RELEASE}"
-    if [[ $(corepack -v) < "0.31.0" ]]; then
-      $STD npm install -g corepack@0.31.0
-    fi
-    if [[ "${PREV_RELEASE}" < 0.23.0 ]]; then
-      $STD apt-get install -y graphicsmagick ghostscript
-    fi
-    cd /opt
-    if [[ -f /opt/karakeep/.env ]] && [[ ! -f /etc/karakeep/karakeep.env ]]; then
-      mkdir -p /etc/karakeep
-      mv /opt/karakeep/.env /etc/karakeep/karakeep.env
-    fi
-    rm -rf /opt/karakeep
-    curl -fsSL "https://github.com/karakeep-app/karakeep/archive/refs/tags/v${RELEASE}.zip" -o "v${RELEASE}.zip"
-    $STD unzip "v${RELEASE}.zip"
-    mv karakeep-"${RELEASE}" /opt/karakeep
-    cd /opt/karakeep/apps/web
-    $STD pnpm install --frozen-lockfile
-    $STD pnpm build
-    cd /opt/karakeep/apps/workers
-    $STD pnpm install --frozen-lockfile
-    cd /opt/karakeep/apps/cli
-    $STD pnpm install --frozen-lockfile
-    $STD pnpm build
-    cd /opt/karakeep/apps/mcp
-    $STD pnpm install --frozen-lockfile
-    $STD pnpm build
-    export DATA_DIR=/opt/karakeep_data
-    cd /opt/karakeep/packages/db
-    $STD pnpm migrate
-    sed -i "s/SERVER_VERSION=${PREV_RELEASE}/SERVER_VERSION=${RELEASE}/" /etc/karakeep/karakeep.env
-    msg_ok "Updated ${APP} to v${RELEASE}"
 
-    msg_info "Starting Services"
-    systemctl start karakeep-browser karakeep-workers karakeep-web
-    msg_ok "Started Services"
-    msg_info "Cleaning up"
-    rm -R /opt/v"${RELEASE}".zip
-    echo "${RELEASE}" >/opt/${APP}_version.txt
-    msg_ok "Cleaned"
-    msg_ok "Updated Successfully"
-  else
-    msg_ok "No update required.  ${APP} is already at ${RELEASE}."
+  RELEASE=$(curl -fsSL https://api.github.com/repos/karakeep-app/karakeep/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  if [[ -f ~/.karakeep && "$RELEASE" == "$(cat ~/.karakeep)" ]]; then
+    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+    exit
   fi
+  msg_info "Stopping Services"
+  systemctl stop karakeep-web karakeep-workers karakeep-browser
+  msg_ok "Stopped Services"
+  msg_info "Updating yt-dlp"
+  $STD yt-dlp --update-to nightly
+  msg_ok "Updated yt-dlp"
+  msg_info "Updating ${APP} to v${RELEASE}"
+  if [[ -f /opt/${APP}_version.txt && "$(cat /opt/${APP}_version.txt)" < "0.23.0" ]]; then
+    $STD apt-get install -y graphicsmagick ghostscript
+  fi
+  if [[ -f /opt/karakeep/.env ]] && [[ ! -f /etc/karakeep/karakeep.env ]]; then
+    mkdir -p /etc/karakeep
+    mv /opt/karakeep/.env /etc/karakeep/karakeep.env
+  fi
+  rm -rf /opt/karakeep
+  fetch_and_deploy_gh_release "karakeep" "karakeep-app/karakeep"
+  if command -v corepack; then
+    $STD corepack disable
+  fi
+  MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
+  NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
+  export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
+  export NEXT_TELEMETRY_DISABLED=1
+  export CI="true"
+  cd /opt/karakeep/apps/web
+  $STD pnpm install --frozen-lockfile
+  $STD pnpm build
+  cd /opt/karakeep/apps/workers
+  $STD pnpm install --frozen-lockfile
+  cd /opt/karakeep/apps/cli
+  $STD pnpm install --frozen-lockfile
+  $STD pnpm build
+  export DATA_DIR=/opt/karakeep_data
+  cd /opt/karakeep/packages/db
+  $STD pnpm migrate
+  $STD pnpm store prune
+  sed -i "s/^SERVER_VERSION=.*$/SERVER_VERSION=${RELEASE}/" /etc/karakeep/karakeep.env
+  msg_ok "Updated ${APP} to v${RELEASE}"
+
+  msg_info "Starting Services"
+  systemctl start karakeep-browser karakeep-workers karakeep-web
+  msg_ok "Started Services"
+  msg_info "Cleaning up"
+  $STD apt-get autoremove -y
+  $STD apt-get autoclean -y
+  msg_ok "Cleaned"
+  msg_ok "Updated Successfully"
   exit
 }
 

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -55,6 +55,7 @@ MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.
 NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
 msg_info "Installing karakeep"
+export PUPPETEER_SKIP_DOWNLOAD="true"
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
 export NEXT_TELEMETRY_DISABLED=1
 export CI="true"

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -22,7 +22,8 @@ $STD apt-get install -y \
   chromium/stable \
   chromium-common/stable \
   graphicsmagick \
-  ghostscript
+  ghostscript \
+  jq
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Additional Tools"
@@ -48,18 +49,13 @@ sed -i \
   /etc/meilisearch.toml
 msg_ok "Installed Meilisearch"
 
-NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
-$STD npm install -g corepack@0.31.0
+fetch_and_deploy_gh_release "karakeep" "karakeep-app/karakeep"
+cd /opt/karakeep
+MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
+NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
 msg_info "Installing karakeep"
-cd /opt
-RELEASE=$(curl -fsSL https://api.github.com/repos/karakeep-app/karakeep/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-curl -fsSL "https://github.com/karakeep-app/karakeep/archive/refs/tags/v${RELEASE}.zip" -o "v${RELEASE}.zip"
-$STD unzip "v${RELEASE}.zip"
-mv karakeep-"${RELEASE}" /opt/karakeep
-cd /opt/karakeep
-corepack enable
-export PUPPETEER_SKIP_DOWNLOAD="true"
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
 export NEXT_TELEMETRY_DISABLED=1
 export CI="true"
 cd /opt/karakeep/apps/web
@@ -70,15 +66,13 @@ $STD pnpm install --frozen-lockfile
 cd /opt/karakeep/apps/cli
 $STD pnpm install --frozen-lockfile
 $STD pnpm build
-cd /opt/karakeep/apps/mcp
-$STD pnpm install --frozen-lockfile
-$STD pnpm build
+$STD pnpm store prune
 
 export DATA_DIR=/opt/karakeep_data
 karakeep_SECRET=$(openssl rand -base64 36 | cut -c1-24)
 mkdir -p /etc/karakeep
 cat <<EOF >/etc/karakeep/karakeep.env
-SERVER_VERSION=$RELEASE
+SERVER_VERSION="$(cat ~/.karakeep)"
 NEXTAUTH_SECRET="$karakeep_SECRET"
 NEXTAUTH_URL="http://localhost:3000"
 DATA_DIR="$DATA_DIR"
@@ -112,7 +106,6 @@ BROWSER_WEB_URL="http://127.0.0.1:9222"
 # CRAWLER_VIDEO_DOWNLOAD_MAX_SIZE="50"
 # CRAWLER_ENABLE_ADBLOCKER=true
 EOF
-echo "${RELEASE}" >"/opt/${APPLICATION}_version.txt"
 msg_ok "Installed karakeep"
 
 msg_info "Running Database Migration"
@@ -190,7 +183,6 @@ customize
 
 msg_info "Cleaning up"
 rm -rf /tmp/meilisearch.deb
-rm -f /opt/v"${RELEASE}".zip
 $STD apt-get autoremove -y
 $STD apt-get autoclean -y
 msg_ok "Cleaned"


### PR DESCRIPTION
## ✍️ Description  

- changes export during install to disable automatic browser downloading by Playwright
- removes yarn
- removes MCP build
- performs `pnpm store prune` after install/update to remove extraneous packages


## 🔗 Related PR / Issue  
Link: #5697 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
