### PR TITLE
Syncthing: Switch to v2 stable repository

### DIFF
--- a/install/syncthing-install.sh
+++ b/install/syncthing-install.sh
@@ -13,16 +13,19 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Syncthing"
-curl -fsSL -o /usr/share/keyrings/syncthing-archive-keyring.gpg https://syncthing.net/release-key.gpg
-sh -c 'echo "deb [signed-by=/usr/share/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable" > /etc/apt/sources.list.d/syncthing.list'
+msg_info "Setting up Syncthing repo"
+mkdir -p /etc/apt/keyrings
+curl -fsSL "https://syncthing.net/release-key.gpg" -o /etc/apt/keyrings/syncthing-archive-keyring.gpg
+echo "deb [signed-by=/etc/apt/keyrings/syncthing-archive-keyring.gpg] https://apt.syncthing.net/ syncthing stable-v2" >/etc/apt/sources.list.d/syncthing.list
 $STD apt-get update
+msg_ok "Set up Syncthing repo"
+
+msg_info "Installing Syncthing"
 $STD apt-get install -y syncthing
-$STD systemctl enable syncthing@root.service
-systemctl start syncthing@root.service
+systemctl enable -q --now syncthing@root
 sleep 5
 sed -i "{s/127.0.0.1:8384/0.0.0.0:8384/g}" /root/.local/state/syncthing/config.xml
-systemctl restart syncthing@root.service
+systemctl restart syncthing@root
 msg_ok "Installed Syncthing"
 
 motd_ssh


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Switched from v1 to v2 stable repository


## 🔗 Related PR / Issue  
Link: #7147 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
