### PR TITLE
karakeep: Run workers in prod without tsx

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -52,6 +52,10 @@ function update_script() {
   rm -rf /opt/karakeep
   msg_ok "Update prepared"
 
+  if grep -q "start:prod" /etc/systemd/system/karakeep-workers.service; then
+    sed -i 's|^ExecStart=.*$|ExecStart=/usr/bin/node dist/index.mjs|' /etc/systemd/system/karakeep-workers.service
+    systemctl daemon-reload
+  fi
   fetch_and_deploy_gh_release "karakeep" "karakeep-app/karakeep"
   if command -v corepack >/dev/null; then
     $STD corepack disable
@@ -70,6 +74,7 @@ function update_script() {
   $STD pnpm build
   cd /opt/karakeep/apps/workers
   $STD pnpm install --frozen-lockfile
+  $STD pnpm build
   cd /opt/karakeep/apps/cli
   $STD pnpm install --frozen-lockfile
   $STD pnpm build

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -64,6 +64,7 @@ $STD pnpm install --frozen-lockfile
 $STD pnpm build
 cd /opt/karakeep/apps/workers
 $STD pnpm install --frozen-lockfile
+$STD pnpm build
 cd /opt/karakeep/apps/cli
 $STD pnpm install --frozen-lockfile
 $STD pnpm build
@@ -167,7 +168,7 @@ Wants=network.target karakeep-browser.service meilisearch.service
 After=network.target karakeep-browser.service meilisearch.service
 
 [Service]
-ExecStart=pnpm start:prod
+ExecStart=/usr/bin/node dist/index.mjs
 WorkingDirectory=/opt/karakeep/apps/workers
 EnvironmentFile=/etc/karakeep/karakeep.env
 Restart=always


### PR DESCRIPTION
## ✍️ Description  

- compile TypeScript files to JS during build
- may improve performance on slow-ass devices
- slightly increases build time

## 🔗 Related PR / Issue  
Link: [This commit](https://github.com/karakeep-app/karakeep/commit/2cce45b7ed04b819bf25fa8ac129f300e1469846) in the Karakeep repo


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
