### PR TITLE
Update Monica and Outline to use Node.js 22

### DIFF
--- a/ct/monica.sh
+++ b/ct/monica.sh
@@ -27,6 +27,9 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+
+  NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
+
   if check_for_gh_release "monica" "monicahq/monica"; then
     msg_info "Stopping Service"
     systemctl stop apache2

--- a/ct/outline.sh
+++ b/ct/outline.sh
@@ -28,6 +28,8 @@ function update_script() {
     exit
   fi
 
+  NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
+
   if check_for_gh_release "outline" "outline/outline"; then
     msg_info "Stopping Services"
     systemctl stop outline
@@ -37,7 +39,7 @@ function update_script() {
     cp /opt/outline/.env /opt
     msg_ok "Backup created"
 
-    fetch_and_deploy_gh_release "outline" "outline/outline" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "outline" "outline/outline" "tarball"
 
     msg_info "Updating ${APP}"
     cd /opt/outline

--- a/install/monica-install.sh
+++ b/install/monica-install.sh
@@ -16,7 +16,7 @@ update_os
 PHP_VERSION="8.2" PHP_APACHE="YES" PHP_MODULE="dom,gmp,iconv,mysqli,pdo-mysql,redis,tokenizer" setup_php
 setup_composer
 setup_mariadb
-NODE_VERSION="20" NODE_MODULE="yarn@latest" setup_nodejs
+NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
 
 msg_info "Setting up MariaDB"
 DB_NAME=monica

--- a/install/outline-install.sh
+++ b/install/outline-install.sh
@@ -20,7 +20,7 @@ $STD apt-get install -y \
   redis
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="20" NODE_MODULE="yarn@latest" setup_nodejs
+NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
 PG_VERSION="16" setup_postgresql
 
 msg_info "Set up PostgreSQL Database"


### PR DESCRIPTION
## ✍️ Description  

Bump Node.js version from 20 to 22 for both Monica and Outline in install and update scripts. Also set CLEAN_INSTALL=1 for Outline update to ensure a clean deployment. This keeps the stack up to date with the latest Node.js LTS.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
