### PR TITLE
Increase default disk size for Apt-Cacher-NG

### DIFF
--- a/ct/apt-cacher-ng.sh
+++ b/ct/apt-cacher-ng.sh
@@ -9,7 +9,7 @@ APP="Apt-Cacher-NG"
 var_tags="${var_tags:-caching}"
 var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-512}"
-var_disk="${var_disk:-2}"
+var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
@@ -20,18 +20,18 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /var ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    msg_info "Updating $APP LXC"
-    $STD apt-get update
-    $STD apt-get -y upgrade
-    msg_ok "Updated $APP LXC"
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /var ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  msg_info "Updating $APP LXC"
+  $STD apt-get update
+  $STD apt-get -y upgrade
+  msg_ok "Updated $APP LXC"
+  exit
 }
 
 start

--- a/frontend/public/json/apt-cacher-ng.json
+++ b/frontend/public/json/apt-cacher-ng.json
@@ -21,7 +21,7 @@
       "resources": {
         "cpu": 1,
         "ram": 512,
-        "hdd": 2,
+        "hdd": 10,
         "os": "debian",
         "version": "12"
       }


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Updated the default disk size from 2GB to 10GB in both the setup script and the frontend JSON configuration for Apt-Cacher-NG. This change ensures sufficient storage for caching operations.


## 🔗 Related PR / Issue  
Link: #7344


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
