### PR TITLE
turnkey: add hostname & Fix TUN access

### DIFF
--- a/turnkey/turnkey.sh
+++ b/turnkey/turnkey.sh
@@ -98,17 +98,20 @@ turnkey=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "TurnKey LXCs
 
 # Setup script environment
 PASS="$(openssl rand -base64 8)"
-CTID=$(pvesh get /cluster/nextid)
+#CTID=$(pvesh get /cluster/nextid)
+CTID=$(whiptail --backtitle "Container ID" --title "Choose the Container ID" --inputbox "Enter the conatiner ID..." 8 40 $(pvesh get /cluster/nextid) 3>&1 1>&2 2>&3)
 PCT_OPTIONS="
     -features keyctl=1,nesting=1
     -hostname turnkey-${turnkey}
-    -tags proxmox-helper-scripts
+    -tags community-script
     -onboot 1
     -cores 2
     -memory 2048
     -password $PASS
     -net0 name=eth0,bridge=vmbr0,ip=dhcp
     -unprivileged 1
+    -lxc.cgroup2.devices.allow: c 10:200 rwm
+    -lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0
   "
 DEFAULT_PCT_OPTIONS=(
   -arch $(dpkg --print-architecture)
@@ -239,4 +242,5 @@ info "Proceed to the LXC console to complete the setup."
 echo
 info "login: root"
 info "password: $PASS"
+info "(credentials also stored at /turnkey-$(${turnkey}.creds))"
 echo

--- a/turnkey/turnkey.sh
+++ b/turnkey/turnkey.sh
@@ -203,11 +203,11 @@ pct create $CTID ${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE} ${PCT_OPTIONS[@]} >/dev/
 echo "TurnKey ${turnkey} password: ${PASS}" >>~/turnkey-${turnkey}.creds # file is located in the Proxmox root directory
 
 # If turnkey is "OpenVPN", add access to the tun device
-NAT_DEVICE_REQUIRED=("OpenVPN") # Setup this way in case future turnkeys also need tun access
-if printf '%s\n' "${NAT_DEVICE_REQUIRED[@]}" | grep -qw "${turnkey}"; then
+TUN_DEVICE_REQUIRED=("openvpn") # Setup this way in case future turnkeys also need tun access
+if printf '%s\n' "${TUN_DEVICE_REQUIRED[@]}" | grep -qw "${turnkey}"; then
   info "${turnkey} requires access to /dev/net/tun on the host. Modifying the container configuration to allow this."
-  echo "lxc.cgroup2.devices.allow: c 10:200 rwm" >> /etc/pve/lxc/$CTID.conf
-  echo "lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0" >> /etc/pve/lxc/$CTID.conf
+  echo "lxc.cgroup2.devices.allow: c 10:200 rwm" >> /etc/pve/lxc/${CTID}.conf
+  echo "lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0" >> /etc/pve/lxc/${CTID}.conf
   sleep 5
 fi
 
@@ -251,5 +251,5 @@ info "Proceed to the LXC console to complete the setup."
 echo
 info "login: root"
 info "password: $PASS"
-info "(credentials also stored in the root user's root directory in 'turnkey-$(${turnkey}.creds)'.)"
+info "(credentials also stored in the root user's root directory in the 'turnkey-${turnkey}.creds' file.)"
 echo

--- a/turnkey/turnkey.sh
+++ b/turnkey/turnkey.sh
@@ -98,11 +98,13 @@ turnkey=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "TurnKey LXCs
 
 # Setup script environment
 PASS="$(openssl rand -base64 8)"
-#CTID=$(pvesh get /cluster/nextid)
-CTID=$(whiptail --backtitle "Container ID" --title "Choose the Container ID" --inputbox "Enter the conatiner ID..." 8 40 $(pvesh get /cluster/nextid) 3>&1 1>&2 2>&3)
+# Prompt user to confirm container ID
+  CTID=$(whiptail --backtitle "Container ID" --title "Choose the Container ID" --inputbox "Enter the conatiner ID..." 8 40 $(pvesh get /cluster/nextid) 3>&1 1>&2 2>&3)
+# Prompt user to confirm Hostname
+  HOST_NAME=$(whiptail --backtitle "Hostname" --title "Choose the Hostname" --inputbox "Enter the containers Hostname..." 8 40 "turnkey-${turnkey}" 3>&1 1>&2 2>&3)
 PCT_OPTIONS="
     -features keyctl=1,nesting=1
-    -hostname turnkey-${turnkey}
+    -hostname $HOST_NAME
     -tags community-script
     -onboot 1
     -cores 2
@@ -110,8 +112,6 @@ PCT_OPTIONS="
     -password $PASS
     -net0 name=eth0,bridge=vmbr0,ip=dhcp
     -unprivileged 1
-    -lxc.cgroup2.devices.allow: c 10:200 rwm
-    -lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0
   "
 DEFAULT_PCT_OPTIONS=(
   -arch $(dpkg --print-architecture)
@@ -202,6 +202,15 @@ pct create $CTID ${TEMPLATE_STORAGE}:vztmpl/${TEMPLATE} ${PCT_OPTIONS[@]} >/dev/
 # Save password
 echo "TurnKey ${turnkey} password: ${PASS}" >>~/turnkey-${turnkey}.creds # file is located in the Proxmox root directory
 
+# If turnkey is "OpenVPN", add access to the tun device
+NAT_DEVICE_REQUIRED=("OpenVPN") # Setup this way in case future turnkeys also need tun access
+if printf '%s\n' "${NAT_DEVICE_REQUIRED[@]}" | grep -qw "${turnkey}"; then
+  info "${turnkey} requires access to /dev/net/tun on the host. Modifying the container configuration to allow this."
+  echo "lxc.cgroup2.devices.allow: c 10:200 rwm" >> /etc/pve/lxc/$CTID.conf
+  echo "lxc.mount.entry: /dev/net/tun dev/net/tun none bind,create=file 0 0" >> /etc/pve/lxc/$CTID.conf
+  sleep 5
+fi
+
 # Start container
 msg "Starting LXC Container..."
 pct start "$CTID"
@@ -242,5 +251,5 @@ info "Proceed to the LXC console to complete the setup."
 echo
 info "login: root"
 info "password: $PASS"
-info "(credentials also stored at /turnkey-$(${turnkey}.creds))"
+info "(credentials also stored in the root user's root directory in 'turnkey-$(${turnkey}.creds)'.)"
 echo


### PR DESCRIPTION
Allow choosing container ID & add tun device access to the container if it is OpenVPN. Also notify user that the credentials are stored in a file on the host machine.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Allow choosing container ID and Hostname. Add tun device access to the container if it is OpenVPN. Also notify user that the credentials are stored in a file on the host machine. Also standardized the containers tag.

This is to resolve the issue when installing OpenVPN where it did not have access to the tun device as it was created as an unprivileged container. Being able to control the container ID and Hostname may also be important in certain environments. Standardizing the tag to show the same tag as other script installed VM's.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [X] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
