### PR TITLE
Update openwebui.sh

### DIFF
--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -33,11 +33,17 @@ function update_script() {
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
+      msg_info "Stopping Service"
+      systemctl stop ollama.service
+      msg_ok "Stopped Service"
+      curl -fsSLO https://ollama.com/download/ollama-linux-amd64.tgz
       rm -rf /usr/lib/ollama
       rm -rf /usr/bin/ollama
-      curl -fsSLO https://ollama.com/download/ollama-linux-amd64.tgz
       tar -C /usr -xzf ollama-linux-amd64.tgz
       rm -rf ollama-linux-amd64.tgz
+      msg_info "Starting Service"
+      systemctl start ollama.service
+      msg_info "Started Service"
       msg_ok "Ollama updated to version $RELEASE"
     else
       msg_ok "Ollama is already up to date."

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -34,7 +34,7 @@ function update_script() {
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
       msg_info "Stopping Service"
-      systemctl stop ollama.service
+      systemctl stop ollama
       msg_ok "Stopped Service"
       curl -fsSLO https://ollama.com/download/ollama-linux-amd64.tgz
       rm -rf /usr/lib/ollama
@@ -42,7 +42,7 @@ function update_script() {
       tar -C /usr -xzf ollama-linux-amd64.tgz
       rm -rf ollama-linux-amd64.tgz
       msg_info "Starting Service"
-      systemctl start ollama.service
+      systemctl start ollama
       msg_info "Started Service"
       msg_ok "Ollama updated to version $RELEASE"
     else


### PR DESCRIPTION
added stop and start ollama.service
otherwise we get a warning of version mismatch

example:
ollama -v
ollama version is 0.11.8
Warning: client version is 0.11.10

also, download new version before removing old installation.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  



## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
