### PR TITLE
Cronicle: Dont copy init.d service file

### DIFF
--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -61,9 +61,6 @@ function update_script() {
       $STD node bin/build.js dist
       sed -i "s/localhost:3012/${IP}:3012/g" /opt/cronicle/conf/config.json
       $STD /opt/cronicle/bin/control.sh start
-      $STD cp /opt/cronicle/bin/cronicled.init /etc/init.d/cronicled
-      chmod 775 /etc/init.d/cronicled
-      $STD update-rc.d cronicled defaults
       msg_ok "Installed Cronicle Worker"
 
       echo -e "\n Add Masters secret key to /opt/cronicle/conf/config.json \n"

--- a/install/cronicle-install.sh
+++ b/install/cronicle-install.sh
@@ -24,9 +24,6 @@ $STD node bin/build.js dist
 sed -i "s/localhost:3012/${IP}:3012/g" /opt/cronicle/conf/config.json
 $STD /opt/cronicle/bin/control.sh setup
 $STD /opt/cronicle/bin/control.sh start
-$STD cp /opt/cronicle/bin/cronicled.init /etc/init.d/cronicled
-chmod 775 /etc/init.d/cronicled
-$STD update-rc.d cronicled defaults
 msg_ok "Configured Cronicle Primary Server"
 
 motd_ssh


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- There is no need to copy service file into `init.d`.


## 🔗 Related PR / Issue  
Link: #8328 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
