### PR TITLE
Unifi: Bump libssl debian version to new update

### DIFF
--- a/install/unifi-install.sh
+++ b/install/unifi-install.sh
@@ -35,8 +35,8 @@ if ! grep -q -m1 'avx[^ ]*' /proc/cpuinfo; then
   msg_ok "No AVX Support Detected"
   msg_info "Installing MongoDB 4.4"
   if ! dpkg -l | grep -q "libssl1.1"; then
-    curl -fsSL "https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u3_amd64.deb" -o "libssl1.1_1.1.1w-0+deb11u3_amd64.deb"
-    $STD dpkg -i libssl1.1_1.1.1w-0+deb11u3_amd64.deb
+    curl -fsSL "https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u4_amd64.deb" -o "libssl1.1_1.1.1w-0+deb11u4_amd64.deb"
+    $STD dpkg -i libssl1.1_1.1.1w-0+deb11u4_amd64.deb
   fi
   curl -fsSL "https://www.mongodb.org/static/pgp/server-4.4.asc" | gpg --dearmor -o /usr/share/keyrings/mongodb-server-4.4.gpg
   cat <<EOF | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.sources >/dev/null


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Fix the issue installing Unifi LXC.
The issue is that libssl Debian package disappeared and build is failing.
`https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u3_amd64.deb` is replaced with `https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u4_amd64.deb`


## 🔗 Related PR / Issue  
Link: N/A


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
