### PR TITLE
post-pve/post-pbs: Disable 'pve-enterprise' and 'ceph enterprise' repositories

### DIFF
--- a/tools/pve/post-pbs-install.sh
+++ b/tools/pve/post-pbs-install.sh
@@ -204,7 +204,13 @@ You normally need a valid subscription for this.
 Disable it (recommended)?" 14 58 2 "yes" " " "no" " " 3>&2 2>&1 1>&3)
     case $CHOICE in
     yes)
-      sed -i '/pbs-enterprise/ s/^/# /' /etc/apt/sources.list.d/pbs-enterprise.sources
+      msg_info "Disabling 'pbs-enterprise' repository"
+      # Use Enabled: false instead of commenting to avoid malformed entry
+      if grep -q "^Enabled:" /etc/apt/sources.list.d/pbs-enterprise.sources 2>/dev/null; then
+        sed -i 's/^Enabled:.*/Enabled: false/' /etc/apt/sources.list.d/pbs-enterprise.sources
+      else
+        echo "Enabled: false" >>/etc/apt/sources.list.d/pbs-enterprise.sources
+      fi
       msg_ok "Disabled 'pbs-enterprise' repository"
       ;;
     no)
@@ -213,11 +219,12 @@ Disable it (recommended)?" 14 58 2 "yes" " " "no" " " 3>&2 2>&1 1>&3)
     esac
   else
     cat >/etc/apt/sources.list.d/pbs-enterprise.sources <<EOF
-# Types: deb
-# URIs: https://enterprise.proxmox.com/debian/pbs
-# Suites: trixie
-# Components: pbs-enterprise
-# Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+Types: deb
+URIs: https://enterprise.proxmox.com/debian/pbs
+Suites: trixie
+Components: pbs-enterprise
+Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+Enabled: false
 EOF
     msg_ok "Added 'pbs-enterprise' repository (disabled)"
   fi
@@ -239,11 +246,12 @@ EOF
   # --- Test repo (pbs-test, renamed) ---
   if ! component_exists_in_sources "pbs-test"; then
     cat >/etc/apt/sources.list.d/pbs-test.sources <<EOF
-# Types: deb
-# URIs: http://download.proxmox.com/debian/pbs
-# Suites: trixie
-# Components: pbs-test
-# Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+Types: deb
+URIs: http://download.proxmox.com/debian/pbs
+Suites: trixie
+Components: pbs-test
+Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+Enabled: false
 EOF
     msg_ok "Added 'pbs-test' repository (disabled)"
   else


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
 using 'Enabled: false' instead of commenting out lines; add 'Enabled: false' to new repository entries.



## 🔗 Related PR / Issue  
Link: #8342 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
