### PR TITLE
Pulse: standardise install/update with Pulse repo script

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -28,10 +28,6 @@ function update_script() {
     exit
   fi
 
-  if [[ ! -f ~/.pulse ]]; then
-    msg_error "Old Installation Found! Please recreate the container due big changes in the software."
-    exit 1
-  fi
   if check_for_gh_release "pulse" "rcourtman/Pulse"; then
     SERVICE_PATH="/etc/systemd/system"
     msg_info "Stopping Services"
@@ -43,19 +39,20 @@ function update_script() {
     fi
 
     fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "*-linux-amd64.tar.gz"
+    ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
     chown -R pulse:pulse /etc/pulse /opt/pulse
-    if [[ -f "$SERVICE_PATH"/pulse.service ]]; then
-      mv "$SERVICE_PATH"/pulse.service "$SERVICE_PATH"/pulse-backend.service
+    if [[ -f "$SERVICE_PATH"/pulse-backend.service ]]; then
+      mv "$SERVICE_PATH"/pulse-backend.service "$SERVICE_PATH"/pulse.service
     fi
     sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
-      -e 's/^Environment="API.*$//' "$SERVICE_PATH"/pulse-backend.service
+      -e 's/^Environment="API.*$//' "$SERVICE_PATH"/pulse.service
     systemctl daemon-reload
     if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
       usermod -s /usr/sbin/nologin pulse
     fi
 
     msg_info "Starting Services"
-    systemctl start pulse-backend
+    systemctl start pulse
     msg_ok "Started Services"
     msg_ok "Updated Successfully"
   fi

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -30,11 +30,12 @@ fi
 
 mkdir -p /etc/pulse
 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "*-linux-amd64.tar.gz"
+ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
 chown -R pulse:pulse /etc/pulse /opt/pulse
 msg_ok "Installed Pulse"
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/pulse-backend.service
+cat <<EOF >/etc/systemd/system/pulse.service
 [Unit]
 Description=Pulse Monitoring Server
 After=network.target
@@ -55,7 +56,7 @@ Environment="PULSE_DATA_DIR=/etc/pulse"
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now pulse-backend
+systemctl enable -q --now pulse
 msg_ok "Created Service"
 
 motd_ssh


### PR DESCRIPTION
## ✍️ Description  

- revert the pulse => pulse-backend service name change
- remove message about older installs
- symlink pulse binary to /usr/local/bin

I tested this and it seems to be possible to install Pulse with this script, and then update with the script in the Pulse repo. The only issue is that the `~/.pulse` file is not updated, so if a user runs `update` in the LXC it will re-install the update.

@rcourtman what do you think about having your script just add the `~/.pulse` file in the root user directory when it installs/updates?

## 🔗 Related PR / Issue  
Link: https://github.com/rcourtman/Pulse/issues/430

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
