### PR TITLE
fix: removing ",gw=" from GATE var when reading/writing from/to config.

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -226,6 +226,7 @@ write_config() {
   # This function writes the configuration to a file.
   if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "Write configfile" --yesno "Do you want to write the selections to a config file?" 10 60; then
     FILEPATH="/opt/community-scripts/${NSAPP}.conf"
+    [[ "$GATE" =~ ",gw=" ]] && local GATE="${GATE##,gw=}"
     if [[ ! -f $FILEPATH ]]; then
       cat <<EOF >"$FILEPATH"
 # ${NSAPP} Configuration File

--- a/misc/config-file.func
+++ b/misc/config-file.func
@@ -272,7 +272,8 @@ config_file() {
       GATE=""
     elif [[ "$NET" =~ $ip_cidr_regex ]]; then
       echo -e "${NETWORK}${BOLD}${DGN}IP Address: ${BGN}$NET${CL}"
-      if [ ! -z "$GATE" ]; then
+      if [[ -n "$GATE" ]]; then
+        [[ "$GATE" =~ ",gw=" ]] && GATE="${GATE##,gw=}"
         if [[ "$GATE" =~ $ip_regex ]]; then
           echo -e "${GATEWAY}${BOLD}${DGN}Gateway IP Address: ${BGN}$GATE${CL}"
           GATE=",gw=$GATE"


### PR DESCRIPTION
## ✍️ Description  

Previously when creating a config, GATE variable would include ",gw=" which was crashing the installer script when read later on due to ip_regex check.

This fix:
1. writes the GATE variable to config without ",gw=" string
2. removes ",gw=" string from the GATE variable when reading existing config
3. small pedantic change - replacing `! -z` with `-n` for clarity and shellcheck standards


## 🔗 Related PR / Issue  
N/A


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
