### PR TITLE
Immich: Debian Trixie

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -11,7 +11,7 @@ var_disk="${var_disk:-20}"
 var_cpu="${var_cpu:-4}"
 var_ram="${var_ram:-4096}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -27,10 +27,21 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  if [[ -f /etc/apt/sources.list.d/immich.list ]]; then
+    msg_error "Wrong Debian version detected!"
+    msg_error "You must upgrade your LXC to Debian Trixie before updating."
+    msg_error "Please visit https://github.com/community-scripts/ProxmoxVE/discussions/7726 for details."
+    echo "${TAB3}  If you have upgraded your LXC to Trixie and you still see this message, please open an Issue in the Community Scripts repo."
+    exit
+  fi
 
   setup_uv
   PNPM_VERSION="$(curl -fsSL "https://raw.githubusercontent.com/immich-app/immich/refs/heads/main/package.json" | jq -r '.packageManager | split("@")[1]')"
   NODE_VERSION="22" NODE_MODULE="pnpm@${PNPM_VERSION}" setup_nodejs
+
+  if dpkg -l | grep -q "libmimalloc2.0"; then
+    $STD apt-get update && $STD apt-get install -y libmimalloc3
+  fi
 
   STAGING_DIR=/opt/staging
   BASE_DIR=${STAGING_DIR}/base-images
