### PR TITLE
Firefly: Move to prebuild archive as installation source

### DIFF
--- a/ct/firefly.sh
+++ b/ct/firefly.sh
@@ -39,7 +39,7 @@ function update_script() {
     cp -r /opt/firefly/storage /opt/storage
     msg_ok "Backed up data"
 
-    fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii"
+    fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii" "prebuild" "latest" "/opt/firefly" "FireflyIII-*.zip"
 
     msg_info "Updating ${APP} to v${RELEASE}"
     rm -rf /opt/firefly/storage

--- a/install/firefly-install.sh
+++ b/install/firefly-install.sh
@@ -20,7 +20,7 @@ msg_ok "Installed Dependencies"
 PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="mysql" setup_php
 setup_composer
 setup_mariadb
-fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii"
+fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii" "prebuild" "latest" "/opt/firefly" "FireflyIII-*.zip"
 LOCAL_IP=$(hostname -I | awk '{print $1}')
 
 msg_info "Setting up database"

--- a/install/firefly-install.sh
+++ b/install/firefly-install.sh
@@ -13,14 +13,9 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y apache2
-msg_ok "Installed Dependencies"
-
 PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="mysql" setup_php
 setup_composer
 setup_mariadb
-fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii" "prebuild" "latest" "/opt/firefly" "FireflyIII-*.zip"
 LOCAL_IP=$(hostname -I | awk '{print $1}')
 
 msg_info "Setting up database"
@@ -38,6 +33,8 @@ mariadb -u root -e "GRANT ALL ON $DB_NAME.* TO '$DB_USER'@'localhost'; FLUSH PRI
 } >>~/firefly.creds
 msg_ok "Set up database"
 
+fetch_and_deploy_gh_release "firefly" "firefly-iii/firefly-iii" "prebuild" "latest" "/opt/firefly" "FireflyIII-*.zip"
+
 msg_info "Configuring Firefly III (Patience)"
 chown -R www-data:www-data /opt/firefly
 chmod -R 775 /opt/firefly/storage
@@ -45,8 +42,6 @@ cd /opt/firefly
 cp .env.example .env
 sed -i "s/DB_HOST=.*/DB_HOST=localhost/" /opt/firefly/.env
 sed -i "s/DB_PASSWORD=.*/DB_PASSWORD=$DB_PASS/" /opt/firefly/.env
-echo "export COMPOSER_ALLOW_SUPERUSER=1" >>~/.bashrc
-source ~/.bashrc
 $STD composer install --no-dev --no-plugins --no-interaction
 $STD php artisan firefly:upgrade-database
 $STD php artisan firefly:correct-database


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- The official documentation states that tarballs shouldn't be used to install the app and that prebuilt archives should be used instead. Fixed now
https://docs.firefly-iii.org/how-to/firefly-iii/installation/self-managed/#installing-firefly-iii


## 🔗 Related PR / Issue  
Link: #5950 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
