### PR TITLE
Bump Guacamole to Debian 13

### DIFF
--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -11,7 +11,7 @@ var_disk="${var_disk:-4}"
 var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-2048}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/apache-guacamole.json
+++ b/frontend/public/json/apache-guacamole.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 4,
         "os": "debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -13,7 +13,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y \
+$STD apt install -y \
   build-essential \
   jq \
   libcairo2-dev \
@@ -22,7 +22,7 @@ $STD apt-get install -y \
   libtool-bin \
   libossp-uuid-dev \
   libvncserver-dev \
-  freerdp2-dev \
+  freerdp3-dev \
   libssh2-1-dev \
   libtelnet-dev \
   libwebsockets-dev \
@@ -56,8 +56,9 @@ mkdir -p /etc/guacamole/{extensions,lib}
 RELEASE_SERVER=$(curl -fsSL https://api.github.com/repos/apache/guacamole-server/tags | jq -r '.[].name' | grep -v -- '-RC' | head -n 1)
 curl -fsSL "https://api.github.com/repos/apache/guacamole-server/tarball/refs/tags/${RELEASE_SERVER}" | tar -xz --strip-components=1 -C /opt/apache-guacamole/server
 cd /opt/apache-guacamole/server
+export CPPFLAGS="-Wno-error=deprecated-declarations"
 $STD autoreconf -fi
-$STD ./configure --with-init-dir=/etc/init.d --enable-allow-freerdp-snapshots
+$STD ./configure --with-init-dir=/etc/init.d --enable-allow-freerdp-snapshots --disable-guaclog
 $STD make
 $STD make install
 $STD ldconfig
@@ -149,6 +150,6 @@ customize
 msg_info "Cleaning up"
 rm -rf ~/mysql-connector-j-9.3.0{,.tar.gz}
 rm -rf ~/guacamole-auth-jdbc-$RELEASE_SERVER{,.tar.gz}
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+$STD apt -y autoremove
+$STD apt -y autoclean
 msg_ok "Cleaned"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Updates guacamole to Debian 13. Debian 13 only has freerdp3 and not freerdp2, however freerdp3 support by guacemole is considered experimental (see https://issues.apache.org/jira/browse/GUACAMOLE-1026).
Should not matter too much, since this script is marked not-updateable, so only new installations will be affected in case there are problems.


## 🔗 Related PR / Issue  
Link: #7332 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
