### PR TITLE
Kasm: Fix install log parsing

### DIFF
--- a/frontend/public/json/kasm.json
+++ b/frontend/public/json/kasm.json
@@ -41,7 +41,7 @@
       "type": "warning"
     },
     {
-      "text": "Show password: `cat ~/kasm.creds`",
+      "text": "Show credentials: `cat ~/kasm.creds`",
       "type": "info"
     }
   ]

--- a/install/kasm-install.sh
+++ b/install/kasm-install.sh
@@ -16,21 +16,21 @@ update_os
 msg_info "Installing Kasm Workspaces"
 KASM_VERSION=$(curl -fsSL 'https://www.kasmweb.com/downloads' | grep -o 'https://kasm-static-content.s3.amazonaws.com/kasm_release_[^"]*\.tar\.gz' | head -n 1 | sed -E 's/.*release_(.*)\.tar\.gz/\1/')
 curl -fsSL -o "/opt/kasm_release_${KASM_VERSION}.tar.gz" "https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
-
 cd /opt
 tar -xf "kasm_release_${KASM_VERSION}.tar.gz"
 chmod +x /opt/kasm_release/install.sh
 printf 'y\ny\ny\n4\n' | bash /opt/kasm_release/install.sh > ~/kasm-install.output 2>&1
-cat ~/kasm-install.output | grep -A 20 -i "credentials\|login\|password\|admin" | sed '1i Kasm-Workspaces-Credentials' >~/kasm.creds
-
+awk '
+  /^Kasm UI Login Credentials$/ {capture=1}
+  capture {print}
+  /^Service Registration Token$/ {in_token=1}
+  in_token && /^-+$/ {dash_count++}
+  in_token && dash_count==2 {exit}
+' ~/kasm-install.output > ~/kasm.creds
 msg_ok "Installed Kasm Workspaces"
 
 motd_ssh
 customize
-
-msg_info "Displaying Kasm Credentials"
-cat ~/kasm.creds
-msg_ok "Kasm Credentials displayed"
 
 msg_info "Cleaning up"
 rm -f /opt/kasm_release_${KASM_VERSION}.tar.gz


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Fixed parsing of installation log into `~/.kasm.creds`. Now shows only credentials, without extra text before it.
- Removed showing of credentials during installation. Now you have to type `cat ~/kasm.creds` like in all other scripts.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
