### PR TITLE
Improve backup of adventurelog folder

### DIFF
--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -36,10 +36,7 @@ function update_script() {
     msg_ok "Services Stopped"
 
     msg_info "Backup Old Installation"
-    mkdir -p /opt/adventurelog-backup
-    cp /opt/adventurelog/backend/server/.env /opt/adventurelog-backup/backend/server/.env
-    cp -r /opt/adventurelog/backend/server/media /opt/adventurelog-backup/backend/server/media
-    cp /opt/adventurelog/frontend/.env /opt/adventurelog-backup/frontend/.env
+    cp -r /opt/adventurelog /opt/adventurelog-backup
     msg_ok "Backup done"
 
     fetch_and_deploy_gh_release "adventurelog" "seanmorley15/adventurelog"


### PR DESCRIPTION
## ✍️ Description  
The code creates a folder named `adventurelog-backup`. It then attempts to copy files from various nested directories, such as `/adventurelog/backend/server/.env`. However, this fails because the required intermediate folders are not created beforehand. Personally, I would simplify the approach by copying the entire parent directory instead. Alternatively, the code could be modified to explicitly create all necessary subdirectories before copying the files. At the end of the script, the entire backup-folder is deleted. So I don't see any harm in just taking a copy of the entire adventurelog directory.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
