### PR TITLE
Wizarr: use absolute path to uv

### DIFF
--- a/ct/wizarr.sh
+++ b/ct/wizarr.sh
@@ -45,13 +45,13 @@ function update_script() {
 
     msg_info "Updating $APP to v${RELEASE}"
     cd /opt/wizarr
-    uv -q sync --locked
-    $STD uv -q run pybabel compile -d app/translations
+    /usr/local/bin/uv -q sync --locked
+    $STD /usr/local/bin/uv -q run pybabel compile -d app/translations
     $STD npm --prefix app/static install
     $STD npm --prefix app/static run build:css
     mkdir -p ./.cache
     $STD tar -xf "$BACKUP_FILE" --directory=/
-    $STD uv -q run flask db upgrade
+    $STD /usr/local/bin/uv -q run flask db upgrade
     msg_ok "Updated $APP to v${RELEASE}"
 
     msg_info "Starting $APP"

--- a/install/wizarr-install.sh
+++ b/install/wizarr-install.sh
@@ -23,12 +23,12 @@ fetch_and_deploy_gh_release "wizarr" "wizarrrr/wizarr"
 
 msg_info "Configure ${APPLICATION}"
 cd /opt/wizarr
-uv -q sync --locked
-$STD uv -q run pybabel compile -d app/translations
+/usr/local/bin/uv -q sync --locked
+$STD /usr/local/bin/uv -q run pybabel compile -d app/translations
 $STD npm --prefix app/static install
 $STD npm --prefix app/static run build:css
 mkdir -p ./.cache
-$STD uv -q run flask db upgrade
+$STD /usr/local/bin/uv -q run flask db upgrade
 msg_ok "Configure ${APPLICATION}"
 
 msg_info "Creating env, start script and service"


### PR DESCRIPTION
## ✍️ Description  

- for reasons unknown, updating to 2025.7.7 failed due to uv not being in the PATH anymore

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
