### PR TITLE
Revert back to debian 12 template for various apps

### DIFF
--- a/ct/odoo.sh
+++ b/ct/odoo.sh
@@ -11,7 +11,7 @@ var_disk="${var_disk:-6}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-4}"
 var_ram="${var_ram:-8192}"
 var_disk="${var_disk:-25}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/odoo.json
+++ b/frontend/public/json/odoo.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 6,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/frontend/public/json/openwebui.json
+++ b/frontend/public/json/openwebui.json
@@ -23,7 +23,7 @@
         "ram": 8192,
         "hdd": 25,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/frontend/public/json/tautulli.json
+++ b/frontend/public/json/tautulli.json
@@ -23,7 +23,7 @@
         "ram": 1024,
         "hdd": 4,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- We are reverting back to Debian 12 template for these apps as they have dependency issues:
	Odoo
	Tautulli
	OpenWebUI


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
