### PR TITLE
ErsatzTV: use project prebuild ffmpeg version

### DIFF
--- a/ct/ersatztv.sh
+++ b/ct/ersatztv.sh
@@ -26,13 +26,14 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  RELEASE=$(curl -fsSL https://api.github.com/repos/ErsatzTV/ErsatzTV/releases | grep -oP '"tag_name": "\K[^"]+' | head -n 1)
+  RELEASE=$(curl -fsSL https://api.github.com/repos/ErsatzTV/ErsatzTV/releases | grep -oP '"tag_name": "\Kv\K[^"]+' | head -n1)
+  RELEASE_FFMPEG=$(curl -fsSL https://api.github.com/repos/ErsatzTV/ErsatzTV-ffmpeg/releases | grep -oP '"tag_name": "\K[^"]+' | head -n 1)
+
   if [[ "${RELEASE}" != "$(cat ~/.ersatztv 2>/dev/null)" ]] || [[ ! -f ~/.ersatztv ]]; then
     msg_info "Stopping ErsatzTV"
     systemctl stop ersatzTV
     msg_ok "Stopped ErsatzTV"
 
-    FFMPEG_VERSION="latest" FFMPEG_TYPE="medium" setup_ffmpeg
     fetch_and_deploy_gh_release "ersatztv" "ErsatzTV/ErsatzTV" "prebuild" "latest" "/opt/ErsatzTV" "*linux-x64.tar.gz"
 
     msg_info "Starting ErsatzTV"
@@ -42,6 +43,29 @@ function update_script() {
     msg_ok "Updated Successfully"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
+  fi
+
+  if [[ "${RELEASE_FFMPEG}" != "$(cat ~/.ersatztv-ffmpeg 2>/dev/null)" ]] || [[ ! -f ~/.ersatztv-ffmpeg ]]; then
+    msg_info "Stopping ErsatzTV"
+    systemctl stop ersatzTV
+    msg_ok "Stopped ErsatzTV"
+
+    fetch_and_deploy_gh_release "ersatztv-ffmpeg" "ErsatzTV/ErsatzTV-ffmpeg" "prebuild" "latest" "/opt/ErsatzTV-ffmpeg" "*-linux64-gpl-7.1.tar.xz"
+
+    msg_info "Set ErsatzTV-ffmpeg links"
+    chmod +x /opt/ErsatzTV-ffmpeg/bin/*
+    ln -sf /opt/ErsatzTV-ffmpeg/bin/ffmpeg /usr/local/bin/ffmpeg
+    ln -sf /opt/ErsatzTV-ffmpeg/bin/ffplay /usr/local/bin/ffplay
+    ln -sf /opt/ErsatzTV-ffmpeg/bin/ffprobe /usr/local/bin/ffprobe
+    msg_ok "ffmpeg links set"
+
+    msg_info "Starting ErsatzTV"
+    systemctl start ersatzTV
+    msg_ok "Started ErsatzTV"
+
+    msg_ok "Updated Successfully"
+  else
+    msg_ok "No update required. ErsatzTV-ffmpeg is already at ${RELEASE_FFMPEG}"
   fi
   exit
 }

--- a/install/ersatztv-install.sh
+++ b/install/ersatztv-install.sh
@@ -13,8 +13,6 @@ setting_up_container
 network_check
 update_os
 
-FFMPEG_VERSION="latest" FFMPEG_TYPE="full" setup_ffmpeg
-
 msg_info "Setting Up Hardware Acceleration"
 $STD apt-get -y install {va-driver-all,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
 if [[ "$CTTYPE" == "0" ]]; then
@@ -26,7 +24,37 @@ if [[ "$CTTYPE" == "0" ]]; then
 fi
 msg_ok "Set Up Hardware Acceleration"
 
+read -r -p "${TAB3}Do you need the intel-media-va-driver-non-free driver for HW encoding (Debian 12 only)? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  msg_info "Installing Intel Hardware Acceleration (non-free)"
+  cat <<EOF >/etc/apt/sources.list.d/non-free.list
+
+deb http://deb.debian.org/debian bookworm non-free non-free-firmware
+deb-src http://deb.debian.org/debian bookworm non-free non-free-firmware
+
+deb http://deb.debian.org/debian-security bookworm-security non-free non-free-firmware
+deb-src http://deb.debian.org/debian-security bookworm-security non-free non-free-firmware
+
+deb http://deb.debian.org/debian bookworm-updates non-free non-free-firmware
+deb-src http://deb.debian.org/debian bookworm-updates non-free non-free-firmware
+EOF
+  $STD apt-get update
+  $STD apt-get -y install {intel-media-va-driver-non-free,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
+else
+  msg_info "Installing Intel Hardware Acceleration"
+  $STD apt-get -y install {va-driver-all,ocl-icd-libopencl1,intel-opencl-icd,vainfo,intel-gpu-tools}
+fi
+msg_ok "Installed and Set Up Intel Hardware Acceleration"
+
 fetch_and_deploy_gh_release "ersatztv" "ErsatzTV/ErsatzTV" "prebuild" "latest" "/opt/ErsatzTV" "*linux-x64.tar.gz"
+fetch_and_deploy_gh_release "ersatztv-ffmpeg" "ErsatzTV/ErsatzTV-ffmpeg" "prebuild" "latest" "/opt/ErsatzTV-ffmpeg" "*-linux64-gpl-7.1.tar.xz"
+
+msg_info "Set ErsatzTV-ffmpeg links"
+chmod +x /opt/ErsatzTV-ffmpeg/bin/*
+ln -sf /opt/ErsatzTV-ffmpeg/bin/ffmpeg /usr/local/bin/ffmpeg
+ln -sf /opt/ErsatzTV-ffmpeg/bin/ffplay /usr/local/bin/ffplay
+ln -sf /opt/ErsatzTV-ffmpeg/bin/ffprobe /usr/local/bin/ffprobe
+msg_ok "ffmpeg links set"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/ersatzTV.service


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- use prebuild ffmpeg version from ersatzTV project
- extend update function
- increase logic
- add non-free hw tools for intel


## 🔗 Related PR / Issue  
Link: #6052 #5443


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
