### PR TITLE
Pulse: binary path changed AGAIN; other fixes

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2025 community-scripts ORG
-# Author: rcourtman
+# Author: rcourtman & vhsdream
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://github.com/rcourtman/Pulse
 
@@ -39,12 +39,19 @@ function update_script() {
     systemctl stop pulse
     msg_ok "Stopped ${APP}"
 
+    dirs=(/opt/pulse/bin /opt/pulse/frontend-modern)
+    for dir in "${dirs[@]}"; do
+      if [[ -d "$dir" ]]; then
+        rm -rf "$dir"
+      fi
+    done
+
     fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "*-linux-amd64.tar.gz"
     chown -R pulse:pulse /etc/pulse /opt/pulse
-    sed -i 's|pulse/pulse|pulse/bin/pulse|' /etc/systemd/system/pulse.service
+    sed -i 's|bin/pulse|pulse|' /etc/systemd/system/pulse.service
     systemctl daemon-reload
-    if [[ -f /opt/pulse/pulse ]]; then
-      rm -rf /opt/pulse/{pulse,frontend-modern}
+    if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
+      usermod -s /usr/sbin/nologin pulse
     fi
 
     msg_info "Starting ${APP}"

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2021-2025 community-scripts ORG
-# Author: rcourtman
+# Author: rcourtman & vhsdream
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://github.com/rcourtman/Pulse
 
@@ -21,7 +21,7 @@ $STD apt-get install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Creating User"
-if useradd -r -m -d /opt/pulse-home -s /bin/bash pulse; then
+if useradd -r -m -d /opt/pulse-home -s /usr/sbin/nologin pulse; then
   msg_ok "Created User"
 else
   msg_error "User creation failed"
@@ -44,7 +44,7 @@ Type=simple
 User=pulse
 Group=pulse
 WorkingDirectory=/opt/pulse
-ExecStart=/opt/pulse/bin/pulse
+ExecStart=/opt/pulse/pulse
 Restart=always
 RestartSec=3
 StandardOutput=journal


### PR DESCRIPTION
## ✍️ Description  

- Reverts the path change from yesterday
  - On install, uses `/opt/pulse/pulse` in systemd service file
  - On update, will change to `/opt/pulse/pulse` if `/opt/pulse/bin/pulse` is found
- Checks for and removes the `/opt/pulse/bin` and `/opt/pulse/frontend-modern` dirs if they exist
- Disables shell access for `pulse` user for better security

## 🔗 Related PR / Issue  
Link: https://github.com/rcourtman/Pulse/releases/tag/v4.3.0


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
