### PR TITLE
Quickfix: Immich: revert install sequence

### DIFF
--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -111,23 +111,6 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   msg_ok "Installed OpenVINO dependencies"
 fi
 
-msg_info "Installing Packages from Testing Repo"
-export APT_LISTCHANGES_FRONTEND=none
-export DEBIAN_FRONTEND=noninteractive
-$STD apt-get install -t testing --no-install-recommends -y \
-  libio-compress-brotli-perl \
-  libwebp7 \
-  libwebpdemux2 \
-  libwebpmux3 \
-  libhwy1t64 \
-  libdav1d-dev \
-  libhwy-dev \
-  libwebp-dev
-if [[ -f ~/.openvino ]]; then
-  $STD apt-get install -t testing -y patchelf
-fi
-msg_ok "Packages from Testing Repo Installed"
-
 NODE_VERSION="22" setup_nodejs
 PG_VERSION="16" PG_MODULES="pgvector" setup_postgresql
 
@@ -153,6 +136,26 @@ $STD sudo -u postgres psql -c "ALTER USER $DB_USER WITH SUPERUSER;"
   echo "Database Name: $DB_NAME"
 } >>~/"$APPLICATION".creds
 msg_ok "Set up Postgresql Database"
+
+msg_info "Installing Packages from Testing Repo"
+export APT_LISTCHANGES_FRONTEND=none
+export DEBIAN_FRONTEND=noninteractive
+$STD apt-get install -t testing --no-install-recommends -y \
+  libio-compress-brotli-perl \
+  libwebp7 \
+  libwebpdemux2 \
+  libwebpmux3 \
+  libhwy1t64 \
+  libdav1d-dev \
+  libhwy-dev \
+  libwebp-dev
+if [[ -f ~/.openvino ]]; then
+  $STD apt-get install -t testing -y patchelf
+fi
+msg_ok "Packages from Testing Repo Installed"
+
+$STD sudo -u postgres psql -c "ALTER DATABASE postgres REFRESH COLLATION VERSION;"
+$STD sudo -u postgres psql -c "ALTER DATABASE $DB_NAME REFRESH COLLATION VERSION;"
 
 msg_info "Compiling Custom Photo-processing Library (extreme patience)"
 LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Apparently the Postgresql-16 install does not like running after packages from Testing are installed. Reverted the change and restored running the DB Collation queries

## 🔗 Related PR / Issue  
Link: #5931 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
