### PR TITLE
use debian source for direct installation of MQTT

### DIFF
--- a/install/mqtt-install.sh
+++ b/install/mqtt-install.sh
@@ -15,12 +15,10 @@ update_os
 
 msg_info "Installing Mosquitto MQTT Broker"
 source /etc/os-release
-curl -fsSL http://repo.mosquitto.org/debian/mosquitto-repo.gpg >/usr/share/keyrings/mosquitto-repo.gpg.key
-chmod go+r /usr/share/keyrings/mosquitto-repo.gpg.key
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mosquitto-repo.gpg.key] http://repo.mosquitto.org/debian ${VERSION_CODENAME} main" >/etc/apt/sources.list.d/mosquitto.list
 $STD apt-get update
 $STD apt-get -y install mosquitto
 $STD apt-get -y install mosquitto-clients
+
 cat <<EOF >/etc/mosquitto/conf.d/default.conf
 allow_anonymous false
 persistence true


### PR DESCRIPTION
## ✍️ Description  
Even Mosquitto homepage states, that newer Debian contains up-to-date mosquitto in sources.
The old guide to add the mosquitto repository is from 2013 and seems not needed anymore.
-> https://mosquitto.org/download/
Using direct install from Debian sources omits the need for adding extra repository.

The change is just to remove the part where mosquito repository was added.
This results in default usage of Debian sources.

## ✅ Prerequisites  (**X** in brackets) 
- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  
