### PR TITLE
IP Tag: Allow installation on PVE 9.x

### DIFF
--- a/tools/pve/add-iptag.sh
+++ b/tools/pve/add-iptag.sh
@@ -1275,9 +1275,9 @@ while true; do
   esac
 done
 
-if ! pveversion | grep -Eq "pve-manager/8\.[0-4](\.[0-9]+)*"; then
+if ! pveversion | grep -Eq "pve-manager/(8\.[0-4]|9\.[0-9]+)(\.[0-9]+)*"; then
   msg_error "This version of Proxmox Virtual Environment is not supported"
-  msg_error "⚠️ Requires Proxmox Virtual Environment Version 8.0 or later."
+  msg_error "⚠️ Requires Proxmox Virtual Environment Version 8.0–8.4 or 9.x."
   msg_error "Exiting..."
   sleep 2
   exit


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
IP Tag validates `pveversion` and only allows insallation on 8.x version. I've changed the constraint to allow 9.x installs and IP Tag seems to be working fine.


## 🔗 Related PR / Issue  
Link: #6674 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
