### PR TITLE
ntfy: bump to debian 13

### DIFF
--- a/ct/ntfy.sh
+++ b/ct/ntfy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2025 tteck
-# Author: tteck (tteckster)
+# Author: CrazyWolf13
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://ntfy.sh/
 
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -23,13 +23,31 @@ function update_script() {
     header_info
     check_container_storage
     check_container_resources
-    if [[ ! -d /var ]]; then
+    if [[ ! -d /etc/ntfy ]]; then
         msg_error "No ${APP} Installation Found!"
         exit
     fi
+
+    if [ -f /etc/apt/keyrings/archive.heckel.io.gpg ]; then
+        msg_info "Correcting old Ntfy Repository"
+        rm -f /etc/apt/keyrings/archive.heckel.io.gpg
+        rm -f /etc/apt/sources.list.d/archive.heckel.io.list
+        rm -f /etc/apt/sources.list.d/archive.heckel.io.list.bak
+        rm -f /etc/apt/sources.list.d/archive.heckel.io.sources
+        curl -fsSL -o /etc/apt/keyrings/ntfy.gpg https://archive.ntfy.sh/apt/keyring.gpg
+        cat <<'EOF' >/etc/apt/sources.list.d/ntfy.sources 
+Types: deb
+URIs: https://archive.ntfy.sh/apt/
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/ntfy.gpg
+EOF
+        msg_ok "Corrected old Ntfy Repository"
+    fi
+    
     msg_info "Updating $APP LXC"
-    $STD apt-get update
-    $STD apt-get -y upgrade
+    $STD apt update
+    $STD apt -y upgrade
     msg_ok "Updated $APP LXC"
     exit
 }

--- a/ct/ntfy.sh
+++ b/ct/ntfy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
-# Copyright (c) 2021-2025 tteck
+# Copyright (c) 2021-2025 community-scripts ORG
 # Author: CrazyWolf13
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://ntfy.sh/

--- a/frontend/public/json/ntfy.json
+++ b/frontend/public/json/ntfy.json
@@ -23,7 +23,7 @@
         "ram": 512,
         "hdd": 2,
         "os": "debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/ntfy-install.sh
+++ b/install/ntfy-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2021-2025 tteck
-# Author: tteck (tteckster)
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: CrazyWolf13
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://ntfy.sh/
 
@@ -13,17 +13,19 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y \
-  apt-transport-https
-msg_ok "Installed Dependencies"
-
 msg_info "Installing ntfy"
 mkdir -p /etc/apt/keyrings
-curl -fsSL https://archive.heckel.io/apt/pubkey.txt | gpg --dearmor -o /etc/apt/keyrings/archive.heckel.io.gpg
-echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/archive.heckel.io.gpg] https://archive.heckel.io/apt debian main" >/etc/apt/sources.list.d/archive.heckel.io.list
-$STD apt-get update
-$STD apt-get install -y ntfy
+sudo curl -fsSL -o /etc/apt/keyrings/ntfy.gpg https://archive.ntfy.sh/apt/keyring.gpg
+cat <<'EOF' >/etc/apt/sources.list.d/ntfy.sources 
+Types: deb
+URIs: https://archive.ntfy.sh/apt/
+Suites: stable
+Components: main
+Signed-By: /etc/apt/keyrings/ntfy.gpg
+EOF
+
+$STD apt update
+$STD apt install -y ntfy
 systemctl enable -q --now ntfy
 msg_ok "Installed ntfy"
 
@@ -31,6 +33,6 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+$STD apt -y autoremove
+$STD apt -y autoclean
 msg_ok "Cleaned"

--- a/install/ntfy-install.sh
+++ b/install/ntfy-install.sh
@@ -16,7 +16,7 @@ update_os
 msg_info "Installing ntfy"
 mkdir -p /etc/apt/keyrings
 curl -fsSL -o /etc/apt/keyrings/ntfy.gpg https://archive.ntfy.sh/apt/keyring.gpg
-cat <<'EOF' >/etc/apt/sources.list.d/ntfy.sources 
+cat <<EOF >/etc/apt/sources.list.d/ntfy.sources 
 Types: deb
 URIs: https://archive.ntfy.sh/apt/
 Suites: stable

--- a/install/ntfy-install.sh
+++ b/install/ntfy-install.sh
@@ -35,4 +35,5 @@ customize
 msg_info "Cleaning up"
 $STD apt -y autoremove
 $STD apt -y autoclean
+$STD apt -y clean
 msg_ok "Cleaned"

--- a/install/ntfy-install.sh
+++ b/install/ntfy-install.sh
@@ -15,7 +15,7 @@ update_os
 
 msg_info "Installing ntfy"
 mkdir -p /etc/apt/keyrings
-sudo curl -fsSL -o /etc/apt/keyrings/ntfy.gpg https://archive.ntfy.sh/apt/keyring.gpg
+curl -fsSL -o /etc/apt/keyrings/ntfy.gpg https://archive.ntfy.sh/apt/keyring.gpg
 cat <<'EOF' >/etc/apt/sources.list.d/ntfy.sources 
 Types: deb
 URIs: https://archive.ntfy.sh/apt/


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Ntfy updated their repo because of apt policy rejection warning.
- Bump to deb 13
- change to deb822 even for deb12 


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
