### PR TITLE
freshrss: fix for broken permissions after update

### DIFF
--- a/ct/freshrss.sh
+++ b/ct/freshrss.sh
@@ -27,8 +27,16 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
-    msg_error "FreshRSS should be updated via the user interface."
-    exit
+
+    if [ ! -x /opt/freshrss/cli/sensitive-log.sh ]; then
+        msg_info "Fixing wrong permissions"
+        chmod +x /opt/freshrss/cli/sensitive-log.sh
+        systemctl restart apache2
+        msg_ok "Fixed wrong permissions"
+    else
+        msg_error "FreshRSS should be updated via the user interface."
+        exit
+    fi
 }
 
 start


### PR DESCRIPTION
Added permission check and fix for sensitive-log.sh.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
After each update freshrss seems to have broken permissions on the file: /opt/freshrss/cli/sensitive-log.sh this PR adds a function to the update command to fix permissions.


## 🔗 Related PR / Issue  
Link: https://github.com/FreshRSS/FreshRSS/issues/7662


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
