### PR TITLE
Refactor GitHubStarsButton to wrap in Link component for external navigation

### DIFF
--- a/frontend/src/components/animate-ui/components/buttons/github-stars.tsx
+++ b/frontend/src/components/animate-ui/components/buttons/github-stars.tsx
@@ -2,6 +2,7 @@ import type { VariantProps } from "class-variance-authority";
 
 import { cva } from "class-variance-authority";
 import { StarIcon } from "lucide-react";
+import Link from "next/link";
 
 import type { ButtonProps as ButtonPrimitiveProps } from "@/components/animate-ui/primitives/buttons/button";
 import type { GithubStarsProps } from "@/components/animate-ui/primitives/animate/github-stars";
@@ -71,30 +72,37 @@ function GitHubStarsButton({
   ...props
 }: GitHubStarsButtonProps) {
   return (
-    <GithubStars
-      asChild
-      username={username}
-      repo={repo}
-      value={value}
-      delay={delay}
-      inView={inView}
-      inViewMargin={inViewMargin}
-      inViewOnce={inViewOnce}
+    <Link
+      target="_blank"
+      rel="noopener noreferrer"
+      data-umami-event="github-stars"
+      href={`https://github.com/${username}/${repo}`}
     >
-      <ButtonPrimitive className={cn(buttonVariants({ variant, size, className }))} {...props}>
-        <GithubStarsLogo />
-        <GithubStarsNumber />
-        <GithubStarsParticles className="text-yellow-500">
-          <GithubStarsIcon
-            icon={StarIcon}
-            data-variant={variant}
-            className={cn(buttonStarVariants({ variant }))}
-            activeClassName="text-yellow-500"
-            size={18}
-          />
-        </GithubStarsParticles>
-      </ButtonPrimitive>
-    </GithubStars>
+      <GithubStars
+        asChild
+        username={username}
+        repo={repo}
+        value={value}
+        delay={delay}
+        inView={inView}
+        inViewMargin={inViewMargin}
+        inViewOnce={inViewOnce}
+      >
+        <ButtonPrimitive className={cn(buttonVariants({ variant, size, className }))} {...props}>
+          <GithubStarsLogo />
+          <GithubStarsNumber />
+          <GithubStarsParticles className="text-yellow-500">
+            <GithubStarsIcon
+              icon={StarIcon}
+              data-variant={variant}
+              className={cn(buttonStarVariants({ variant }))}
+              activeClassName="text-yellow-500"
+              size={18}
+            />
+          </GithubStarsParticles>
+        </ButtonPrimitive>
+      </GithubStars>
+    </Link>
   );
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This pull request updates the `GitHubStarsButton` component to improve accessibility and tracking by wrapping the button in a `Link` component. The link now opens the GitHub repository in a new tab and includes analytics tracking.

**Component enhancement:**

* Wrapped the `GithubStarsButton` content in a Next.js `Link` component that opens the GitHub repo in a new tab, adds `noopener noreferrer` for security, and includes a `data-umami-event` attribute for analytics tracking. [[1]](diffhunk://#diff-29f8b035c8910adb31d602ed8b9c7bcb546198cc71b6da320953c2dbf3d1e7a2R5) [[2]](diffhunk://#diff-29f8b035c8910adb31d602ed8b9c7bcb546198cc71b6da320953c2dbf3d1e7a2R75-R80) [[3]](diffhunk://#diff-29f8b035c8910adb31d602ed8b9c7bcb546198cc71b6da320953c2dbf3d1e7a2R105)


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
