### PR TITLE
Flaresolverr: Pin to 3.3.25 (Python Issue)

### DIFF
--- a/ct/flaresolverr.sh
+++ b/ct/flaresolverr.sh
@@ -35,7 +35,7 @@ function update_script() {
     msg_ok "Stopped service"
 
     rm -rf /opt/flaresolverr
-    fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
+    fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "v3.3.25" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
 
     msg_info "Starting service"
     systemctl start flaresolverr

--- a/frontend/public/json/flaresolverr.json
+++ b/frontend/public/json/flaresolverr.json
@@ -31,5 +31,10 @@
     "username": null,
     "password": null
   },
-  "notes": []
+  "notes": [
+    {
+      "text": "Flaresolverr is pinned to Version 3.3.25 because they add an breaking python package which doesn't work with debian 12.`",
+      "type": "info"
+    }
+  ]
 }

--- a/install/flaresolverr-install.sh
+++ b/install/flaresolverr-install.sh
@@ -27,7 +27,7 @@ $STD apt update
 $STD apt install -y google-chrome-stable
 msg_ok "Installed Chrome"
 
-fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
+fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "v3.3.25" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/flaresolverr.service


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Version pinned to 3.3.25 because they use in there prebuild package an new python 3.13 (fixed)
=> Try with uv doesnt work, because this tool use everytime the build in python, which failed with GLIBC


## 🔗 Related PR / Issue  
Link: #7226


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
