### PR TITLE
vm: move pv installation into ensure_pv function

### DIFF
--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -205,6 +205,15 @@ function exit-script() {
   exit
 }
 
+function ensure_pv() {
+  if ! command -v pv &>/dev/null; then
+    msg_info "Installing required package: pv"
+    apt-get update -qq &>/dev/null
+    apt-get install -y pv &>/dev/null
+    msg_ok "Installed pv"
+  fi
+}
+
 function default_settings() {
   BRANCH="$stable"
   VMID=$(get_valid_nextid)
@@ -448,8 +457,8 @@ check_root
 arch_check
 pve_check
 ssh_check
+ensure_pv
 start_script
-
 post_to_api_vm
 
 msg_info "Validating Storage"
@@ -503,10 +512,6 @@ if [[ ! -s "$CACHE_FILE" ]]; then
   msg_ok "Downloaded ${CL}${BL}$(basename "$CACHE_FILE")${CL}"
 else
   msg_ok "Using cached image ${CL}${BL}$(basename "$CACHE_FILE")${CL}"
-fi
-
-if ! command -v pv &>/dev/null; then
-  apt-get update -qq &>/dev/null && apt-get install -y pv &>/dev/null
 fi
 
 set -o pipefail

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -201,6 +201,15 @@ function exit-script() {
   exit
 }
 
+function ensure_pv() {
+  if ! command -v pv &>/dev/null; then
+    msg_info "Installing required package: pv"
+    apt-get update -qq &>/dev/null
+    apt-get install -y pv &>/dev/null
+    msg_ok "Installed pv"
+  fi
+}
+
 function default_settings() {
   VMID=$(get_valid_nextid)
   MACHINE="q35"
@@ -432,6 +441,7 @@ check_root
 arch_check
 pve_check
 ssh_check
+ensure_pv
 start_script
 
 msg_info "Validating Storage"
@@ -470,10 +480,6 @@ if [[ ! -s "$CACHE_FILE" ]]; then
   curl -f#SL -o "$CACHE_FILE" "$URL"
 else
   msg_ok "Using cached Umbrel OS image"
-fi
-
-if ! command -v pv &>/dev/null; then
-  apt-get update -qq &>/dev/null && apt-get install -y pv &>/dev/null
 fi
 
 set -o pipefail


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Moved pv installation logic into a reusable ensure_pv function in both haos-vm.sh and umbrel-os-vm.sh. This improves code clarity and avoids duplicate code for checking and installing the pv package.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
