### PR TITLE
Fix typo where install mode was changed instead of pinned version

### DIFF
--- a/install/flaresolverr-install.sh
+++ b/install/flaresolverr-install.sh
@@ -27,7 +27,7 @@ $STD apt update
 $STD apt install -y google-chrome-stable
 msg_ok "Installed Chrome"
 
-fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "v3.3.25" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
+fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "v3.3.25" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/flaresolverr.service


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Noticed a typo in a previous PR that pins the flaresolverr version to v3.3.25. See #7226 and https://github.com/community-scripts/ProxmoxVE/pull/7248 for more details.

The typo caused the following error when trying to build the flaresolverr lxc container:
`
  ✔️   Installed Chrome
   ✖️   Unknown mode: v3.3.25

[ERROR] in line 30: exit code 0: while executing command return 1

[ERROR] in line 1353: exit code 0: while executing command lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh)"
`


## 🔗 Related PR / Issue  
Issue: #7226 
previous PR: #7248 


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