@@ -45,8 +56,10 @@ function update_script() {
       for url in "${INTEL_URLS[@]}"; do
         curl -fsSLO "$url"
       done
+      $STD apt-mark unhold libigdgmm12
       $STD apt install -y ./*.deb
       rm ./*.deb
+      $STD apt-mark hold libigdgmm12
       msg_ok "Intel iGPU dependencies updated"
     fi
     rm ~/Dockerfile
@@ -78,22 +91,10 @@ function update_script() {
 
     if [[ ! -f ~/.vchord_version ]] || [[ "$VCHORD_RELEASE" != "$(cat ~/.vchord_version)" ]]; then
       msg_info "Updating VectorChord"
-      if [[ ! -f ~/.vchord_version ]] || [[ ! "$(cat ~/.vchord_version)" > "0.3.0" ]]; then
-        $STD sudo -u postgres pg_dumpall --clean --if-exists --username=postgres | gzip >/etc/postgresql/immich-db-vchord0.3.0.sql.gz
-        chown postgres /etc/postgresql/immich-db-vchord0.3.0.sql.gz
-        $STD sudo -u postgres gunzip --stdout /etc/postgresql/immich-db-vchord0.3.0.sql.gz |
-          sed -e "s/SELECT pg_catalog.set_config('search_path', '', false);/SELECT pg_catalog.set_config('search_path', 'public, pg_catalog', true);/g" \
-            -e "/vchordrq.prewarm_dim/d" |
-          sudo -u postgres psql
-      fi
       curl -fsSL "https://github.com/tensorchord/vectorchord/releases/download/${VCHORD_RELEASE}/postgresql-16-vchord_${VCHORD_RELEASE}-1_amd64.deb" -o vchord.deb
       $STD apt install -y ./vchord.deb
       $STD sudo -u postgres psql -d immich -c "ALTER EXTENSION vchord UPDATE;"
       systemctl restart postgresql
-      if [[ ! -f ~/.vchord_version ]] || [[ ! "$(cat ~/.vchord_version)" > "0.3.0" ]]; then
-        $STD sudo -u postgres psql -d immich -c "REINDEX INDEX face_index;"
-        $STD sudo -u postgres psql -d immich -c "REINDEX INDEX clip_index;"
-      fi
       echo "$VCHORD_RELEASE" >~/.vchord_version
       rm ./vchord.deb
       msg_ok "Updated VectorChord to v${VCHORD_RELEASE}"
@@ -126,9 +127,6 @@ EOF
 
     msg_info "Updating ${APP} web and microservices"
     cd "$SRC_DIR"/server
-    if [[ "$RELEASE" == "1.135.1" ]]; then
-      rm ./src/schema/migrations/1750323941566-UnsetPrewarmDimParameter.ts
-    fi
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     export CI=1
     corepack enable
@@ -144,6 +142,7 @@ EOF
 
     # openapi & web build
     cd "$SRC_DIR"
+    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
     $STD pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install
     $STD pnpm --filter @immich/sdk --filter immich-web build
     cp -a web/build "$APP_DIR"/www
@@ -158,16 +157,16 @@ EOF
     msg_ok "Updated ${APP} web and microservices"
 
     cd "$SRC_DIR"/machine-learning
-    mkdir -p "$ML_DIR"
+    mkdir -p "$ML_DIR" && chown -R immich:immich "$ML_DIR"
     export VIRTUAL_ENV="${ML_DIR}"/ml-venv
     if [[ -f ~/.openvino ]]; then
       msg_info "Updating HW-accelerated machine-learning"
-      $STD /usr/local/bin/uv sync --extra openvino --no-cache --active
+      $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv sync --extra openvino --active -n -p python3.11 --managed-python
       patchelf --clear-execstack "${VIRTUAL_ENV}/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so"
       msg_ok "Updated HW-accelerated machine-learning"
     else
       msg_info "Updating machine-learning"
-      $STD /usr/local/bin/uv sync --extra cpu --no-cache --active
+      $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv sync --extra cpu --active -n -p python3.11 --managed-python
       msg_ok "Updated machine-learning"
     fi
     cd "$SRC_DIR"
@@ -186,10 +185,6 @@ EOF
     ln -s "$GEO_DIR" "$APP_DIR"
 
     chown -R immich:immich "$INSTALL_DIR"
-    if [[ ! -f ~/.debian_version.bak ]]; then
-      cp /etc/debian_version ~/.debian_version.bak
-      sed -i 's/.*/13.0/' /etc/debian_version
-    fi
     msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Cleaning up"
@@ -205,8 +200,7 @@ function compile_libjxl() {
   SOURCE=${SOURCE_DIR}/libjxl
   JPEGLI_LIBJPEG_LIBRARY_SOVERSION="62"
   JPEGLI_LIBJPEG_LIBRARY_VERSION="62.3.0"
-  # : "${LIBJXL_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libjxl.json)}"
-  : "${LIBJXL_REVISION:=794a5dcf0d54f9f0b20d288a12e87afb91d20dfc}"
+  : "${LIBJXL_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libjxl.json)}"
   if [[ "$LIBJXL_REVISION" != "$(grep 'libjxl' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libjxl"
     if [[ -d "$SOURCE" ]]; then rm -rf "$SOURCE"; fi
@@ -253,8 +247,7 @@ function compile_libheif() {
     $STD apt-get install -y libaom-dev
     local update="required"
   fi
-  # : "${LIBHEIF_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libheif.json)}"
-  : "${LIBHEIF_REVISION:=35dad50a9145332a7bfdf1ff6aef6801fb613d68}"
+  : "${LIBHEIF_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libheif.json)}"
   if [[ "${update:-}" ]] || [[ "$LIBHEIF_REVISION" != "$(grep 'libheif' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libheif"
     if [[ -d "$SOURCE" ]]; then rm -rf "$SOURCE"; fi
@@ -285,9 +278,7 @@ function compile_libheif() {
 
 function compile_libraw() {
   SOURCE=${SOURCE_DIR}/libraw
-  local update
-  # : "${LIBRAW_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libraw.json)}"
-  : "${LIBRAW_REVISION:=09bea31181b43e97959ee5452d91e5bc66365f1f}"
+  : "${LIBRAW_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libraw.json)}"
   if [[ "$LIBRAW_REVISION" != "$(grep 'libraw' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libraw"
     if [[ -d "$SOURCE" ]]; then rm -rf "$SOURCE"; fi
@@ -308,15 +299,15 @@ function compile_libraw() {
 
 function compile_imagemagick() {
   SOURCE=$SOURCE_DIR/imagemagick
-  # : "${IMAGEMAGICK_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/imagemagick.json)}"
-  : "${IMAGEMAGICK_REVISION:=8289a3388a085ad5ae81aa6812f21554bdfd54f2}"
-  if [[ "$IMAGEMAGICK_REVISION" != "$(grep 'imagemagick' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
+  : "${IMAGEMAGICK_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/imagemagick.json)}"
+  if [[ "$IMAGEMAGICK_REVISION" != "$(grep 'imagemagick' ~/.immich_library_revisions | awk '{print $2}')" ]] ||
+    ! grep -q 'DMAGICK_LIBRAW' /usr/local/lib/ImageMagick-7*/config-Q16HDRI/configure.xml; then
     msg_info "Recompiling ImageMagick"
     if [[ -d "$SOURCE" ]]; then rm -rf "$SOURCE"; fi
     $STD git clone https://github.com/ImageMagick/ImageMagick.git "$SOURCE"
     cd "$SOURCE"
     $STD git reset --hard "$IMAGEMAGICK_REVISION"
-    $STD ./configure --with-modules
+    $STD ./configure --with-modules CPPFLAGS="-DMAGICK_LIBRAW_VERSION_TAIL=202502"
     $STD make -j"$(nproc)"
     $STD make install
     ldconfig /usr/local/lib
@@ -329,8 +320,7 @@ function compile_imagemagick() {
 
 function compile_libvips() {
   SOURCE=$SOURCE_DIR/libvips
-  # : "${LIBVIPS_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libvips.json)}"
-  : "${LIBVIPS_REVISION:=8fa37a64547e392d3808eed8d72adab7e02b3d00}"
+  : "${LIBVIPS_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libvips.json)}"
   if [[ "$LIBVIPS_REVISION" != "$(grep 'libvips' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libvips"
     if [[ -d "$SOURCE" ]]; then rm -rf "$SOURCE"; fi

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -31,7 +31,7 @@ function update_script() {
     msg_error "Wrong Debian version detected!"
     msg_error "You must upgrade your LXC to Debian Trixie before updating."
     msg_error "Please visit https://github.com/community-scripts/ProxmoxVE/discussions/7726 for details."
-    echo "${TAB3}  If you have upgraded your LXC to Trixie and you still see this message, please open an Issue in the Community Scripts repo."
+    echo "${TAB3}  If you have upgraded your LXC to Trixie and you still see this message, please open an Issue in the Community-Scripts repo."
     exit
   fi
 

--- a/frontend/public/json/immich.json
+++ b/frontend/public/json/immich.json
@@ -23,7 +23,7 @@
         "ram": 4096,
         "hdd": 20,
         "os": "Debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -15,14 +15,7 @@ update_os
 
 setup_uv
 
-msg_info "Configuring apt and installing dependencies"
-echo "deb http://deb.debian.org/debian testing main contrib" >/etc/apt/sources.list.d/immich.list
-cat <<EOF >/etc/apt/preferences.d/immich
-Package: *
-Pin: release a=testing
-Pin-Priority: -10
-EOF
-
+msg_info "Installing dependencies"
 $STD apt-get update
 $STD apt-get install --no-install-recommends -y \
   git \
@@ -53,25 +46,33 @@ $STD apt-get install --no-install-recommends -y \
   libgomp1 \
   liblqr-1-0 \
   libltdl7 \
-  libmimalloc2.0 \
+  libmimalloc3 \
   libopenjp2-7 \
   meson \
   ninja-build \
   pkg-config \
-  cpanminus \
   mesa-utils \
   mesa-va-drivers \
   mesa-vulkan-drivers \
   ocl-icd-libopencl1 \
   tini \
-  zlib1g
+  zlib1g \
+  libio-compress-brotli-perl \
+  libwebp7 \
+  libwebpdemux2 \
+  libwebpmux3 \
+  libhwy1t64 \
+  libdav1d-dev \
+  libhwy-dev \
+  libwebp-dev \
+  libaom-dev
 curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor -o /etc/apt/keyrings/jellyfin.gpg
 DPKG_ARCHITECTURE="$(dpkg --print-architecture)"
 export DPKG_ARCHITECTURE
 cat <<EOF >/etc/apt/sources.list.d/jellyfin.sources
 Types: deb
 URIs: https://repo.jellyfin.org/debian
-Suites: bookworm
+Suites: trixie
 Components: main
 Architectures: ${DPKG_ARCHITECTURE}
 Signed-By: /etc/apt/keyrings/jellyfin.gpg
@@ -93,6 +94,7 @@ read -r -p "${TAB3}Install OpenVINO dependencies for Intel HW-accelerated machin
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   msg_info "Installing OpenVINO dependencies"
   touch ~/.openvino
+  $STD apt-get install -y --no-install-recommends patchelf
   tmp_dir=$(mktemp -d)
   $STD pushd "$tmp_dir"
   curl -fsSLO https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17384.11/intel-igc-core_1.0.17384.11_amd64.deb
@@ -100,6 +102,7 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   curl -fsSLO https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/intel-opencl-icd_24.31.30508.7_amd64.deb
   curl -fsSLO https://github.com/intel/compute-runtime/releases/download/24.31.30508.7/libigdgmm12_22.4.1_amd64.deb
   $STD apt install -y ./*.deb
+  $STD apt-mark hold libigdgmm12
   $STD popd
   rm -rf "$tmp_dir"
   dpkg -l | grep "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
@@ -134,27 +137,7 @@ $STD sudo -u postgres psql -c "ALTER USER $DB_USER WITH SUPERUSER;"
 } >>~/"$APPLICATION".creds
 msg_ok "Set up Postgresql Database"
 
-msg_info "Installing Packages from Testing Repo"
-export APT_LISTCHANGES_FRONTEND=none
-export DEBIAN_FRONTEND=noninteractive
-$STD apt-get install -t testing --no-install-recommends -y \
-  libio-compress-brotli-perl \
-  libwebp7 \
-  libwebpdemux2 \
-  libwebpmux3 \
-  libhwy1t64 \
-  libdav1d-dev \
-  libhwy-dev \
-  libwebp-dev \
-  libaom-dev
-if [[ -f ~/.openvino ]]; then
-  $STD apt-get install -t testing -y patchelf
-fi
-msg_ok "Packages from Testing Repo Installed"
-
-$STD sudo -u postgres psql -c "ALTER DATABASE postgres REFRESH COLLATION VERSION;"
-$STD sudo -u postgres psql -c "ALTER DATABASE $DB_NAME REFRESH COLLATION VERSION;"
-
+msg_info "Compiling Custom Photo-processing Library (extreme patience)"
 LD_LIBRARY_PATH=/usr/local/lib
 export LD_RUN_PATH=/usr/local/lib
 STAGING_DIR=/opt/staging
@@ -169,8 +152,7 @@ cd "$STAGING_DIR"
 SOURCE=${SOURCE_DIR}/libjxl
 JPEGLI_LIBJPEG_LIBRARY_SOVERSION="62"
 JPEGLI_LIBJPEG_LIBRARY_VERSION="62.3.0"
-# : "${LIBJXL_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libjxl.json)}"
-: "${LIBJXL_REVISION:=794a5dcf0d54f9f0b20d288a12e87afb91d20dfc}"
+: "${LIBJXL_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libjxl.json)}"
 $STD git clone https://github.com/libjxl/libjxl.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBJXL_REVISION"
@@ -207,8 +189,7 @@ msg_ok "(1/5) Compiled libjxl"
 
 msg_info "(2/5) Compiling libheif"
 SOURCE=${SOURCE_DIR}/libheif
-# : "${LIBHEIF_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libheif.json)}"
-: "${LIBHEIF_REVISION:=35dad50a9145332a7bfdf1ff6aef6801fb613d68}"
+: "${LIBHEIF_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libheif.json)}"
 $STD git clone https://github.com/strukturag/libheif.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBHEIF_REVISION"
@@ -233,8 +214,7 @@ msg_ok "(2/5) Compiled libheif"
 
 msg_info "(3/5) Compiling libraw"
 SOURCE=${SOURCE_DIR}/libraw
-# : "${LIBRAW_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libraw.json)}"
-: "${LIBRAW_REVISION:=09bea31181b43e97959ee5452d91e5bc66365f1f}"
+: "${LIBRAW_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libraw.json)}"
 $STD git clone https://github.com/libraw/libraw.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBRAW_REVISION"
@@ -249,12 +229,11 @@ msg_ok "(3/5) Compiled libraw"
 
 msg_info "(4/5) Compiling imagemagick"
 SOURCE=$SOURCE_DIR/imagemagick
-# : "${IMAGEMAGICK_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/imagemagick.json)}"
-: "${IMAGEMAGICK_REVISION:=8289a3388a085ad5ae81aa6812f21554bdfd54f2}"
+: "${IMAGEMAGICK_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/imagemagick.json)}"
 $STD git clone https://github.com/ImageMagick/ImageMagick.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$IMAGEMAGICK_REVISION"
-$STD ./configure --with-modules
+$STD ./configure --with-modules CPPFLAGS="-DMAGICK_LIBRAW_VERSION_TAIL=202502"
 $STD make -j"$(nproc)"
 $STD make install
 ldconfig /usr/local/lib
@@ -264,8 +243,7 @@ msg_ok "(4/5) Compiled imagemagick"
 
 msg_info "(5/5) Compiling libvips"
 SOURCE=$SOURCE_DIR/libvips
-# : "${LIBVIPS_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libvips.json)}"
-: "${LIBVIPS_REVISION:=8fa37a64547e392d3808eed8d72adab7e02b3d00}"
+: "${LIBVIPS_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libvips.json)}"
 $STD git clone https://github.com/libvips/libvips.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBVIPS_REVISION"
@@ -314,6 +292,7 @@ sed -i 's|^start|./start|' "$APP_DIR"/bin/immich-admin
 
 # openapi & web build
 cd "$SRC_DIR"
+echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
 $STD pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install
 $STD pnpm --filter @immich/sdk --filter immich-web build
 cp -a web/build "$APP_DIR"/www
@@ -326,16 +305,17 @@ $STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
 msg_ok "Installed Immich Server and Web Components"
 
 cd "$SRC_DIR"/machine-learning
-mkdir -p "$ML_DIR"
+$STD useradd -U -s /usr/sbin/nologin -r -M -d "$INSTALL_DIR" immich
+mkdir -p "$ML_DIR" && chown -R immich:immich "$INSTALL_DIR"
 export VIRTUAL_ENV="${ML_DIR}/ml-venv"
 if [[ -f ~/.openvino ]]; then
   msg_info "Installing HW-accelerated machine-learning"
-  $STD uv sync --extra openvino --no-cache --active
+  $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv sync --extra openvino --active -n -p python3.11 --managed-python
   patchelf --clear-execstack "${VIRTUAL_ENV}/lib/python3.11/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.cpython-311-x86_64-linux-gnu.so"
   msg_ok "Installed HW-accelerated machine-learning"
 else
   msg_info "Installing machine-learning"
-  $STD uv sync --extra cpu --no-cache --active
+  $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv sync --extra cpu --active -n -p python3.11 --managed-python
   msg_ok "Installed machine-learning"
 fi
 cd "$SRC_DIR"
@@ -374,8 +354,7 @@ mkdir -p /var/log/immich
 touch /var/log/immich/{web.log,ml.log}
 msg_ok "Installed ${APPLICATION}"
 
-msg_info "Creating user, env file, scripts & services"
-$STD useradd -U -s /usr/sbin/nologin -r -M -d "$INSTALL_DIR" immich
+msg_info "Modifying user, creating env file, scripts & services"
 usermod -aG video,render immich
 
 cat <<EOF >"${INSTALL_DIR}"/.env
@@ -464,11 +443,8 @@ WantedBy=multi-user.target
 EOF
 chown -R immich:immich "$INSTALL_DIR" /var/log/immich
 systemctl enable -q --now "$APPLICATION"-ml.service "$APPLICATION"-web.service
-msg_ok "Created user, env file, scripts and services"
+msg_ok "Modified user, created env file, scripts and services"
 
-sed -i "$ a VERSION_ID=12" /etc/os-release # otherwise the motd_ssh function will fail
-cp /etc/debian_version ~/.debian_version.bak
-sed -i 's/.*/13.0/' /etc/debian_version
 motd_ssh
 customize
 


### PR DESCRIPTION
## ✍️ Description  

- Use Debian Stable repo for all dependencies
- Remove unneeded dependencies
- Replace `libmimalloc2.0` with `libmimalloc3`
- Remove pre-1.140.x workarounds
- Pin an Intel OpenVINO dependency
- Force use of Python3.11 for machine-learning builds
- Unpin custom photo-library revisions
- Remove old vchord patches
- Remove DB collation version refresh
- Exit on detection of Debian 12 or below with message
- Force hardlink as pnpm import method (fixes #7192)

## 🔗 Related PR / Issue  
Link: #7726 

## ⚠️ Breaking Change

Support for the Debian 12 (Bookworm) version of Immich has ended. If you try to update your Bookworm Immich LXC it will fail and tell you to upgrade to Trixie first. The script will fail before it deletes anything so that's cool. Go to [this discussion](https://github.com/community-scripts/ProxmoxVE/discussions/7726) to learn how to migrate.

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
