### PR TITLE
Bump Home Assistant template to Ubuntu 24.04

### DIFF
--- a/ct/homeassistant-core.sh
+++ b/ct/homeassistant-core.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-ubuntu}"
-var_version="${var_version:-24.10}"
+var_version="${var_version:-24.04}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -21,10 +21,10 @@ catch_errors
 
 function update_script() {
   header_info
-  if ! lsb_release -d | grep -q "Ubuntu 24.10"; then
-    msg_error "Wrong OS detected. This script only supports Ubuntu 24.10."
+  if ! lsb_release -d | grep -q "Ubuntu 24.04"; then
+    msg_error "This script is designed for Ubuntu 24.04 only."
     msg_error "Read Guide: https://github.com/community-scripts/ProxmoxVE/discussions/1549"
-    exit 1
+    exit
   fi
   check_container_storage
   check_container_resources

--- a/frontend/public/json/homeassistant-core.json
+++ b/frontend/public/json/homeassistant-core.json
@@ -23,7 +23,7 @@
                 "ram": 2048,
                 "hdd": 10,
                 "os": "ubuntu",
-                "version": "24.10"
+                "version": "24.04"
             }
         }
     ],


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This script previously used Ubuntu 24.10 template which had compatibility issues, so I've tested successfully with 24.04. The script was failing with (in verbose mode):
  ✔️   LXC Template List Updated
  ✔️   LXC Template 'ubuntu-24.04-standard_24.04-2_amd64.tar.zst' is ready to use.
   ✖️   Container creation failed. Checking if template is corrupted or incomplete.
   ✖️   Template is valid, but container creation still failed.

[ERROR] in line 1122: exit code 0: while executing command bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/create_lxc.sh)" $?

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
    I couldn't test this in ProxmoxVED as the script didn't exist. Instead, I tested on my fork directly (e.g. bash -c "$(curl -fsSL https://raw.githubusercontent.com/mattv8/ProxmoxVE/main/ct/homeassistant-core.sh)")
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
