### PR TITLE
beszel: fix: binary permission after upgrade

### DIFF
--- a/ct/beszel.sh
+++ b/ct/beszel.sh
@@ -33,6 +33,7 @@ function update_script() {
 
     msg_info "Updating $APP"
     $STD /opt/beszel/beszel update
+    chmod +x /opt/beszel/beszel
     msg_ok "Updated $APP"
 
     msg_info "Starting $APP"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Out of some weird reason beszel binary seems to not be executable anymore after each upgrade, I noticed this already in the other updates.
Quickly run a chmod to ensure it's executable.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
