### PR TITLE
immich: guard /dev/dri permissions so CPU-only installs don’t fail

### DIFF
--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -81,7 +81,7 @@ $STD apt-get update
 $STD apt-get install -y jellyfin-ffmpeg7
 ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
 ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
-if [[ "$CTTYPE" == "0" ]]; then
+if [[ "$CTTYPE" == "0" && -d /dev/dri ]]; then
   chgrp video /dev/dri
   chmod 755 /dev/dri
   chmod 660 /dev/dri/*


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

The installer failed on systems without a usable `/dev/dri` device because it always tried to run `chgrp video /dev/dri`.

Updated the condition so that the permissions step only runs if the container is privileged and `/dev/dri` actually exists. This prevents unnecessary errors on CPU-only or non-GPU hosts while keeping GPU setups unaffected.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [**X**] **Self-review completed** – Code follows project standards.  
- [**X**] **Tested thoroughly** – Changes work as expected.  
- [**X**] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [**X**] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
