### PR TITLE
Add margin-bottom to Most Viewed Scripts header to unifi UI

### DIFF
--- a/frontend/src/app/scripts/_components/script-info-blocks.tsx
+++ b/frontend/src/app/scripts/_components/script-info-blocks.tsx
@@ -143,7 +143,7 @@ export function MostViewedScripts({ items }: { items: Category[] }) {
     <div className="">
       {mostViewedScripts.length > 0 && (
         <>
-          <h2 className="text-lg font-semibold">Most Viewed Scripts</h2>
+          <h2 className="text-lg font-semibold mb-1">Most Viewed Scripts</h2>
         </>
       )}
       <div className="min-w flex w-full flex-row flex-wrap gap-4">


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This pull request makes a small UI improvement to the `MostViewedScripts` component by adjusting the spacing under the section heading.

- Added a `mb-1` (margin-bottom) class to the "Most Viewed Scripts" heading in `script-info-blocks.tsx` to improve visual spacing.

<img width="1013" height="582" alt="image" src="https://github.com/user-attachments/assets/fa291b32-40df-441d-a65c-be136276db49" />

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
