### PR TITLE
Update prompt for Stirling-PDF login option

### DIFF
--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -32,7 +32,7 @@ msg_ok "Installed Dependencies"
 PYTHON_VERSION="3.12" setup_uv
 JAVA_VERSION="21" setup_java
 
-read -r -p "${TAB3}Do you want to Stirling-PDF with Login? (no/n = without Login) [Y/n] " response
+read -r -p "${TAB3}Do you want to Stirling-PDF use with Login? (no/n = without Login) [Y/n] " response
 response=${response,,} # Convert to lowercase
 login_mode="false"
 if [[ "$response" == "y" || "$response" == "yes" || -z "$response" ]]; then

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -32,7 +32,7 @@ msg_ok "Installed Dependencies"
 PYTHON_VERSION="3.12" setup_uv
 JAVA_VERSION="21" setup_java
 
-read -r -p "${TAB3}Do you want to Stirling-PDF use with Login? (no/n = without Login) [Y/n] " response
+read -r -p "${TAB3}Do you want to use Stirling-PDF with Login? (no/n = without Login) [Y/n] " response
 response=${response,,} # Convert to lowercase
 login_mode="false"
 if [[ "$response" == "y" || "$response" == "yes" || -z "$response" ]]; then


### PR DESCRIPTION
Added missing "use" to the login prompt.

## ✍️ Description  
The prompt for using the login option of Stirling PDF was missing a verb.


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
