### PR TITLE
Add Warning for Containerized Home Assistant

### DIFF
--- a/frontend/public/json/homeassistant.json
+++ b/frontend/public/json/homeassistant.json
@@ -33,6 +33,10 @@
     },
     "notes": [
         {
+            "text": "Containerized version doesn't allow Home Assistant add-ons.",
+            "type": "warning"
+        },
+        {
             "text": "If the LXC is created Privileged, the script will automatically set up USB passthrough.",
             "type": "warning"
         },


### PR DESCRIPTION
This pull request adds an important note to the Home Assistant configuration JSON to clarify a limitation of the containerized version, listed on their website as such.

https://www.home-assistant.io/installation/

Documentation update:

* Added a warning note to `frontend/public/json/homeassistant.json` indicating that the containerized version does not support Home Assistant add-ons.