### PR TITLE
[FIX]Pulse: replace policykit-1 with polkitd

### DIFF
--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -17,7 +17,7 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   diffutils \
-  policykit-1
+  polkitd
 msg_ok "Installed Dependencies"
 
 msg_info "Creating User"


### PR DESCRIPTION
## ✍️ Description  

- New installs (Debian 13) need to use polkitd or pkexec
- This doesn't affect LXCs that were manually upgraded from Debian 12 (if policykit-1 is installed all is well).

## 🔗 Related PR / Issue  
Link: #8438


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
