### PR TITLE
add 'g++' to actualbudget-install.sh

### DIFF
--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -15,7 +15,8 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  make g++
+  make \
+  g++
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Actual Budget"

--- a/install/actualbudget-install.sh
+++ b/install/actualbudget-install.sh
@@ -15,7 +15,7 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  make
+  make g++
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Actual Budget"


### PR DESCRIPTION
## ✍️ Description  

The install script fails on line 53 (`$STD npm install --location=global @actual-app/sync-server`).  Installing `gcc`, which is required by `better-sqlite3`, which `@actual-app/sync-server` depends on, is the solution. 

Added `g++` to the dependency line `18`.


## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change 

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
