### PR TITLE
Karakeep: workaround/fix for #6593

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -78,7 +78,7 @@ function update_script() {
   cd /opt/karakeep/apps/cli
   $STD pnpm install --frozen-lockfile
   $STD pnpm build
-  DATA_DIR="$(sed -n '/^DATA_DIR/p' /etc/karakeep/karakeep.env | awk -F= '{print $2}')"
+  DATA_DIR="$(sed -n '/^DATA_DIR/p' /etc/karakeep/karakeep.env | awk -F= '{print $2}' | tr -d '="=')"
   export DATA_DIR="${DATA_DIR:-/opt/karakeep_data}"
   cd /opt/karakeep/packages/db
   $STD pnpm migrate

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -69,7 +69,7 @@ cat <<EOF >/etc/karakeep/karakeep.env
 SERVER_VERSION="$(cat ~/.karakeep)"
 NEXTAUTH_SECRET="$karakeep_SECRET"
 NEXTAUTH_URL="http://localhost:3000"
-DATA_DIR="$DATA_DIR"
+DATA_DIR=${DATA_DIR}
 MEILI_ADDR="http://127.0.0.1:7700"
 MEILI_MASTER_KEY="$MASTER_KEY"
 BROWSER_WEB_URL="http://127.0.0.1:9222"


### PR DESCRIPTION
## ✍️ Description  

- This PR fixes the DB migration failure due to the `DATA_DIR` variable being surrounded by quotes in the env file. Previously this was not an issue because we exported the value without grabbing it from the env file. Now that it is user-configurable and considering that the value in the env file has been surrounded by quotes since the start, when we grab the value we need to ensure the quotes are removed.
- The install script has been updated to not use quotes and the new parsing command in the update function has been tested with both quoted and unquoted values.

## 🔗 Related PR / Issue  
Link: #6593 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
