### PR TITLE
PiAlert: bugfix dependencies

### DIFF
--- a/install/pialert-install.sh
+++ b/install/pialert-install.sh
@@ -52,7 +52,6 @@ $STD apt-get -y install \
   python3-tz \
   python3-tzlocal \
   python3-aiohttp \
-  python3-paho-mqtt \
   python3-cryptography
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 $STD pip3 install mac-vendor-lookup
@@ -61,6 +60,7 @@ $STD pip3 install cryptography
 $STD pip3 install pyunifi
 $STD pip3 install openwrt-luci-rpc
 $STD pip3 install asusrouter
+$STD pip3 install paho-mqtt
 msg_ok "Installed Python Dependencies"
 
 msg_info "Installing Pi.Alert"


### PR DESCRIPTION
The pip package is required instead of the apt package because the apt package is too old.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

I apologize for the renewed request. The final test showed that the required Python3 package via apt is much too old compared to the pip package. For this reason, the dependencies have been adjusted once again.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
