### PR TITLE
[core]: add fallback if mariadb upstream unreachable

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1202,7 +1202,19 @@ setup_mariadb() {
       echo "mariadb-server-$ver mariadb-server/feedback boolean false" | debconf-set-selections
     done
   fi
-  DEBIAN_FRONTEND=noninteractive $STD apt-get install -y mariadb-server mariadb-client
+  DEBIAN_FRONTEND=noninteractive $STD apt-get install -y mariadb-server mariadb-client || {
+    msg_warn "Failed to install MariaDB ${MARIADB_VERSION} from upstream repo – trying distro package as fallback..."
+    # Cleanup, remove upstream repo to avoid conflicts
+    rm -f /etc/apt/sources.list.d/mariadb.list /etc/apt/trusted.gpg.d/mariadb.gpg
+    $STD apt-get update
+    # Final fallback: distro package
+    DEBIAN_FRONTEND=noninteractive $STD apt-get install -y mariadb-server mariadb-client || {
+      msg_error "MariaDB installation failed even with distro fallback!"
+      return 1
+    }
+    msg_ok "Setup MariaDB (distro fallback)"
+    return 0
+  }
 
   msg_ok "Setup MariaDB $MARIADB_VERSION"
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Add fallback installation for MariaDB if upstream fails.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
