### PR TITLE
[core] fix: expand $CACHER_IP in apt-proxy-detect.sh (revert quoted heredoc)

### DIFF
--- a/misc/install.func
+++ b/misc/install.func
@@ -131,8 +131,8 @@ network_check() {
 update_os() {
   msg_info "Updating Container OS"
   if [[ "$CACHER" == "yes" ]]; then
-    echo "Acquire::http::Proxy-Auto-Detect \"/usr/local/bin/apt-proxy-detect.sh\";" >/etc/apt/apt.conf.d/00aptproxy
-    cat <<'EOF' >/usr/local/bin/apt-proxy-detect.sh
+    echo 'Acquire::http::Proxy-Auto-Detect "/usr/local/bin/apt-proxy-detect.sh";' >/etc/apt/apt.conf.d/00aptproxy
+    cat <<EOF >/usr/local/bin/apt-proxy-detect.sh
 #!/bin/bash
 if nc -w1 -z "${CACHER_IP}" 3142; then
   echo -n "http://${CACHER_IP}:3142"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This PR fixes a regression introduced in commit #8d91a5d where the apt-proxy-detect.sh script used a quoted heredoc (<<'EOF'), causing ${CACHER_IP} to be written literally instead of being expanded.
The heredoc is now unquoted again (<<EOF) to ensure proper substitution of the CACHER_IP value at script creation time. Also simplified the echo line for apt.conf.d using single quotes to avoid double-escaping issues.
This resolves issues where apt in LXCs fails with "forward host lookup failed" due to unset CACHER_IP at runtime.



## 🔗 Related PR / Issue  
Link: #6368


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
