### PR TITLE
Wireguard: Fix sysctl for Trixie

### DIFF
--- a/install/wireguard-install.sh
+++ b/install/wireguard-install.sh
@@ -31,8 +31,14 @@ if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
   cd /etc/wgdashboard/src || exit
   chmod u+x wgd.sh
   $STD ./wgd.sh install
-  echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
-  $STD sysctl -p /etc/sysctl.conf
+  . /etc/os-release
+  if [ "$VERSION_CODENAME" = "trixie" ]; then
+    echo "net.ipv4.ip_forward=1" >>/etc/sysctl.d/sysctl.conf
+    $STD sysctl -p /etc/sysctl.d/sysctl.conf
+  else
+    echo "net.ipv4.ip_forward=1" >>/etc/sysctl.conf
+    $STD sysctl -p /etc/sysctl.conf
+  fi
   msg_ok "Installed WGDashboard"
 
   msg_info "Create Example Config for WGDashboard"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Added a check if user choose default Debian 13 install or maybe Debian 12 and set the `sysctl.conf` accordingly. This check is needed if users still want to use Debian 12 or Ubuntu

## 🔗 Related PR / Issue  
Link: #8203 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
