### PR TITLE
feat: added mobile ui subscription nag removal

### DIFF
--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -514,7 +514,42 @@ post_routines_common() {
   yes)
     whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "Support Subscriptions" "Supporting the software's development team is essential. Check their official website's Support Subscriptions for pricing. Without their dedicated work, we wouldn't have this exceptional software." 10 58
     msg_info "Disabling subscription nag"
-    echo "DPkg::Post-Invoke { \"if [ -s /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js ] && ! grep -q -F 'NoMoreNagging' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; then echo 'Removing subscription nag from UI...'; sed -i '/data\.status/{s/\\!//;s/active/NoMoreNagging/}' /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js; fi\" };" >/etc/apt/apt.conf.d/no-nag-script
+    # Create external script, this is needed because DPkg::Post-Invoke is fidly with quote interpretation
+    cat >/usr/local/bin/pve-remove-nag.sh <<'EOF'
+#!/bin/sh
+WEB_JS=/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js
+if [ -s "$WEB_JS" ] && ! grep -q NoMoreNagging "$WEB_JS"; then
+    echo "Patching Web UI nag..."
+    sed -i -e "/data\.status/ s/!//" -e "/data\.status/ s/active/NoMoreNagging/" "$WEB_JS"
+fi
+
+MOBILE_TPL=/usr/share/pve-yew-mobile-gui/index.html.tpl
+MARKER="<!-- ANSIBLE MANAGED BLOCK FOR MOBILE NAG -->"
+if [ -f "$MOBILE_TPL" ] && ! grep -q "$MARKER" "$MOBILE_TPL"; then
+    echo "Patching Mobile UI nag..."
+    printf "%s\n" \
+      "$MARKER" \
+      "<script>" \
+      "  function watchAndRemoveDialog() {" \
+      "    const observer = new MutationObserver(() => {" \
+      "      const dialog = document.querySelector('dialog[aria-label=\"No valid subscription\"]');" \
+      "      if (dialog) { dialog.remove(); console.log('Removed dialog: No valid subscription'); }" \
+      "    });" \
+      "    observer.observe(document.body, { childList: true, subtree: true });" \
+      "  }" \
+      "  setTimeout(watchAndRemoveDialog, 100);" \
+      "</script>" \
+      "" >> "$MOBILE_TPL"
+fi
+EOF
+
+    chmod 755 /usr/local/bin/pve-remove-nag.sh
+    
+    cat >/etc/apt/apt.conf.d/no-nag-script <<'EOF'
+DPkg::Post-Invoke { "/usr/local/bin/pve-remove-nag.sh"; };
+EOF
+    chmod 644 /etc/apt/apt.conf.d/no-nag-script
+
     msg_ok "Disabled subscription nag (Delete browser cache)"
     ;;
   no)

--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -524,7 +524,7 @@ if [ -s "$WEB_JS" ] && ! grep -q NoMoreNagging "$WEB_JS"; then
 fi
 
 MOBILE_TPL=/usr/share/pve-yew-mobile-gui/index.html.tpl
-MARKER="<!-- ANSIBLE MANAGED BLOCK FOR MOBILE NAG -->"
+MARKER="<!-- MANAGED BLOCK FOR MOBILE NAG -->"
 if [ -f "$MOBILE_TPL" ] && ! grep -q "$MARKER" "$MOBILE_TPL"; then
     echo "Patching Mobile UI nag..."
     printf "%s\n" \
@@ -533,7 +533,7 @@ if [ -f "$MOBILE_TPL" ] && ! grep -q "$MARKER" "$MOBILE_TPL"; then
       "  function watchAndRemoveDialog() {" \
       "    const observer = new MutationObserver(() => {" \
       "      const dialog = document.querySelector('dialog[aria-label=\"No valid subscription\"]');" \
-      "      if (dialog) { dialog.remove(); console.log('Removed dialog: No valid subscription'); }" \
+      "      if (dialog) { dialog.remove(); console.log('Removed dialog: No valid subscription'); observer.disconnect(); }" \
       "    });" \
       "    observer.observe(document.body, { childList: true, subtree: true });" \
       "  }" \


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This PR adds a naive way to remove the subscription nag, currently present in the mobile version
<img width="438" height="941" alt="image" src="https://github.com/user-attachments/assets/878f4c44-3eb9-43c0-825a-4c4fc9b9e67b" />

Since they are using webassembly for the mobile version, we could not just plug this inside the javascript, as how we did with the UI version, hence I have opted for a solution where I register an observer which monitors for the dialog.

for a quick test:

``sh
bash -c "$(curl -fsSL https://raw.githubusercontent.com/ivan-penchev/ProxmoxVE/refs/heads/main/tools/pve/post-pve-install.sh)"
``

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
