### PR TITLE
host-backup.sh: Added "ALL" option and include timestamp in backup filename

### DIFF
--- a/tools/pve/host-backup.sh
+++ b/tools/pve/host-backup.sh
@@ -41,6 +41,7 @@ function perform_backup {
 
   # Build a list of directories for backup
   local CTID_MENU=()
+  CTID_MENU=("ALL" "Backup all folders" "OFF")
   while read -r dir; do
     CTID_MENU+=("$(basename "$dir")" "$dir " "OFF")
   done < <(ls -d "${DIR}"*)
@@ -52,7 +53,13 @@ function perform_backup {
       "\nSelect what files/directories to backup:\n" 16 $(((${#DIRNAME} + 2) + 88)) 6 "${CTID_MENU[@]}" 3>&1 1>&2 2>&3) || return
 
     for selected_dir in ${HOST_BACKUP//\"/}; do
-      selected_directories+=("${DIR}$selected_dir")
+      if [[ "$selected_dir" == "ALL" ]]; then
+        # if ALL was chosen, secure all folders
+        selected_directories=("${DIR}"*/)
+        break
+      else
+        selected_directories+=("${DIR}$selected_dir")
+      fi
     done
   done
 

--- a/tools/pve/host-backup.sh
+++ b/tools/pve/host-backup.sh
@@ -69,7 +69,7 @@ function perform_backup {
   read -p "Press ENTER to continue..."
   header_info
   echo "Working..."
-  tar -czf "$BACKUP_PATH$BACKUP_FILE-$(date +%Y_%m_%d).tar.gz" --absolute-names "${selected_directories[@]}"
+  tar -czf "$BACKUP_PATH$BACKUP_FILE-$(date +%Y_%m_%dT%H_%M).tar.gz" --absolute-names "${selected_directories[@]}"
   header_info
   echo -e "\nFinished"
   echo -e "\e[1;33m \nA backup is rendered ineffective when it remains stored on the host.\n \e[0m"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

This update enhances the Proxmox VE host backup script by improving usability and traceability:

- 🆕 Added an **"ALL"** option in the directory selection menu to allow backing up all subfolders at once.  
- 🕒 Updated the backup filename to include a **timestamp** (`YYYY-MM-DDTHH-MM`), providing clearer versioning and preventing filename collisions.  

Example filename:
hostname--etc-backup-2025-10-11T16-01.tar.gz

These improvements make the backup process faster, more consistent, and easier to manage.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
