### PR TITLE
zigbee2mqtt: Use hardlinks for PNPM packages

### DIFF
--- a/ct/zigbee2mqtt.sh
+++ b/ct/zigbee2mqtt.sh
@@ -47,6 +47,7 @@ function update_script() {
     rm -rf /opt/zigbee2mqtt/data
     mv /opt/z2m_backup/data /opt/zigbee2mqtt
     cd /opt/zigbee2mqtt
+    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
     $STD pnpm install --frozen-lockfile
     $STD pnpm build
     msg_ok "Updated Zigbee2MQTT"

--- a/install/zigbee2mqtt-install.sh
+++ b/install/zigbee2mqtt-install.sh
@@ -31,6 +31,7 @@ msg_info "Setting up Zigbee2MQTT"
 cd /opt/zigbee2mqtt/data || exit
 mv configuration.example.yaml configuration.yaml
 cd /opt/zigbee2mqtt || exit
+echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
 $STD pnpm install --no-frozen-lockfile
 $STD pnpm build
 msg_ok "Installed Zigbee2MQTT"


### PR DESCRIPTION
## ✍️ Description  
Fix EAGAIN failure when creating a new Zigbee2MQTT LXC with a ZFS backed storage.


## 🔗 Related PR / Issue  
Link: #8354


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
