### PR TITLE
Alternative connectivity checks for LXC

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1286,8 +1286,8 @@ EOF
         msg_ok "Network in LXC is reachable"
         break
       fi
-      # Try with curl since ping may be blocked.
-      if pct exec "$CTID" -- curl -sfI --max-time 10 -sfI deb.debian.org >/dev/null 2>&1; then
+      # Try with curl since ping may be blocked
+      if pct exec "$CTID" -- curl -fsSL --max-time 10 deb.debian.org >/dev/null 2>&1; then
         msg_ok "Network in LXC is reachable"
         break
       fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -1286,6 +1286,11 @@ EOF
         msg_ok "Network in LXC is reachable"
         break
       fi
+      # Try with curl since ping may be blocked.
+      if pct exec "$CTID" -- curl -sfI --max-time 10 -sfI deb.debian.org >/dev/null 2>&1; then
+        msg_ok "Network in LXC is reachable"
+        break
+      fi
       if [ "$i" -lt 10 ]; then
         msg_warn "No network yet in LXC (try $i/10) – waiting..."
         sleep 3

--- a/misc/build.func
+++ b/misc/build.func
@@ -1287,7 +1287,7 @@ EOF
         break
       fi
       # Try with curl since ping may be blocked
-      if pct exec "$CTID" -- curl -fsSL --max-time 10 deb.debian.org >/dev/null 2>&1; then
+      if pct exec "$CTID" -- curl -fsSIL --max-time 10 deb.debian.org >/dev/null 2>&1; then
         msg_ok "Network in LXC is reachable"
         break
       fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -1286,7 +1286,6 @@ EOF
         msg_ok "Network in LXC is reachable"
         break
       fi
-      # Try with curl since ping may be blocked
       if pct exec "$CTID" -- curl -fsSIL --max-time 10 deb.debian.org >/dev/null 2>&1; then
         msg_ok "Network in LXC is reachable"
         break


### PR DESCRIPTION
## ✍️ Description  

My ISP blocks ICMP pings. I can't prevent that. Connectivity checks introduced in #6142 prevent me (and [others](https://github.com/community-scripts/ProxmoxVE/issues/6363) with the same issue, https://github.com/community-scripts/ProxmoxVE/pull/6172#issuecomment-3106203300 to use community-scripts). 

A potential solution to this problem is to check not only ping but a `curl` request to the debian page. If ping works, the second check is never reached.

See below that the curl method works in my case even when ping is blocked:

<img width="905" height="458" alt="Screenshot_2025-08-01_12-53-28" src="https://github.com/user-attachments/assets/022bf8f3-10fc-48e0-9280-952a1f7c2d48" />


## 🔗 Related PR / Issue  

- #6363
- #6172


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
