### PR TITLE
BookLore: upgrade to Java 25/Gradle 9

### DIFF
--- a/ct/booklore.sh
+++ b/ct/booklore.sh
@@ -45,6 +45,8 @@ function update_script() {
     $STD npm run build --configuration=production
     msg_ok "Built Frontend"
 
+    JAVA_VERSION="25" setup_java
+
     msg_info "Building Backend"
     cd /opt/booklore/booklore-api
     APP_VERSION=$(curl -fsSL https://api.github.com/repos/booklore-app/BookLore/releases/latest | yq '.tag_name' | sed 's/^v//')

--- a/install/booklore-install.sh
+++ b/install/booklore-install.sh
@@ -18,7 +18,7 @@ $STD apt-get install -y nginx
 msg_ok "Installed Dependencies"
 
 fetch_and_deploy_gh_release "booklore" "booklore-app/BookLore"
-JAVA_VERSION="21" setup_java
+JAVA_VERSION="25" setup_java
 NODE_VERSION="22" setup_nodejs
 setup_mariadb
 setup_yq


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- BookLore v1.5.0 has upgraded to Java 25/Gradle 9
- Thankfully the upgrade on our end is pretty painless
- booklore-install.sh: change `JAVA_VERSION` to 25
- booklore.sh: add `setup_java` to the update function

## 🔗 Related PR / Issue  
Link: #8164


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
