### PR TITLE
Update cockpit installation/update

### DIFF
--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -27,73 +27,12 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  UPD=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "SUPPORT" --radiolist --cancel-button Exit-Script "Spacebar = Select" 11 58 4 \
-    "1" "Update LXC" ON \
-    "2" "Install cockpit-file-sharing" OFF \
-    "3" "Install cockpit-identities" OFF \
-    "4" "Install cockpit-navigator" OFF \
-    3>&1 1>&2 2>&3)
-
-  if [ "$UPD" == "1" ]; then
-    msg_info "Updating ${APP} LXC"
-    $STD apt update
-    $STD apt -y upgrade
-    msg_ok "Updated ${APP} LXC"
-    exit
-  fi
-
-  if [ "$UPD" == "2" ]; then
-    msg_info "Installing dependencies (patience)"
-    $STD apt install -y \
-      attr \
-      nfs-kernel-server \
-      samba \
-      samba-common-bin \
-      winbind \
-      gawk
-    msg_ok "Installed dependencies"
-    msg_info "Installing Cockpit file sharing"
-    URL=$(curl -fsSL https://api.github.com/repos/45Drives/cockpit-file-sharing/releases/latest | grep download | grep focal_all.deb | cut -d\" -f4)
-    FILE=$(basename "$URL")
-    curl -fsSL "$URL" -o "$FILE"
-    $STD dpkg -i "$FILE" || $STD apt install -f -y
-    rm -f "$FILE"
-    msg_ok "Installed Cockpit file sharing"
-    exit
-  fi
-
-  if [ "$UPD" == "3" ]; then
-    msg_info "Installing dependencies (patience)"
-    $STD apt install -y \
-      psmisc \
-      samba \
-      samba-common-bin
-    msg_ok "Installed dependencies"
-    msg_info "Installing Cockpit identities"
-    URL=$(curl -fsSL https://api.github.com/repos/45Drives/cockpit-identities/releases/latest | grep download | grep focal_all.deb | cut -d\" -f4)
-    FILE=$(basename "$URL")
-    curl -fsSL "$URL" -o "$FILE"
-    $STD dpkg -i "$FILE" || $STD apt install -f -y
-    rm -f "$FILE"
-    msg_ok "Installed Cockpit identities"
-    exit
-  fi
-
-  if [ "$UPD" == "4" ]; then
-    msg_info "Installing dependencies"
-    $STD apt install -y \
-      rsync \
-      zip
-    msg_ok "Installed dependencies"
-    msg_info "Installing Cockpit navigator"
-    URL=$(curl -fsSL https://api.github.com/repos/45Drives/cockpit-navigator/releases/latest | grep download | grep focal_all.deb | cut -d\" -f4)
-    FILE=$(basename "$URL")
-    curl -fsSL "$URL" -o "$FILE"
-    $STD dpkg -i "$FILE" || $STD apt install -f -y
-    rm -f "$FILE"
-    msg_ok "Installed Cockpit navigator"
-    exit
-  fi
+  
+  msg_info "Updating ${APP} LXC"
+  $STD apt update
+  $STD apt -y upgrade
+  msg_ok "Updated ${APP} LXC"
+  exit
 }
 
 start

--- a/install/cockpit-install.sh
+++ b/install/cockpit-install.sh
@@ -16,11 +16,47 @@ update_os
 
 msg_info "Installing Cockpit"
 source /etc/os-release
-echo "deb http://deb.debian.org/debian ${VERSION_CODENAME}-backports main" >/etc/apt/sources.list.d/backports.list
+
+cat <<EOF >/etc/apt/sources.list.d/debian-backports.sources
+Types: deb deb-src
+URIs: http://deb.debian.org/debian
+Suites: ${VERSION_CODENAME}-backports
+Components: main
+Enabled: yes
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
+EOF
+
 $STD apt update
-$STD apt install -t ${VERSION_CODENAME}-backports cockpit --no-install-recommends -y
+$STD apt install -t ${VERSION_CODENAME}-backports cockpit cracklib-runtime --no-install-recommends -y
 sed -i "s/root//g" /etc/cockpit/disallowed-users
 msg_ok "Installed Cockpit"
+
+read -r -p "Would you like to install 45Drives' cockpit-file-sharing, cockpit-identities, and cockpit-navigator  <y/N> " prompt
+if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
+  install_45drives=true
+  if [[ "${VERSION_ID}" -ge 13 ]]; then
+    read -r -p "Debian ${VERSION_ID} is not officially supported by 45Drives yet, would you like to continue anyway? <y/N> " prompt
+    if [[ ! "${prompt,,}" =~ ^(y|yes)$ ]]; then
+      install_45drives=false
+    fi
+  fi
+  if [[ "$install_45drives" == "true" ]]; then
+    msg_info "Installing 45Drives' cockpit extensions"
+    curl -fsSL https://repo.45drives.com/key/gpg.asc | gpg --pinentry-mode loopback --batch --yes --dearmor -o /usr/share/keyrings/45drives-archive-keyring.gpg
+    cat <<EOF >/etc/apt/sources.list.d/45drives-enterprise.sources
+Types: deb
+URIs: https://repo.45drives.com/enterprise/debian
+Suites: bookworm
+Components: main
+Architectures: amd64
+Signed-By: /usr/share/keyrings/45drives-archive-keyring.gpg
+EOF
+
+    $STD apt update
+    $STD apt install cockpit-file-sharing cockpit-identities cockpit-navigator -y
+    msg_ok "Installed 45Drives' cockpit extensions"
+  fi
+fi
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Changes
* Install missing dependency `cracklib-runtime` (to check password strength for new accounts)
* Use deb822 sources files
* 45Drives' extensions
  * Move from update to install script
  * Use the official bookworm repo instead of github releases (which used to contain ubuntu debs), this also automatically takes care of dependencies
  * Give a warning on Debian 13, cockpit works fine on 13, but 45Drives extensions haven't been updated yet, and there are some small issues (like https://github.com/45Drives/cockpit-identities/issues/9)

Given the issues with 45Drives Debian 13 support, we should probably suggest if people are planning to use their extensions, they should use `var_version=12`.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
