### PR TITLE
website: correct mealie interface_port

### DIFF
--- a/frontend/public/json/mealie.json
+++ b/frontend/public/json/mealie.json
@@ -9,7 +9,7 @@
   "updateable": true,
   "privileged": false,
   "config_path": "/opt/mealie/mealie.env",
-  "interface_port": 3000,
+  "interface_port": 9000,
   "documentation": "https://mealie.io/",
   "website": "https://mealie.io/",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/mealie.webp",


### PR DESCRIPTION
Mealie's default port is 9000, not 3000.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  



## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [ ] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
