### PR TITLE
Guardian: Added validation before copying file and fix build command error

### DIFF
--- a/ct/guardian.sh
+++ b/ct/guardian.sh
@@ -40,9 +40,9 @@ if check_for_gh_release "guardian" "HydroshieldMKII/Guardian" ; then
     msg_ok "Backed up Database"
   fi
 
-  cp /opt/guardian/.env /opt
+  [[ -f "/opt/guardian/.env" ]] && cp "/opt/guardian/.env" "/opt"
   CLEAN_INSTALL=1 fetch_and_deploy_gh_release "guardian" "HydroshieldMKII/Guardian" "tarball" "latest" "/opt/guardian"
-  mv /opt/.env /opt/guardian
+  [[ -f "/opt/.env" ]] && mv "/opt/.env" "/opt/guardian"
 
   if [[ -f "/tmp/plex-guard.db.backup" ]] ; then
     msg_info "Restoring Database"
@@ -58,7 +58,8 @@ if check_for_gh_release "guardian" "HydroshieldMKII/Guardian" ; then
 
   cd /opt/guardian/frontend
   $STD npm ci
-  $STD DEPLOYMENT_MODE=standalone npm run build
+  export DEPLOYMENT_MODE=standalone
+  $STD npm run build
   msg_ok "Updated Guardian"
 
   msg_info "Starting Services"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

1. Added validation before copying the .env on update since by default there is no .env and it is very optional. 

the output was:

```
  ✔️   Stopped Services
  ✔️   Backed up Database
cp: cannot stat '/opt/guardian/.env': No such file or directory

[ERROR] in line 43: exit code 0: while executing command cp /opt/guardian/.env /opt
```

2. Also fixed the build command on update, the environment variable was being interpreted as a command therefore failing

the output was:

```
line 64: DEPLOYMENT_MODE=standalone: command not found

[ERROR] in line 64: exit code 0: while executing command $STD DEPLOYMENT_MODE=standalone npm run build
```


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
