### PR TITLE
FileBrowser Quantum: safer update (tmp download + atomic replace + arch autodetect)

### DIFF
--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -120,30 +120,18 @@ fi
     read -r update_prompt
   if [[ "${update_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_info "Updating ${APP}"
-  
-    # Download to same filesystem as INSTALL_PATH so rename is atomic
     tmp="${INSTALL_PATH}.tmp.$$"
-  
     if ! curl -fSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$tmp"; then
       msg_error "Download failed"
       rm -f "$tmp"
       exit 1
     fi
-  
     chmod 0755 "$tmp"
-  
-    # Swap in atomically; if mv fails, don't claim success
     if ! mv -f "$tmp" "$INSTALL_PATH"; then
       msg_error "Install failed (cannot move into $INSTALL_PATH)"
       rm -f "$tmp"
       exit 1
     fi
-  
-    # (Optional) restart so the new binary is used immediately;
-    # if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet filebrowser; then
-    #   systemctl restart filebrowser || true
-    # fi
-  
     msg_ok "Updated ${APP}"
     exit 0
   else

--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -171,7 +171,7 @@ if [[ -f "$INSTALL_PATH" ]]; then
     echo -e "${YW}⚠️ Update skipped. Exiting.${CL}"
     exit 0
   fi
-
+fi
 
 echo -e "${YW}⚠️ ${APP} is not installed.${CL}"
 echo -n "Enter port number (Default: ${DEFAULT_PORT}): "


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Safer updater for **FileBrowser Quantum** addon in `tools/addon/filebrowser-quantum.sh`.

**Before (problem)**
- Update path streamed `curl` directly into `/usr/local/bin/filebrowser` and printed success even if `curl` failed.
- This led to errors like `curl: (23) Failure writing output to destination` and a false “Updated” message.

**After (this PR)**
- Download to a **temp file on the same filesystem**, then **atomic `mv`** into `INSTALL_PATH`.
- Print success **only if `curl` and `mv` succeed**.
- (Also includes the missing `fi` to close the `if [[ -f "$INSTALL_PATH" ]]` block.)

_No changes to defaults, service unit, or dependencies. amd64 asset unchanged._

---

## 🔗 Related PR / Issue  
Link: N/A

---

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Verified on Debian/Proxmox host:
  - Success: downloads to temp and atomically replaces the binary.
  - Failure: forced bad URL → script reports error and does **not** claim success.  
- [x] **No security risks** – No secrets; permissions set to 0755; atomic replace avoids partial writes.

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves incorrect success message and fragile in-place write.
- [x] 🔧 **Refactoring / Code Cleanup** – Small robustness improvement.
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [ ] 🆕 **New script**
- [ ] 🌍 **Website update**
- [ ] 📝 **Documentation update**