### PR TITLE
Librespeed-Rust: Fix service name and RELEASE var fetching

### DIFF
--- a/ct/librespeed-rust.sh
+++ b/ct/librespeed-rust.sh
@@ -27,16 +27,17 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  RELEASE=$(curl -fsSL https://api.github.com/repos/librespeed/speedtest-rust/releases/latest | grep '"tag_name"' | sed -E 's/.*"tag_name": "v([^"]+).*/\1/')
+  
+  RELEASE=$(curl -fsSL https://api.github.com/repos/librespeed/speedtest-rust/releases/latest | jq -r '.tag_name' | sed 's/^v//')
   if [[ "${RELEASE}" != "$(cat ~/.librespeed 2>/dev/null)" ]] || [[ ! -f ~/.librespeed ]]; then
     msg_info "Stopping Services"
-    systemctl stop librespeed-rs
+    systemctl stop librespeed_rs
     msg_ok "Services Stopped"
 
     fetch_and_deploy_gh_release "librespeed-rust" "librespeed/speedtest-rust" "binary" "latest" "/opt/librespeed-rust" "librespeed-rs-x86_64-unknown-linux-gnu.deb"
 
     msg_info "Starting Service"
-    systemctl start librespeed-rs
+    systemctl start librespeed_rs
     msg_ok "Started Service"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/install/librespeed-rust-install.sh
+++ b/install/librespeed-rust-install.sh
@@ -16,7 +16,7 @@ update_os
 fetch_and_deploy_gh_release "librespeed-rust" "librespeed/speedtest-rust" "binary" "latest" "/opt/librespeed-rust" "librespeed-rs-x86_64-unknown-linux-gnu.deb"
 
 msg_info "Enabling Service"
-systemctl enable -q --now speedtest_rs.service
+systemctl enable -q --now speedtest_rs
 msg_ok "Enabled Service"
 
 motd_ssh


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Fixed bad service name in update function
- Now using jq to fetch RELEASE var, same as in `tools.func`


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
