### PR TITLE
AdGuard Home: Bump to Debian 13

### DIFF
--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -20,15 +20,15 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/AdGuardHome ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    msg_error "Adguard Home should be updated via the user interface."
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/AdGuardHome ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  msg_error "Adguard Home can only be updated via the user interface."
+  exit
 }
 
 start

--- a/frontend/public/json/adguard.json
+++ b/frontend/public/json/adguard.json
@@ -1,51 +1,51 @@
 {
-    "name": "AdGuard Home",
-    "slug": "adguard",
-    "categories": [
-        5
-    ],
-    "date_created": "2024-04-28",
-    "type": "ct",
-    "updateable": true,
-    "privileged": false,
-    "interface_port": 3000,
-    "documentation": "https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started",
-    "website": "https://adguard.com/en/adguard-home/overview.html",
-    "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/adguard-home.webp",
-    "config_path": "/opt/AdGuardHome/AdGuardHome.yaml",
-    "description": "AdGuard Home is an open-source, self-hosted network-wide ad blocker. It blocks advertisements, trackers, phishing and malware websites, and provides protection against online threats. AdGuard Home is a DNS-based solution, which means it blocks ads and malicious content at the network level, before it even reaches your device. It runs on your home network and can be easily configured and managed through a web-based interface. It provides detailed statistics and logs, allowing you to see which websites are being blocked, and why. AdGuard Home is designed to be fast, lightweight, and easy to use, making it an ideal solution for home users who want to block ads, protect their privacy, and improve the speed and security of their online experience.",
-    "install_methods": [
-        {
-            "type": "default",
-            "script": "ct/adguard.sh",
-            "resources": {
-                "cpu": 1,
-                "ram": 512,
-                "hdd": 2,
-                "os": "debian",
-                "version": "12"
-            }
-        },
-        {
-            "type": "alpine",
-            "script": "ct/alpine-adguard.sh",
-            "resources": {
-                "cpu": 1,
-                "ram": 256,
-                "hdd": 1,
-                "os": "alpine",
-                "version": "3.22"
-            }
-        }
-    ],
-    "default_credentials": {
-        "username": null,
-        "password": null
+  "name": "AdGuard Home",
+  "slug": "adguard",
+  "categories": [
+    5
+  ],
+  "date_created": "2024-04-28",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 3000,
+  "documentation": "https://github.com/AdguardTeam/AdGuardHome/wiki/Getting-Started",
+  "website": "https://adguard.com/en/adguard-home/overview.html",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/adguard-home.webp",
+  "config_path": "/opt/AdGuardHome/AdGuardHome.yaml",
+  "description": "AdGuard Home is an open-source, self-hosted network-wide ad blocker. It blocks advertisements, trackers, phishing and malware websites, and provides protection against online threats. AdGuard Home is a DNS-based solution, which means it blocks ads and malicious content at the network level, before it even reaches your device. It runs on your home network and can be easily configured and managed through a web-based interface. It provides detailed statistics and logs, allowing you to see which websites are being blocked, and why. AdGuard Home is designed to be fast, lightweight, and easy to use, making it an ideal solution for home users who want to block ads, protect their privacy, and improve the speed and security of their online experience.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/adguard.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 2,
+        "os": "debian",
+        "version": "13"
+      }
     },
-    "notes": [
-        {
-            "text": "Adguard Home can be updated via the user interface.",
-            "type": "info"
-        }
-    ]
+    {
+      "type": "alpine",
+      "script": "ct/alpine-adguard.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 256,
+        "hdd": 1,
+        "os": "alpine",
+        "version": "3.22"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "AdGuard Home can only be updated via the user interface.",
+      "type": "info"
+    }
+  ]
 }

--- a/install/adguard-install.sh
+++ b/install/adguard-install.sh
@@ -13,9 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing AdGuard Home"
-$STD tar zxvf <(curl -fsSL https://static.adtidy.org/adguardhome/release/AdGuardHome_linux_amd64.tar.gz) -C /opt
-msg_ok "Installed AdGuard Home"
+fetch_and_deploy_gh_release "AdGuardHome" "AdguardTeam/AdGuardHome" "prebuild" "latest" "/opt/AdGuardHome" "AdGuardHome_linux_amd64.tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/AdGuardHome.service
@@ -45,6 +43,7 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+$STD apt -y autoremove
+$STD apt -y autoclean
+$STD apt -y clean
 msg_ok "Cleaned"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- Bump default OS version for AdGuard Home container to Debian 13 in both ct/adguard.sh and adguard.json. 
- Update install script to use fetch_and_deploy_gh_release for more robust deployment. 
- Clarify update instructions in scripts and metadata to state that AdGuard Home can only be updated via the user interface.
- Minor cleanup in install script and messaging.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
