### PR TITLE
RustDesk Server: Update the credentials info

### DIFF
--- a/frontend/public/json/rustdeskserver.json
+++ b/frontend/public/json/rustdeskserver.json
@@ -48,7 +48,11 @@
       "type": "info"
     },
     {
-      "text": "Login credentials: `cat ~/rustdesk.creds`",
+      "text": "To set admin password on Debian, type `cd /var/lib/rustdesk-api && rustdesk-api reset-admin-pwd <yournewpasswordhere>` inside LXC.",
+      "type": "info"
+    },
+    {
+      "text": "To see admin password on Alpine, type `cat ~/rustdesk.creds` inside LXC.",
       "type": "info"
     }
   ]

--- a/install/rustdeskserver-install.sh
+++ b/install/rustdeskserver-install.sh
@@ -18,18 +18,6 @@ fetch_and_deploy_gh_release "rustdesk-hbbs" "rustdesk/rustdesk-server" "binary" 
 fetch_and_deploy_gh_release "rustdesk-utils" "rustdesk/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-utils*amd64.deb"
 fetch_and_deploy_gh_release "rustdesk-api" "lejianwen/rustdesk-api" "binary" "latest" "/opt/rustdesk" "rustdesk-api-server*amd64.deb"
 
-msg_info "Configuring RustDesk Server"
-ADMINPASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c13)
-cd /var/lib/rustdesk-api
-$STD rustdesk-api reset-admin-pwd $ADMINPASS
-{
-  echo "RustDesk WebUI"
-  echo ""
-  echo "Username: admin"
-  echo "Password: $ADMINPASS"
-} >>~/rustdesk.creds
-msg_ok "Configured RustDesk Server"
-
 motd_ssh
 customize
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- As some of the users have very slow hosts, making the admin password setup fail in some instances, and as we don't want to make installs longer than needed, we removed the command that sets the admin password. Now the user runs the command manually
- Website updated with credentials information for both script variants, Debian and Alpine


## 🔗 Related PR / Issue  
Link: #7465 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
