### PR TITLE
Fix: Komga uses .komga as storage / so it fails after install

### DIFF
--- a/ct/komga.sh
+++ b/ct/komga.sh
@@ -35,7 +35,7 @@ function update_script() {
     msg_ok "Stopped ${APP}"
 
     rm -f /opt/komga/komga.jar
-    USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "komga" "gotson/komga" "singlefile" "latest" "/opt/komga" "komga*.jar"
+    USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "komga-org" "gotson/komga" "singlefile" "latest" "/opt/komga" "komga*.jar"
     mv /opt/komga/komga-*.jar /opt/komga/komga.jar
 
     msg_info "Starting ${APP}"

--- a/install/komga-install.sh
+++ b/install/komga-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 JAVA_VERSION="21" setup_java
-USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "komga" "gotson/komga" "singlefile" "latest" "/opt/komga" "komga*.jar"
+USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "komga-org" "gotson/komga" "singlefile" "latest" "/opt/komga" "komga*.jar"
 mv /opt/komga/komga-*.jar /opt/komga/komga.jar
 
 msg_info "Creating Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

komga uses .komga as storage for her .yml config, so change the "app"-name from fetch function to komga-org


## 🔗 Related PR / Issue  
Link: #6516


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
