### PR TITLE
karakeep: export DATA_DIR from user config in update

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -60,6 +60,7 @@ function update_script() {
   NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
   msg_info "Updating ${APP} to v${RELEASE}"
+  corepack enable
   export PUPPETEER_SKIP_DOWNLOAD="true"
   export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD="true"
   export NEXT_TELEMETRY_DISABLED=1
@@ -72,7 +73,8 @@ function update_script() {
   cd /opt/karakeep/apps/cli
   $STD pnpm install --frozen-lockfile
   $STD pnpm build
-  export DATA_DIR=/opt/karakeep_data
+  DATA_DIR="$(sed -n '/^DATA_DIR/p' /etc/karakeep/karakeep.env | awk -F= '{print $2}')"
+  export DATA_DIR="${DATA_DIR:-/opt/karakeep_data}"
   cd /opt/karakeep/packages/db
   $STD pnpm migrate
   $STD pnpm store prune


### PR DESCRIPTION
## ✍️ Description  

- allows the user to change the DATA_DIR location and update.
- Will use the default (/opt/karakeep_data) if it's not set in the env file
- fixed an issue with pnpm not being found during update

## 🔗 Related PR / Issue  
Link: #6267 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
