### PR TITLE
Increase: Core Network check (pre-LXC Creation) 

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1282,36 +1282,42 @@ EOF
   if [ "$var_os" != "alpine" ]; then
     msg_info "Waiting for network in LXC container"
     for i in {1..10}; do
+      # 1. Primary check: ICMP ping (fastest, but may be blocked by ISP/firewall)
       if pct exec "$CTID" -- ping -c1 -W1 deb.debian.org >/dev/null 2>&1; then
-        msg_ok "Network in LXC is reachable"
+        msg_ok "Network in LXC is reachable (ping)"
         break
       fi
-      if pct exec "$CTID" -- curl -fsSIL --max-time 10 deb.debian.org >/dev/null 2>&1; then
-        msg_ok "Network in LXC is reachable"
-        break
-      fi
+      # Wait and retry if not reachable yet
       if [ "$i" -lt 10 ]; then
-        msg_warn "No network yet in LXC (try $i/10) – waiting..."
+        msg_warn "No network in LXC yet (try $i/10) – waiting..."
         sleep 3
       else
-        msg_error "No network in LXC after waiting."
-        read -r -p "Set fallback DNS (1.1.1.1/8.8.8.8)? [y/N]: " choice
-        case "$choice" in
-        [yY]*)
-          pct set "$CTID" --nameserver 1.1.1.1
-          pct set "$CTID" --nameserver 8.8.8.8
-          if pct exec "$CTID" -- ping -c1 -W1 deb.debian.org >/dev/null 2>&1; then
-            msg_ok "Network reachable after DNS fallback"
-          else
-            msg_error "Still no network/DNS in LXC! Aborting customization."
-            exit 1
-          fi
-          ;;
-        *)
-          msg_error "Aborted by user – no DNS fallback set."
-          exit 1
-          ;;
-        esac
+        # After 10 unsuccessful ping attempts, try HTTP connectivity via wget as fallback
+        msg_warn "Ping failed 10 times. Trying HTTP connectivity check (wget) as fallback..."
+        if pct exec "$CTID" -- wget -q --spider http://deb.debian.org; then
+          msg_ok "Network in LXC is reachable (wget fallback)"
+        else
+          msg_error "No network in LXC after all checks."
+          read -r -p "Set fallback DNS (1.1.1.1/8.8.8.8)? [y/N]: " choice
+          case "$choice" in
+          [yY]*)
+            pct set "$CTID" --nameserver 1.1.1.1
+            pct set "$CTID" --nameserver 8.8.8.8
+            # Final attempt with wget after DNS change
+            if pct exec "$CTID" -- wget -q --spider http://deb.debian.org; then
+              msg_ok "Network reachable after DNS fallback"
+            else
+              msg_error "Still no network/DNS in LXC! Aborting customization."
+              exit_script
+            fi
+            ;;
+          *)
+            msg_error "Aborted by user – no DNS fallback set."
+            exit_script
+            ;;
+          esac
+        fi
+        break
       fi
     done
   fi

--- a/misc/build.func
+++ b/misc/build.func
@@ -1346,7 +1346,11 @@ EOF'
   fi
   msg_ok "Customized LXC Container"
 
-  lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/"$var_install".sh)" $?
+  lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh)"
+  EXITCODE=$?
+  if [[ $EXITCODE -eq 10 ]]; then
+    destroy_lxc
+  fi
 }
 
 # This function sets the description of the container.

--- a/misc/build.func
+++ b/misc/build.func
@@ -1353,10 +1353,6 @@ EOF'
   msg_ok "Customized LXC Container"
 
   lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh)"
-  EXITCODE=$?
-  if [[ $EXITCODE -eq 10 ]]; then
-    destroy_lxc
-  fi
 }
 
 # This function sets the description of the container.


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- First, up to 10 tries with ICMP ping to deb.debian.org (fastest method if ICMP is allowed).
- If all pings fail, fallback to an HTTP(S) check using wget --spider to test real outbound connectivity.
- If both methods fail, user is prompted to set fallback DNS (Cloudflare & Google). After setting, the HTTP check is retried one last time.
- If all methods still fail, the script exits cleanly via the centralized exit_script handler.

**Note - Usage of wget**
On fresh Debian/Ubuntu LXC containers, wget is installed by default, while curl is usually not included in the minimal system image. This means wget is always available for basic connectivity checks before any package installation.
Using wget --spider allows us to reliably test HTTP(S) connectivity without extra dependencies, making the check robust and portable across all default LXC environments.

**Example-Flow:**
1. 🔄 Try ping (ICMP) to deb.debian.org (max 10 tries)
   → If success: proceed
   → If fail: try HTTP connectivity check

2. 🌐 Try HTTP connectivity: wget --spider http://deb.debian.org
   → If success: proceed
   → If fail: prompt user for fallback DNS

3. ⚠️ User prompt: "Set fallback DNS (1.1.1.1/8.8.8.8)? [y/N]"
   → If user agrees: set DNS and retry HTTP check once
   → If user aborts: exit_script

4. 🌐 Retry HTTP connectivity after DNS fallback
   → If success: proceed
   → If fail: exit_script


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
