### PR TITLE
ProxmoxVE 9.0 Beta: add BETA Version as test in pve_check

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -66,13 +66,36 @@ root_check() {
 
 # This function checks the version of Proxmox Virtual Environment (PVE) and exits if the version is not supported.
 pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[0-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 # When a node is running tens of containers, it's possible to exceed the kernel's cryptographic key storage allocations.

--- a/vm/archlinux-vm.sh
+++ b/vm/archlinux-vm.sh
@@ -138,14 +138,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/debian-vm.sh
+++ b/vm/debian-vm.sh
@@ -138,14 +138,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/docker-vm.sh
+++ b/vm/docker-vm.sh
@@ -139,14 +139,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -142,14 +142,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -139,14 +139,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/nextcloud-vm.sh
+++ b/vm/nextcloud-vm.sh
@@ -138,14 +138,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/openwrt.sh
+++ b/vm/openwrt.sh
@@ -184,14 +184,37 @@ function msg_error() {
   echo -e "${BFR} ${CROSS} ${RD}${msg}${CL}"
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/opnsense-vm.sh
+++ b/vm/opnsense-vm.sh
@@ -180,14 +180,37 @@ function msg_error() {
   echo -e "${BFR} ${CROSS} ${RD}${msg}${CL}"
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/owncloud-vm.sh
+++ b/vm/owncloud-vm.sh
@@ -139,14 +139,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/pimox-haos-vm.sh
+++ b/vm/pimox-haos-vm.sh
@@ -147,14 +147,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/ubuntu2204-vm.sh
+++ b/vm/ubuntu2204-vm.sh
@@ -134,14 +134,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/ubuntu2410-vm.sh
+++ b/vm/ubuntu2410-vm.sh
@@ -136,14 +136,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/ubuntu2504-vm.sh
+++ b/vm/ubuntu2504-vm.sh
@@ -136,14 +136,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -138,14 +138,37 @@ function check_root() {
   fi
 }
 
-function pve_check() {
-  if ! pveversion | grep -Eq "pve-manager/8\.[1-4](\.[0-9]+)*"; then
-    msg_error "${CROSS}${RD}This version of Proxmox Virtual Environment is not supported"
-    echo -e "Requires Proxmox Virtual Environment Version 8.1 or later."
-    echo -e "Exiting..."
-    sleep 2
-    exit
+pve_check() {
+  local PVE_VER
+  PVE_VER="$(pveversion | awk -F'/' '{print $2}' | awk -F'-' '{print $1}')"
+
+  # Check for Proxmox VE 8.x
+  if [[ "$PVE_VER" =~ ^8\.([0-9]+) ]]; then
+    local MINOR="${BASH_REMATCH[1]}"
+    if ((MINOR < 1 || MINOR > 4)); then
+      msg_error "This version of Proxmox VE is not supported."
+      echo -e "Required: Proxmox VE version 8.1 – 8.4"
+      exit 1
+    fi
+    return 0
   fi
+
+  # Check for Proxmox VE 9.x (Beta) — require confirmation
+  if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
+    if whiptail --title "Proxmox 9.x Detected (Beta)" \
+      --yesno "You are using Proxmox VE $PVE_VER, which is currently in Beta state.\n\nThis version is experimentally supported.\n\nDo you want to proceed anyway?" 12 70; then
+      msg_ok "Confirmed: Continuing with Proxmox VE $PVE_VER"
+      return 0
+    else
+      msg_error "Aborted by user: Proxmox VE 9.x was not confirmed."
+      exit 1
+    fi
+  fi
+
+  # All other unsupported versions
+  msg_error "This version of Proxmox VE is not supported."
+  echo -e "Supported versions: Proxmox VE 8.1 – 8.4 or 9.x (Beta, with confirmation)"
+  exit 1
 }
 
 function arch_check() {


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- add an seperate check for pve 9 version as beta, with whiptail to accept or decline

<img width="614" height="253" alt="image" src="https://github.com/user-attachments/assets/3bde2adb-201a-4f32-962f-f946e97ea871" />
<img width="492" height="110" alt="image" src="https://github.com/user-attachments/assets/6935270c-fcf6-48ef-8668-7fdf7491eb63" />


Stable enough to test, known issues:
- some templates (f.e. 24.10 Ubuntu) are no longer available
- ubuntu 25.04 is new available
- its unknown how current VM templates will perform.

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
