### PR TITLE
Wikijs: Bump Node.js version to 22

### DIFF
--- a/ct/wikijs.sh
+++ b/ct/wikijs.sh
@@ -27,7 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  NODE_VERSION="22" NODE_MODULE="yarn@latest,node-gyp" setup_nodejs
   if check_for_gh_release "wikijs" "requarks/wiki"; then
     msg_info "Verifying whether ${APP}' new release is v3.x+ and current install uses SQLite."
     SQLITE_INSTALL=$([ -f /opt/wikijs/db.sqlite ] && echo "true" || echo "false")

--- a/install/wikijs-install.sh
+++ b/install/wikijs-install.sh
@@ -18,7 +18,7 @@ $STD apt-get install -y \
   git
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="20" NODE_MODULE="yarn@latest,node-gyp" setup_nodejs
+NODE_VERSION="22" NODE_MODULE="yarn@latest,node-gyp" setup_nodejs
 PG_VERSION="17" setup_postgresql
 fetch_and_deploy_gh_release "wikijs" "requarks/wiki" "prebuild" "latest" "/opt/wikijs" "wiki-js.tar.gz"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

needed for versions > 302
Docs: Node.js 22: version 22.0 or later. (since v2.5.302)


## 🔗 Related PR / Issue  
Link: #7641


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
