### PR TITLE
post-pbs: increase enterprise recognition

### DIFF
--- a/tools/pve/post-pbs-install.sh
+++ b/tools/pve/post-pbs-install.sh
@@ -196,17 +196,30 @@ EOF
   esac
 
   # --- Enterprise repo ---
-  if ! component_exists_in_sources "pbs-enterprise"; then
-    cat >/etc/apt/sources.list.d/pbs-enterprise.sources <<EOF
-Types: deb
-URIs: https://enterprise.proxmox.com/debian/pbs
-Suites: trixie
-Components: pbs-enterprise
-Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
-EOF
-    msg_ok "Added 'pbs-enterprise' repository"
+  if component_exists_in_sources "pbs-enterprise"; then
+    CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "PBS Enterprise Repository" --menu \
+      "Enterprise repository detected.
+
+You normally need a valid subscription for this.
+Disable it (recommended)?" 14 58 2 "yes" " " "no" " " 3>&2 2>&1 1>&3)
+    case $CHOICE in
+    yes)
+      sed -i '/pbs-enterprise/ s/^/# /' /etc/apt/sources.list.d/pbs-enterprise.sources
+      msg_ok "Disabled 'pbs-enterprise' repository"
+      ;;
+    no)
+      msg_error "Keeping 'pbs-enterprise' active (subscription required!)"
+      ;;
+    esac
   else
-    msg_ok "'pbs-enterprise' repository already present"
+    cat >/etc/apt/sources.list.d/pbs-enterprise.sources <<EOF
+# Types: deb
+# URIs: https://enterprise.proxmox.com/debian/pbs
+# Suites: trixie
+# Components: pbs-enterprise
+# Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+EOF
+    msg_ok "Added 'pbs-enterprise' repository (disabled)"
   fi
 
   # --- No-subscription repo ---


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

better recognition of existing repo -> opt-in to disable enterprise

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
