### PR TITLE
Strip SD and NS prefixes before writing to config file

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -250,6 +250,17 @@ write_config() {
   if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "Write configfile" --yesno "Do you want to write the selections to a config file?" 10 60; then
     FILEPATH="/opt/community-scripts/${NSAPP}.conf"
     [[ "$GATE" =~ ",gw=" ]] && local GATE="${GATE##,gw=}"
+
+    # Strip prefixes from parameters for config file storage
+    local SD_VALUE="${SD}"
+    local NS_VALUE="${NS}"
+    local MAC_VALUE="${MAC}"
+    local VLAN_VALUE="${VLAN}"
+    [[ "$SD" =~ ^-searchdomain= ]] && SD_VALUE="${SD#-searchdomain=}"
+    [[ "$NS" =~ ^-nameserver= ]] && NS_VALUE="${NS#-nameserver=}"
+    [[ "$MAC" =~ ^,hwaddr= ]] && MAC_VALUE="${MAC#,hwaddr=}"
+    [[ "$VLAN" =~ ^,tag= ]] && VLAN_VALUE="${VLAN#,tag=}"
+
     if [[ ! -f $FILEPATH ]]; then
       cat <<EOF >"$FILEPATH"
 # ${NSAPP} Configuration File
@@ -272,10 +283,10 @@ IPV6_METHOD="${IPV6_METHOD:-none}"
 GATE="${GATE:-none}"
 APT_CACHER_IP="${APT_CACHER_IP:-none}"
 MTU="${MTU:-1500}"
-SD="${SD:-none}"
-NS="${NS:-none}"
-MAC="${MAC:-none}"
-VLAN="${VLAN:-none}"
+SD="${SD_VALUE:-none}"
+NS="${NS_VALUE:-none}"
+MAC="${MAC_VALUE:-none}"
+VLAN="${VLAN_VALUE:-none}"
 SSH="${SSH}"
 SSH_AUTHORIZED_KEY="${SSH_AUTHORIZED_KEY}"
 TAGS="${TAGS:-none}"
@@ -310,10 +321,10 @@ IPV6_METHOD="${IPV6_METHOD:-none}"
 GATE="${GATE:-none}"
 APT_CACHER_IP="${APT_CACHER_IP:-none}"
 MTU="${MTU:-1500}"
-SD="${SD:-none}"
-NS="${NS:-none}"
-MAC="${MAC:-none}"
-VLAN="${VLAN:-none}"
+SD="${SD_VALUE:-none}"
+NS="${NS_VALUE:-none}"
+MAC="${MAC_VALUE:-none}"
+VLAN="${VLAN_VALUE:-none}"
 SSH="${SSH}"
 SSH_AUTHORIZED_KEY="${SSH_AUTHORIZED_KEY}"
 TAGS="${TAGS:-none}"
@@ -807,7 +818,36 @@ advanced_settings() {
 
   if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "ADVANCED SETTINGS COMPLETE" --yesno "Ready to create ${APP} LXC?" 10 58); then
     echo -e "${CREATING}${BOLD}${RD}Creating a ${APP} LXC using the above advanced settings${CL}"
+
+    # Strip prefixes from DNS parameters for config file storage
+    local SD_VALUE="$SD"
+    local NS_VALUE="$NS"
+    local MAC_VALUE="$MAC"
+    local VLAN_VALUE="$VLAN"
+    [[ "$SD" =~ ^-searchdomain= ]] && SD_VALUE="${SD#-searchdomain=}"
+    [[ "$NS" =~ ^-nameserver= ]] && NS_VALUE="${NS#-nameserver=}"
+    [[ "$MAC" =~ ^,hwaddr= ]] && MAC_VALUE="${MAC#,hwaddr=}"
+    [[ "$VLAN" =~ ^,tag= ]] && VLAN_VALUE="${VLAN#,tag=}"
+
+    # Temporarily store original values
+    local SD_ORIG="$SD"
+    local NS_ORIG="$NS"
+    local MAC_ORIG="$MAC"
+    local VLAN_ORIG="$VLAN"
+
+    # Set clean values for config file writing
+    SD="$SD_VALUE"
+    NS="$NS_VALUE"
+    MAC="$MAC_VALUE"
+    VLAN="$VLAN_VALUE"
+
     write_config
+
+    # Restore original formatted values for container creation
+    SD="$SD_ORIG"
+    NS="$NS_ORIG"
+    MAC="$MAC_ORIG"
+    VLAN="$VLAN_ORIG"
   else
     clear
     header_info

--- a/misc/config-file.func
+++ b/misc/config-file.func
@@ -469,8 +469,11 @@ config_file() {
       SD=""
       echo -e "${SEARCH}${BOLD}${DGN}DNS Search Domain: ${BGN}Host${CL}"
     else
-      echo -e "${SEARCH}${BOLD}${DGN}DNS Search Domain: ${BGN}$SD${CL}"
-      SD="-searchdomain=$SD"
+      # Strip prefix if present for config file storage
+      local SD_VALUE="$SD"
+      [[ "$SD" =~ ^-searchdomain= ]] && SD_VALUE="${SD#-searchdomain=}"
+      echo -e "${SEARCH}${BOLD}${DGN}DNS Search Domain: ${BGN}$SD_VALUE${CL}"
+      SD="-searchdomain=$SD_VALUE"
     fi
   else
     if SD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a DNS Search Domain (leave blank for HOST)" 8 58 --title "DNS Search Domain" 3>&1 1>&2 2>&3); then
@@ -492,11 +495,14 @@ config_file() {
       NS=""
       echo -e "${NETWORK}${BOLD}${DGN}DNS Server IP Address: ${BGN}Host${CL}"
     else
-      if [[ "$NS" =~ $ip_regex ]]; then
-        echo -e "${NETWORK}${BOLD}${DGN}DNS Server IP Address: ${BGN}$NS${CL}"
-        NS="-nameserver=$NS"
+      # Strip prefix if present for config file storage
+      local NS_VALUE="$NS"
+      [[ "$NS" =~ ^-nameserver= ]] && NS_VALUE="${NS#-nameserver=}"
+      if [[ "$NS_VALUE" =~ $ip_regex ]]; then
+        echo -e "${NETWORK}${BOLD}${DGN}DNS Server IP Address: ${BGN}$NS_VALUE${CL}"
+        NS="-nameserver=$NS_VALUE"
       else
-        msg_error "Invalid IP Address format for DNS Server. Needs to be 0.0.0.0, was ${NS}"
+        msg_error "Invalid IP Address format for DNS Server. Needs to be 0.0.0.0, was ${NS_VALUE}"
         exit
       fi
     fi
@@ -519,11 +525,14 @@ config_file() {
       MAC=""
       echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}Host${CL}"
     else
-      if [[ "$MAC" =~ ^([A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2}$ ]]; then
-        echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}$MAC${CL}"
-        MAC=",hwaddr=$MAC"
+      # Strip prefix if present for config file storage
+      local MAC_VALUE="$MAC"
+      [[ "$MAC" =~ ^,hwaddr= ]] && MAC_VALUE="${MAC#,hwaddr=}"
+      if [[ "$MAC_VALUE" =~ ^([A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2}$ ]]; then
+        echo -e "${MACADDRESS}${BOLD}${DGN}MAC Address: ${BGN}$MAC_VALUE${CL}"
+        MAC=",hwaddr=$MAC_VALUE"
       else
-        msg_error "MAC Address must be in the format xx:xx:xx:xx:xx:xx, was ${MAC}"
+        msg_error "MAC Address must be in the format xx:xx:xx:xx:xx:xx, was ${MAC_VALUE}"
         exit
       fi
     fi
@@ -546,11 +555,14 @@ config_file() {
       VLAN=""
       echo -e "${VLANTAG}${BOLD}${DGN}Vlan: ${BGN}Host${CL}"
     else
-      if [[ "$VLAN" =~ ^-?[0-9]+$ ]]; then
-        echo -e "${VLANTAG}${BOLD}${DGN}Vlan: ${BGN}$VLAN${CL}"
-        VLAN=",tag=$VLAN"
+      # Strip prefix if present for config file storage
+      local VLAN_VALUE="$VLAN"
+      [[ "$VLAN" =~ ^,tag= ]] && VLAN_VALUE="${VLAN#,tag=}"
+      if [[ "$VLAN_VALUE" =~ ^-?[0-9]+$ ]]; then
+        echo -e "${VLANTAG}${BOLD}${DGN}Vlan: ${BGN}$VLAN_VALUE${CL}"
+        VLAN=",tag=$VLAN_VALUE"
       else
-        msg_error "VLAN must be an integer, was ${VLAN}"
+        msg_error "VLAN must be an integer, was ${VLAN_VALUE}"
         exit
       fi
     fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
During testing of PR #6354 I encountered an issue with how the vars to the config files are written. The NS and SD write a prefix to the variables that causes the following error:
  🔍  DNS Search Domain: -searchdomain=home.mydomain.com
   ✖️   Invalid IP Address format for DNS Server. Needs to be 0.0.0.0, was -nameserver=192.168.50.200

If I cat the config with `grep -E '(NS|SD)' /opt/community-scripts/homeassistant-core.conf` it looks like:
```bash
SD="-searchdomain=home.mydomain.com"
NS="-nameserver=192.168.50.200"
```
when it should be:
```bash
SD="home.mydomain.com"
NS="192.168.50.200"
```

Didn't seem to be behaving properly, so creating this PR to address. Presumably same issue for MAC and VLAN as well.

## 🔗 Related PR / Issue  
Link: #6354 

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected. 
    WAY too many changes between ProxmoxVED files in this PR, so I tested on my fork directly (e.g. bash -c "$(curl -fsSL https://raw.githubusercontent.com/mattv8/ProxmoxVE/main/ct/homeassistant-core.sh)")...
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
