### PR TITLE
paperless-ngx: remove unneeded deps, use static ghostscript

### DIFF
--- a/install/paperless-ngx-install.sh
+++ b/install/paperless-ngx-install.sh
@@ -22,7 +22,7 @@ $STD apt install -y \
   optipng \
   libpq-dev \
   libmagic-dev \
-  libzbar0 \
+  libzbar0t64 \
   poppler-utils \
   default-libmysqlclient-dev \
   automake \
@@ -30,17 +30,7 @@ $STD apt install -y \
   pkg-config \
   libtiff-dev \
   libpng-dev \
-  libleptonica-dev
-msg_ok "Installed Dependencies"
-
-PG_VERSION="16" setup_postgresql
-PYTHON_VERSION="3.13" setup_uv
-fetch_and_deploy_gh_release "paperless" "paperless-ngx/paperless-ngx" "prebuild" "latest" "/opt/paperless" "paperless*tar.xz"
-fetch_and_deploy_gh_release "jbig2enc" "ie13/jbig2enc" "tarball" "latest" "/opt/jbig2enc"
-setup_gs
-
-msg_info "Installing OCR Dependencies (Patience)"
-$STD apt install -y \
+  libleptonica-dev \
   unpaper \
   icc-profiles-free \
   qpdf \
@@ -49,18 +39,13 @@ $STD apt install -y \
   pngquant \
   zlib1g \
   tesseract-ocr \
-  tesseract-ocr-eng
-msg_ok "Installed OCR Dependencies"
+  tesseract-ocr-eng \
+  ghostscript
+msg_ok "Installed Dependencies"
 
-msg_info "Setup JBIG2"
-cd /opt/jbig2enc
-$STD bash ./autogen.sh
-$STD bash ./configure
-$STD make
-$STD make install
-cd /
-rm -rf /opt/jbig2enc
-msg_ok "Installed JBIG2"
+PG_VERSION="16" setup_postgresql
+PYTHON_VERSION="3.13" setup_uv
+fetch_and_deploy_gh_release "paperless" "paperless-ngx/paperless-ngx" "prebuild" "latest" "/opt/paperless" "paperless*tar.xz"
 
 msg_info "Setting up PostgreSQL database"
 DB_NAME=paperlessdb


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

use trixie ghostscript (10.05.1) - remove old deps
use jbig2enc from trixie repo

## 🔗 Related PR / Issue  
Link: #8390


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
