### PR TITLE
Fixed the previous fix of the anti-nag hook

### DIFF
--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -141,7 +141,7 @@ EOF
     yes)
       whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "Support Subscriptions" "Supporting the software's development team is essential. Check their official website's Support Subscriptions for pricing. Without their dedicated work, we wouldn't have this exceptional software." 10 58
       msg_info "Disabling subscription nag"
-      echo "DPkg::Post-Invoke { \"dpkg -V proxmox-widget-toolkit 2>/dev/null && [ -f /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js ] && echo 'Removing subscription nag from UI...' && sed -i '/data\.status/{s/\!/=/;s/active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js\"; };" >/etc/apt/apt.conf.d/no-nag-script
+      echo "DPkg::Post-Invoke { \"if [ -s /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js ] && ! grep -q -F 'NoMoreNagging' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; then echo 'Removing subscription nag from UI...'; sed -i '/data\.status/{s/\!/=/;s/active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; fi\" };" >/etc/apt/apt.conf.d/no-nag-script
       apt --reinstall install proxmox-widget-toolkit &>/dev/null
       msg_ok "Disabled subscription nag (Delete browser cache)"
       ;;


### PR DESCRIPTION
## ✍️ Description  
[Yesterday's fix](https://github.com/community-scripts/ProxmoxVE/pull/6084) of the anti-nag apt hook had some unintended side effects as reported today by @memesalot and @vsc55 in #6078. This PR fixes this. What is being done in particular:

- `&&` chaining is replaced back with an if-condition because otherwise the hook returns with a non-0 exit code when JS patching is not needed and `apt` scares users with an error message
- `dpkg -V` check has been replaced with a `grep -F` check to avoid stdout leaking `??5?????? /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` (I couldn't reproduce that on my installs, glad others helped with testing)

**Draft until this concern by @vsc55 is resolved:**

> I mean that the new sed syntax is not compatible with older versions of the pve js file.

## 🔗 Related PR / Issue  
Link: #6078
Link: #6084


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  This time also tested by @vsc55: [message link](https://github.com/community-scripts/ProxmoxVE/issues/6078#issuecomment-3094439446)
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
