### PR TITLE
Update Zabbix install for Debian 13 and agent selection

### DIFF
--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-6}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -23,37 +23,72 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
+
   if [[ ! -f /etc/zabbix/zabbix_server.conf ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  msg_info "Stopping ${APP} Services"
-  systemctl stop zabbix-server zabbix-agent2
-  msg_ok "Stopped ${APP} Services"
 
-  msg_info "Updating $APP LXC"
+  . /etc/os-release
+  if [ "$VERSION_CODENAME" != "trixie" ]; then
+    msg_error "Unsupported Debian version: $VERSION_CODENAME – please upgrade to Debian 13 (Trixie) before updating Zabbix."
+    exit 1
+  fi
+
+  if systemctl list-unit-files | grep -q zabbix-agent2.service; then
+    AGENT_SERVICE="zabbix-agent2"
+  else
+    AGENT_SERVICE="zabbix-agent"
+  fi
+
+  msg_info "Stopping Services"
+  systemctl stop zabbix-server $AGENT_SERVICE
+  msg_ok "Stopped Services"
+
+  msg_info "Updating Zabbix"
   mkdir -p /opt/zabbix-backup/
   cp /etc/zabbix/zabbix_server.conf /opt/zabbix-backup/
   cp /etc/apache2/conf-enabled/zabbix.conf /opt/zabbix-backup/
   cp -R /usr/share/zabbix/ /opt/zabbix-backup/
-  #cp -R /usr/share/zabbix-* /opt/zabbix-backup/ Remove temporary
+
   rm -Rf /etc/apt/sources.list.d/zabbix.list
   cd /tmp
   curl -fsSL "$(curl -fsSL https://repo.zabbix.com/zabbix/ |
     grep -oP '(?<=href=")[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1 |
-    xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian12_all.deb")" \
-    -o /tmp/zabbix-release_latest+debian12_all.deb
-  $STD dpkg -i zabbix-release_latest+debian12_all.deb
-  $STD apt-get update
-  $STD apt-get install --only-upgrade zabbix-server-pgsql zabbix-frontend-php zabbix-agent2 zabbix-agent2-plugin-*
+    xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb")" \
+    -o /tmp/zabbix-release_latest+debian13_all.deb
+  $STD dpkg -i zabbix-release_latest+debian13_all.deb
+  $STD apt update
 
-  msg_info "Starting ${APP} Services"
-  systemctl start zabbix-server zabbix-agent2
+  $STD apt install --only-upgrade zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql
+
+  if [ "$AGENT_SERVICE" = "zabbix-agent2" ]; then
+    $STD apt install --only-upgrade zabbix-agent2 zabbix-agent2-plugin-postgresql
+    if [ -f /etc/zabbix/zabbix_agent2.d/plugins.d/nvidia.conf ]; then
+      sed -i 's|^Plugins.NVIDIA.System.Path=.*|# Plugins.NVIDIA.System.Path=/usr/libexec/zabbix/zabbix-agent2-plugin-nvidia-gpu|' \
+        /etc/zabbix/zabbix_agent2.d/plugins.d/nvidia.conf
+    fi
+  else
+    $STD apt install --only-upgrade zabbix-agent
+  fi
+
+  if command -v fping >/dev/null 2>&1; then
+    FPING_PATH=$(command -v fping)
+    sed -i "s|^#\?FpingLocation=.*|FpingLocation=$FPING_PATH|" /etc/zabbix/zabbix_server.conf
+  fi
+  if command -v fping6 >/dev/null 2>&1; then
+    FPING6_PATH=$(command -v fping6)
+    sed -i "s|^#\?Fping6Location=.*|Fping6Location=$FPING6_PATH|" /etc/zabbix/zabbix_server.conf
+  fi
+  msg_ok "Updated Zabbix"
+
+  msg_info "Starting Services"
+  systemctl start zabbix-server $AGENT_SERVICE
   systemctl restart apache2
-  msg_ok "Started ${APP} Services"
+  msg_ok "Started Services"
 
   msg_info "Cleaning Up"
-  rm -rf /tmp/zabbix-release_latest+debian12_all.deb
+  rm -rf /tmp/zabbix-release_latest+debian13_all.deb
   msg_ok "Cleaned"
   msg_ok "Updated Successfully"
   exit

--- a/frontend/public/json/zabbix.json
+++ b/frontend/public/json/zabbix.json
@@ -23,7 +23,7 @@
         "ram": 4096,
         "hdd": 6,
         "os": "debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],
@@ -33,11 +33,19 @@
   },
   "notes": [
     {
-      "text": "Database credentials: `cat zabbix.creds`",
+      "text": "Database credentials: `cat ~/zabbix.creds`",
       "type": "info"
     },
     {
-      "text": "Zabbix agent 2 is used by default",
+      "text": "You can choose between Zabbix agent (classic) and agent2 (modern) during installation",
+      "type": "info"
+    },
+    {
+      "text": "For agent2 the PostgreSQL plugin is installed by default; all plugins are optional",
+      "type": "info"
+    },
+    {
+      "text": "If agent2 with NVIDIA plugin is installed in an environment without GPU, the installer disables it automatically",
       "type": "info"
     }
   ]

--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -13,20 +13,61 @@ setting_up_container
 network_check
 update_os
 
+PG_VERSION="17" setup_postgresql
+
 msg_info "Installing Zabbix"
 cd /tmp
 curl -fsSL "$(curl -fsSL https://repo.zabbix.com/zabbix/ |
   grep -oP '(?<=href=")[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1 |
-  xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian12_all.deb")" \
-  -o /tmp/zabbix-release_latest+debian12_all.deb
-$STD dpkg -i /tmp/zabbix-release_latest+debian12_all.deb
-$STD apt-get update
-$STD apt-get install -y zabbix-server-pgsql zabbix-frontend-php php8.2-pgsql zabbix-apache-conf zabbix-sql-scripts
-$STD apt-get install -y zabbix-agent2 zabbix-agent2-plugin-*
+  xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb")" \
+  -o /tmp/zabbix-release_latest+debian13_all.deb
+$STD dpkg -i /tmp/zabbix-release_latest+debian13_all.deb
+$STD apt update
+$STD apt install -y zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql zabbix-apache-conf zabbix-sql-scripts
 msg_ok "Installed Zabbix"
 
+while true; do
+  read -rp "Install which agent? [1=agent (classic), 2=agent2 (modern), default=1]: " AGENT_CHOICE
+  case "$AGENT_CHOICE" in
+  2)
+    AGENT_PKG="zabbix-agent2"
+    break
+    ;;
+  "" | 1)
+    AGENT_PKG="zabbix-agent"
+    break
+    ;;
+  *)
+    echo "Invalid choice. Please enter 1 or 2."
+    ;;
+  esac
+done
+msg_ok "Selected $AGENT_PKG"
+
+if [ "$AGENT_PKG" = "zabbix-agent2" ]; then
+  echo "Choose plugins for Zabbix Agent2:"
+  echo "1) PostgreSQL only (default, recommended)"
+  echo "2) All plugins (may cause issues)"
+  read -rp "Choose option [1-2]: " PLUGIN_CHOICE
+
+  case "$PLUGIN_CHOICE" in
+  2)
+    $STD apt install -y zabbix-agent2 zabbix-agent2-plugin-*
+    ;;
+  *)
+    $STD apt install -y zabbix-agent2 zabbix-agent2-plugin-postgresql
+    ;;
+  esac
+
+  if [ -f /etc/zabbix/zabbix_agent2.d/plugins.d/nvidia.conf ]; then
+    sed -i 's|^Plugins.NVIDIA.System.Path=.*|# Plugins.NVIDIA.System.Path=/usr/libexec/zabbix/zabbix-agent2-plugin-nvidia-gpu|' \
+      /etc/zabbix/zabbix_agent2.d/plugins.d/nvidia.conf
+  fi
+else
+  $STD apt install -y zabbix-agent
+fi
+
 msg_info "Setting up PostgreSQL"
