### PR TITLE
Improve globaleaks install ensuring install can proceed without user …

### DIFF
--- a/install/globaleaks-install.sh
+++ b/install/globaleaks-install.sh
@@ -18,7 +18,7 @@ curl -fsSL https://deb.globaleaks.org/globaleaks.asc | gpg --dearmor -o /etc/apt
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/globaleaks.gpg] http://deb.globaleaks.org $DISTRO_CODENAME/" >/etc/apt/sources.list.d/globaleaks.list
 echo 'APPARMOR_SANDBOXING=0' >/etc/default/globaleaks
 $STD apt update
-$STD apt -y install globaleaks
+$STD apt -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install globaleaks
 msg_ok "Setup GlobaLeaks"
 
 motd_ssh


### PR DESCRIPTION
Following a retesting with the community it resulted this options are needed when installing the package, if the application has been preconfigured using the /etc/default/globaleaks before installation.

```bash
apt-get -y \
  -o Dpkg::Options::=--force-confdef \
  -o Dpkg::Options::=--force-confold \
  install globaleaks
```