### PR TITLE
Add missing default user & pass for RabbitMQ

### DIFF
--- a/frontend/public/json/rabbitmq.json
+++ b/frontend/public/json/rabbitmq.json
@@ -28,8 +28,8 @@
     }
   ],
   "default_credentials": {
-    "username": null,
-    "password": null
+    "username": "proxmox",
+    "password": "proxmox"
   },
   "notes": []
 }


### PR DESCRIPTION
## ✍️ Description  
When installing RabbitMQ, the install script create a default user and password.
Those informations are not provided in the documentation.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
