### PR TITLE
Wizarr: fix uv lock issue; use correct output suppression

### DIFF
--- a/ct/wizarr.sh
+++ b/ct/wizarr.sh
@@ -45,13 +45,14 @@ function update_script() {
 
     msg_info "Updating $APP"
     cd /opt/wizarr
-    /usr/local/bin/uv -q sync --locked
-    $STD /usr/local/bin/uv -q run pybabel compile -d app/translations
+    $STD /usr/local/bin/uv lock
+    $STD /usr/local/bin/uv sync --locked
+    $STD /usr/local/bin/uv run pybabel compile -d app/translations
     $STD npm --prefix app/static install
     $STD npm --prefix app/static run build:css
     mkdir -p ./.cache
     $STD tar -xf "$BACKUP_FILE" --directory=/
-    $STD /usr/local/bin/uv -q run flask db upgrade
+    $STD /usr/local/bin/uv run flask db upgrade
     msg_ok "Updated $APP"
 
     msg_info "Starting $APP"
@@ -61,7 +62,7 @@ function update_script() {
     msg_info "Cleaning Up"
     rm -rf "$BACKUP_FILE"
     msg_ok "Cleanup Completed"
-    msg_ok "Update Successfully"
+    msg_ok "Updated Successfully"
   fi
   exit
 }

--- a/install/wizarr-install.sh
+++ b/install/wizarr-install.sh
@@ -23,12 +23,13 @@ fetch_and_deploy_gh_release "wizarr" "wizarrrr/wizarr"
 
 msg_info "Configure ${APPLICATION}"
 cd /opt/wizarr
-/usr/local/bin/uv -q sync --locked
-$STD /usr/local/bin/uv -q run pybabel compile -d app/translations
+$STD /usr/local/bin/uv lock
+$STD /usr/local/bin/uv sync --locked
+$STD /usr/local/bin/uv run pybabel compile -d app/translations
 $STD npm --prefix app/static install
 $STD npm --prefix app/static run build:css
 mkdir -p ./.cache
-$STD /usr/local/bin/uv -q run flask db upgrade
+$STD /usr/local/bin/uv run flask db upgrade
 msg_ok "Configure ${APPLICATION}"
 
 msg_info "Creating env, start script and service"


### PR DESCRIPTION
## ✍️ Description  

- We need to run `uv lock` before running `uv sync`
- Fixed some issues with the output suppression for the `uv` commands

## 🔗 Related PR / Issue  
Link: #7363 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
