### PR TITLE
archivebox: fix wrong formatted uv command

### DIFF
--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -42,7 +42,7 @@ function update_script() {
 
   msg_info "Updating ArchiveBox"
   cd /opt/archivebox/data
-  uv --system pip install --upgrade --ignore-installed archivebox
+  $STD uv pip install --system --upgrade --no-reinstall archivebox
   sudo -u archivebox archivebox init
   msg_ok "Updated ArchiveBox"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

fix wrong parsing of --system (its an pip command, not an uv command)


## 🔗 Related PR / Issue  
Link: #6748


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