-$STD apt-get install -y postgresql
 DB_NAME=zabbixdb
 DB_USER=zabbix
 DB_PASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-13)
@@ -35,17 +76,32 @@ $STD sudo -u postgres psql -c "CREATE DATABASE $DB_NAME WITH OWNER $DB_USER ENCO
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET client_encoding TO 'utf8';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET default_transaction_isolation TO 'read committed';"
 $STD sudo -u postgres psql -c "ALTER ROLE $DB_USER SET timezone TO 'UTC'"
+{
+  echo "Zabbix-Credentials"
+  echo "Zabbix Database User: $DB_USER"
+  echo "Zabbix Database Password: $DB_PASS"
+  echo "Zabbix Database Name: $DB_NAME"
+  echo "Zabbix Admin Email: $ADMIN_EMAIL"
+  echo "Zabbix Admin Password: $ADMIN_PASSWORD"
+} >>~/zabbix.creds
+
 zcat /usr/share/zabbix/sql-scripts/postgresql/server.sql.gz | sudo -u $DB_USER psql $DB_NAME &>/dev/null
 sed -i "s/^DBName=.*/DBName=$DB_NAME/" /etc/zabbix/zabbix_server.conf
 sed -i "s/^DBUser=.*/DBUser=$DB_USER/" /etc/zabbix/zabbix_server.conf
 sed -i "s/^# DBPassword=.*/DBPassword=$DB_PASS/" /etc/zabbix/zabbix_server.conf
