### PR TITLE
UmbrelOS: Refactor / use q35 / better import

### DIFF
--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -466,7 +466,7 @@ FILE_IMG="/var/lib/vz/template/tmp/${CACHE_FILE##*/%.xz}"
 mkdir -p "$CACHE_DIR" "$(dirname "$FILE_IMG")"
 
 if [[ ! -s "$CACHE_FILE" ]]; then
-  msg_info "Downloading Umbrel OS image"
+  msg_ok "Downloading Umbrel OS image"
   curl -f#SL -o "$CACHE_FILE" "$URL"
 else
   msg_ok "Using cached Umbrel OS image"
@@ -481,7 +481,7 @@ qm create "$VMID" -machine q35 -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_
   -cores "$CORE_COUNT" -memory "$RAM_SIZE" -name "$HN" -tags community-script \
   -net0 "virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU" -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
 
-xz -dc "$CACHE_FILE" | pv -N "\nExtracting" >"$FILE_IMG"
+xz -dc "$CACHE_FILE" | pv -N "Extracting" >"$FILE_IMG"
 
 if qm disk import --help >/dev/null 2>&1; then
   IMPORT_CMD=(qm disk import)

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -251,16 +251,16 @@ function advanced_settings() {
     fi
   done
 
-  if MACH=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "MACHINE TYPE" --radiolist --cancel-button Exit-Script "Choose Type" 10 58 2 \
-    "i440fx" "Machine i440fx" ON \
-    "q35" "Machine q35" OFF \
+  if MACH=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "MACHINE TYPE" --radiolist --cancel-button Exit-Script "Choose Machine Type" 10 58 2 \
+    "q35" "Modern (PCIe, UEFI, default)" ON \
+    "i440fx" "Legacy (older compatibility)" OFF \
     3>&1 1>&2 2>&3); then
-    if [ $MACH = q35 ]; then
-      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}$MACH${CL}"
+    if [ "$MACH" = "q35" ]; then
+      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}q35${CL}"
       FORMAT=""
       MACHINE=" -machine q35"
     else
-      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}$MACH${CL}"
+      echo -e "${CONTAINERTYPE}${BOLD}${DGN}Machine Type: ${BGN}i440fx${CL}"
       FORMAT=",efitype=4m"
       MACHINE=""
     fi

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -469,7 +469,7 @@ if [[ ! -s "$CACHE_FILE" ]]; then
   msg_info "Downloading Umbrel OS image"
   curl -f#SL -o "$CACHE_FILE" "$URL"
 else
-  msg_info "Using cached Umbrel OS image"
+  msg_ok "Using cached Umbrel OS image"
 fi
 
 if ! command -v pv &>/dev/null; then
@@ -481,7 +481,7 @@ qm create "$VMID" -machine q35 -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_
   -cores "$CORE_COUNT" -memory "$RAM_SIZE" -name "$HN" -tags community-script \
   -net0 "virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU" -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
 
-xz -dc "$CACHE_FILE" | pv -N "Extracting" >"$FILE_IMG"
+xz -dc "$CACHE_FILE" | pv -N "\nExtracting" >"$FILE_IMG"
 
 if qm disk import --help >/dev/null 2>&1; then
   IMPORT_CMD=(qm disk import)

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -494,10 +494,10 @@ msg_ok "Imported disk into storage"
 rm -f "$FILE" "$FILE_IMG"
 
 # Attach EFI and root disk
-msg_info "Attaching EFI and root disk \n"
+msg_info "Attaching EFI and root disk"
 qm set $VMID \
   -efidisk0 ${STORAGE}:0,efitype=4m \
-  -scsi0 ${DISK_REF},ssd=1,discard=on,size=${DISK_SIZE} \
+  -scsi0 ${DISK_REF},ssd=1,discard=on \
   --boot order=scsi0 -serial0 socket >/dev/null
 qm set $VMID --agent enabled=1 >/dev/null
 msg_ok "Attached EFI and root disk"

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -310,17 +310,20 @@ function advanced_settings() {
     exit-script
   fi
 
-  if CPU_TYPE1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU MODEL" --radiolist "Choose" --cancel-button Exit-Script 10 58 2 \
-    "0" "KVM64 (Default)" ON \
-    "1" "Host" OFF \
+  if CPU_TYPE1=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU MODEL" --radiolist "Choose CPU Model" --cancel-button Exit-Script 10 58 2 \
+    "KVM64" "Default – safe for migration/compatibility" ON \
+    "Host" "Use host CPU features (faster, no migration)" OFF \
     3>&1 1>&2 2>&3); then
-    if [ $CPU_TYPE1 = "1" ]; then
+    case "$CPU_TYPE1" in
+    "Host")
       echo -e "${OS}${BOLD}${DGN}CPU Model: ${BGN}Host${CL}"
       CPU_TYPE=" -cpu host"
-    else
+      ;;
+    *)
       echo -e "${OS}${BOLD}${DGN}CPU Model: ${BGN}KVM64${CL}"
       CPU_TYPE=""
-    fi
+      ;;
+    esac
   else
     exit-script
   fi
@@ -453,7 +456,7 @@ qm create $VMID -machine q35 -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_TY
 msg_ok "Created VM shell"
 
 msg_info "Importing disk directly from compressed image"
-DISK_REF=$(xzcat "$FILE" | pv -N "Extracting" | qm importdisk $VMID - $STORAGE -format raw | awk '{print $6}')
+DISK_REF=$(xzcat "$FILE" | pv -N "Extracting" | qm disk import $VMID - $STORAGE -format raw | awk '{print $6}')
 msg_ok "Imported disk from ${CL}${BL}${FILE}${CL}"
 rm -f "$FILE"
 

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -457,7 +457,7 @@ fi
 msg_ok "Using ${CL}${BL}$STORAGE${CL} ${GN}for Storage Location."
 
 msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
-msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
+
 msg_info "Retrieving the URL for $APP"
 URL="https://download.umbrel.com/release/latest/umbrelos-amd64.img.xz"
 FILE="$(basename "$URL")"
@@ -481,7 +481,7 @@ msg_ok "Created VM shell"
 FILE_IMG="/var/lib/vz/template/tmp/${FILE%.xz}"
 mkdir -p "$(dirname "$FILE_IMG")"
 
-msg_info "Decompressing $FILE to $FILE_IMG"
+msg_info "Decompressing $FILE to $FILE_IMG\n"
 xz -dc "$FILE" | pv -N "Extracting" >"$FILE_IMG"
 msg_ok "Decompressed to $FILE_IMG"
 
@@ -494,11 +494,11 @@ msg_ok "Imported disk into storage"
 rm -f "$FILE" "$FILE_IMG"
 
 # Attach EFI and root disk
-msg_info "Attaching EFI and root disk"
+msg_info "Attaching EFI and root disk \n"
 qm set $VMID \
   -efidisk0 ${STORAGE}:0,efitype=4m \
   -scsi0 ${DISK_REF},ssd=1,discard=on,size=${DISK_SIZE} \
-  -boot order=scsi0 -serial0 socket >/dev/null
+  --boot order=scsi0 -serial0 socket >/dev/null
 qm set $VMID --agent enabled=1 >/dev/null
 msg_ok "Attached EFI and root disk"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Default VM: q35 + KVM64
Added selection menus for Machine Type and CPU Model
Improved storage detection via pvesm status
Added image caching under /var/lib/vz/template/cache/
Fixed disk import/attach logic (robust parsing, resize separated)
Prompt to keep or delete cached image after install

## 🔗 Related PR / Issue  
Link: #7319


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
