### PR TITLE
Improve OpenWrt VM boot and readiness check

### DIFF
--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -77,7 +77,7 @@ function error_handler() {
   post_update_to_api "failed" "$command"
   local error_message="${RD}[ERROR]${CL} in line ${RD}$line_number${CL}: exit code ${RD}$exit_code${CL}: while executing command ${YW}$command${CL}"
   echo -e "\n$error_message\n"
-  #cleanup_vmid
+  cleanup_vmid
 }
 
 function get_valid_nextid() {
@@ -97,12 +97,12 @@ function get_valid_nextid() {
   echo "$try_id"
 }
 
-# function cleanup_vmid() {
-#   if qm status $VMID &>/dev/null; then
-#     qm stop $VMID &>/dev/null
-#     #qm destroy $VMID &>/dev/null
-#   fi
-# }
+function cleanup_vmid() {
+  if qm status $VMID &>/dev/null; then
+    qm stop $VMID &>/dev/null
+    qm destroy $VMID &>/dev/null
+  fi
+}
 
 function cleanup() {
   popd >/dev/null

--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -588,23 +588,28 @@ msg_ok "Created OpenWrt VM ${CL}${BL}(${HN})"
 msg_info "OpenWrt is being started in order to configure the network interfaces."
 qm start $VMID
 sleep 15
-msg_ok "Network interfaces are being configured as OpenWrt initiates."
-for _ in {1..30}; do
-  if qm status "$VMID" | grep -q "stopped"; then break; fi
-  send_line_to_vm ""
-  send_line_to_vm "uci delete network.@device[0]"
-  send_line_to_vm "uci set network.wan=interface"
-  send_line_to_vm "uci set network.wan.device=eth1"
-  send_line_to_vm "uci set network.wan.proto=dhcp"
-  send_line_to_vm "uci delete network.lan"
-  send_line_to_vm "uci set network.lan=interface"
-  send_line_to_vm "uci set network.lan.device=eth0"
-  send_line_to_vm "uci set network.lan.proto=static"
-  send_line_to_vm "uci set network.lan.ipaddr=${LAN_IP_ADDR}"
-  send_line_to_vm "uci set network.lan.netmask=${LAN_NETMASK}"
-  send_line_to_vm "uci commit"
-  send_line_to_vm "halt"
+msg_info "Waiting for OpenWrt to boot..."
+for i in {1..30}; do
+  if qm agent $VMID ping 2>/dev/null; then
+    msg_ok "OpenWrt is ready"
+    break
+  fi
+  sleep 2
 done
+
+send_line_to_vm ""
+send_line_to_vm "uci delete network.@device[0]"
+send_line_to_vm "uci set network.wan=interface"
+send_line_to_vm "uci set network.wan.device=eth1"
+send_line_to_vm "uci set network.wan.proto=dhcp"
+send_line_to_vm "uci delete network.lan"
+send_line_to_vm "uci set network.lan=interface"
+send_line_to_vm "uci set network.lan.device=eth0"
+send_line_to_vm "uci set network.lan.proto=static"
+send_line_to_vm "uci set network.lan.ipaddr=${LAN_IP_ADDR}"
+send_line_to_vm "uci set network.lan.netmask=${LAN_NETMASK}"
+send_line_to_vm "uci commit"
+send_line_to_vm "halt"
 msg_ok "Network interfaces configured in OpenWrt"
 
 msg_info "Waiting for OpenWrt to shut down..."

--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -590,11 +590,12 @@ qm start $VMID
 sleep 15
 msg_info "Waiting for OpenWrt to boot..."
 for i in {1..30}; do
-  if qm agent $VMID ping 2>/dev/null; then
-    msg_ok "OpenWrt is ready"
+  if qm status "$VMID" | grep -q "running"; then
+    sleep 5
+    msg_ok "OpenWrt is running"
     break
   fi
-  sleep 2
+  sleep 1
 done
 
 send_line_to_vm ""

--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -598,20 +598,27 @@ for i in {1..30}; do
   sleep 1
 done
 
-send_line_to_vm ""
-send_line_to_vm "uci delete network.@device[0]"
-send_line_to_vm "uci set network.wan=interface"
-send_line_to_vm "uci set network.wan.device=eth1"
-send_line_to_vm "uci set network.wan.proto=dhcp"
-send_line_to_vm "uci delete network.lan"
-send_line_to_vm "uci set network.lan=interface"
-send_line_to_vm "uci set network.lan.device=eth0"
-send_line_to_vm "uci set network.lan.proto=static"
-send_line_to_vm "uci set network.lan.ipaddr=${LAN_IP_ADDR}"
-send_line_to_vm "uci set network.lan.netmask=${LAN_NETMASK}"
-send_line_to_vm "uci commit"
-send_line_to_vm "halt"
-msg_ok "Network interfaces configured in OpenWrt"
+msg_ok "Network interfaces are being configured as OpenWrt initiates."
+
+if qm status "$VMID" | grep -q "running"; then
+  send_line_to_vm ""
+  send_line_to_vm "uci delete network.@device[0]"
+  send_line_to_vm "uci set network.wan=interface"
+  send_line_to_vm "uci set network.wan.device=eth1"
+  send_line_to_vm "uci set network.wan.proto=dhcp"
+  send_line_to_vm "uci delete network.lan"
+  send_line_to_vm "uci set network.lan=interface"
+  send_line_to_vm "uci set network.lan.device=eth0"
+  send_line_to_vm "uci set network.lan.proto=static"
+  send_line_to_vm "uci set network.lan.ipaddr=${LAN_IP_ADDR}"
+  send_line_to_vm "uci set network.lan.netmask=${LAN_NETMASK}"
+  send_line_to_vm "uci commit"
+  send_line_to_vm "halt"
+  msg_ok "Network interfaces configured in OpenWrt"
+else
+  msg_error "VM is not running"
+  exit 1
+fi
 
 msg_info "Waiting for OpenWrt to shut down..."
 until qm status "$VMID" | grep -q "stopped"; do


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Replaces the fixed sleep and repeated configuration attempts with a loop that waits for the VM to be ready using 'qm agent ping'. Configuration commands are now sent only after OpenWrt is confirmed to be ready, improving reliability and startup efficiency.
Sometimes it doesnt reboot correctly and get an  [ERROR] in line 179: exit code 255: while executing command qm sendkey $VMID "$character"
This happens not everytime, but so it should be improved

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