-echo "" >~/zabbix.creds
-echo "zabbix Database Credentials" >>~/zabbix.creds
-echo "" >>~/zabbix.creds
-echo -e "zabbix Database User: \e[32m$DB_USER\e[0m" >>~/zabbix.creds
-echo -e "zabbix Database Password: \e[32m$DB_PASS\e[0m" >>~/zabbix.creds
-echo -e "zabbix Database Name: \e[32m$DB_NAME\e[0m" >>~/zabbix.creds
 msg_ok "Set up PostgreSQL"
+
+msg_info "Configuring Fping"
+if command -v fping >/dev/null 2>&1; then
+  FPING_PATH=$(command -v fping)
+  sed -i "s|^#\?FpingLocation=.*|FpingLocation=$FPING_PATH|" /etc/zabbix/zabbix_server.conf
+fi
+
+if command -v fping6 >/dev/null 2>&1; then
+  FPING6_PATH=$(command -v fping6)
+  sed -i "s|^#\?Fping6Location=.*|Fping6Location=$FPING6_PATH|" /etc/zabbix/zabbix_server.conf
+fi
+msg_ok "Configured Fping"
 
 msg_info "Starting Services"
 systemctl restart zabbix-server zabbix-agent2 apache2
@@ -56,7 +112,8 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-rm -rf /tmp/zabbix-release_latest+debian12_all.deb
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+rm -rf /tmp/zabbix-release_latest+debian13_all.deb
+$STD apt -y autoremove
+$STD apt -y autoclean
+$STD apt -y clean
 msg_ok "Cleaned"

--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -27,7 +27,7 @@ $STD apt install -y zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql zabbix-
 msg_ok "Installed Zabbix"
 
 while true; do
-  read -rp "Install which agent? [1=agent (classic), 2=agent2 (modern), default=1]: " AGENT_CHOICE
+  read -rp "Which agent do you want to install? [1=agent (classic), 2=agent2 (modern), default=1]: " AGENT_CHOICE
   case "$AGENT_CHOICE" in
   2)
     AGENT_PKG="zabbix-agent2"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Update scripts and JSON config to support Debian 13 (Trixie) for Zabbix installation and upgrade. Add interactive selection between Zabbix agent (classic) and agent2 (modern) with plugin options during install. Improve handling of agent2 NVIDIA plugin and Fping configuration. Update credential storage and user notes for clarity.



## 🔗 Related PR / Issue  
Link: #7097


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
