### PR TITLE
fix: ensure /etc/pulse exists before chown in update script

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -40,7 +40,13 @@ function update_script() {
 
     fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "*-linux-amd64.tar.gz"
     ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
-    chown -R pulse:pulse /etc/pulse /opt/pulse
+
+    # Ensure /etc/pulse exists and set ownership
+    # Use non-recursive chown on /etc/pulse to preserve existing file permissions
+    mkdir -p /etc/pulse
+    chown pulse:pulse /etc/pulse
+    chown -R pulse:pulse /opt/pulse
+    chmod 700 /etc/pulse
     if [[ -f "$SERVICE_PATH"/pulse-backend.service ]]; then
       mv "$SERVICE_PATH"/pulse-backend.service "$SERVICE_PATH"/pulse.service
     fi

--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -40,9 +40,6 @@ function update_script() {
 
     fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "*-linux-amd64.tar.gz"
     ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
-
-    # Ensure /etc/pulse exists and set ownership
-    # Use non-recursive chown on /etc/pulse to preserve existing file permissions
     mkdir -p /etc/pulse
     chown pulse:pulse /etc/pulse
     chown -R pulse:pulse /opt/pulse


### PR DESCRIPTION
## ✍️ Description

Fixes the update script failure when `/etc/pulse` directory doesn't exist.

The update script assumes `/etc/pulse` already exists, but it could be missing if the user deleted it or the installation was interrupted. This causes the `chown` command to fail with "cannot access '/etc/pulse': No such file or directory".

**Changes:**
- Add `mkdir -p /etc/pulse` to ensure directory exists before chown
- Use non-recursive `chown` on `/etc/pulse` to preserve existing file permissions (matches official Pulse install.sh behavior)
- Keep recursive `chown -R` on `/opt/pulse` for binary ownership
- Add `chmod 700` for security on config directory

**Why non-recursive chown?** The official Pulse install.sh uses non-recursive chown on `/etc/pulse` because this directory contains sensitive configuration files (nodes.enc, alerts.json, .encryption.key) with specific permissions that shouldn't be overridden.

## 🔗 Related PR / Issue
Link: #8064

## ✅ Prerequisites  (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
