### PR TITLE
Gatus: check for GO path before update

### DIFF
--- a/ct/gatus.sh
+++ b/ct/gatus.sh
@@ -33,6 +33,11 @@ function update_script() {
     systemctl stop gatus
     msg_ok "Stopped $APP"
 
+    if [[ :$PATH: != *":/usr/local/bin:"* ]]; then
+      echo 'export PATH="/usr/local/bin:$PATH"' >>~/.bashrc
+      source ~/.bashrc
+    fi
+
     mv /opt/gatus/config/config.yaml /opt
     rm -rf /opt/gatus
     fetch_and_deploy_gh_release "gatus" "TwiN/gatus"


### PR DESCRIPTION
## ✍️ Description  

- `/usr/local/bin` was not in the PATH, causing the update to fail.
- I think this check should work without partial matching, it doesn't rely on `grep` and is relatively compact.

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
