### PR TITLE
Fix: Bazarr requirements.txt file not parse-able by UV

### DIFF
--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -41,8 +41,8 @@ function update_script() {
     msg_info "Setup Bazarr"
     mkdir -p /var/lib/bazarr/
     chmod 775 /opt/bazarr /var/lib/bazarr/
-    sed -i.bak '/--only-binary=Pillow/d' /opt/bazarr/requirements.txt
-    $STD uv pip install -r /opt/bazarr/requirements.txt --system --only-binary=Pillow
+    sed -i.bak 's/--only-binary=Pillow//g' /opt/bazarr/requirements.txt
+    $STD uv pip install -r /opt/bazarr/requirements.txt --system
     msg_ok "Setup Bazarr"
 
     msg_ok "Update Successful"

--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -41,7 +41,8 @@ function update_script() {
     msg_info "Setup Bazarr"
     mkdir -p /var/lib/bazarr/
     chmod 775 /opt/bazarr /var/lib/bazarr/
-    $STD uv pip install -r /opt/bazarr/requirements.txt --system
+    sed -i.bak '/--only-binary=Pillow/d' /opt/bazarr/requirements.txt
+    $STD uv pip install -r /opt/bazarr/requirements.txt --system --only-binary=Pillow
     msg_ok "Setup Bazarr"
 
     msg_ok "Update Successful"

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -25,8 +25,8 @@ fetch_and_deploy_gh_release "bazarr" "morpheus65535/bazarr" "prebuild" "latest" 
 msg_info "Installing Bazarr"
 mkdir -p /var/lib/bazarr/
 chmod 775 /opt/bazarr /var/lib/bazarr/
-sed -i.bak '/--only-binary=Pillow/d' /opt/bazarr/requirements.txt
-$STD uv pip install -r /opt/bazarr/requirements.txt --system --only-binary=Pillow
+sed -i.bak 's/--only-binary=Pillow//g' /opt/bazarr/requirements.txt
+$STD uv pip install -r /opt/bazarr/requirements.txt --system
 msg_ok "Installed Bazarr"
 
 msg_info "Creating Service"

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -25,7 +25,8 @@ fetch_and_deploy_gh_release "bazarr" "morpheus65535/bazarr" "prebuild" "latest" 
 msg_info "Installing Bazarr"
 mkdir -p /var/lib/bazarr/
 chmod 775 /opt/bazarr /var/lib/bazarr/
-$STD uv pip install -r /opt/bazarr/requirements.txt --system
+sed -i.bak '/--only-binary=Pillow/d' /opt/bazarr/requirements.txt
+$STD uv pip install -r /opt/bazarr/requirements.txt --system --only-binary=Pillow
 msg_ok "Installed Bazarr"
 
 msg_info "Creating Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
The requirements.txt file that ships with Bazarr includes a flag that is not parse-able by UV, this PR simply strips that flag out of the file and adds it manually to the UV install line.

Please reject this PR if this is not an elegant enough solution.

## 🔗 Related PR / Issue  
Link: #6700  


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
