### PR TITLE
UrBackup Server: Fix install going interactive

### DIFF
--- a/frontend/public/json/urbackupserver.json
+++ b/frontend/public/json/urbackupserver.json
@@ -35,6 +35,10 @@
     {
       "text": "You probably want to drastically extend the storage space to fit whatever clients you want to back up",
       "type": "info"
+    },
+    {
+      "text": "Directory `/opt/urbackup/backups` is set as initial backup path. Change it to your liking",
+      "type": "info"
     }
   ]
 }

--- a/install/urbackupserver-install.sh
+++ b/install/urbackupserver-install.sh
@@ -14,8 +14,11 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y coreutils
+$STD apt install -y \
+  coreutils \
+  debconf-utils
 msg_ok "Installed Dependencies"
+
 
 msg_info "Installing UrBackup Server"
 curl -fsSL https://download.opensuse.org/repositories/home:uroni/Debian_12/Release.key | gpg --dearmor -o /usr/share/keyrings/home-uroni.gpg
@@ -27,6 +30,8 @@ Components:
 Signed-By: /usr/share/keyrings/home-uroni.gpg
 EOF
 $STD apt update
+mkdir -p /opt/urbackup/backups
+echo "urbackup-server urbackup/backuppath string /opt/urbackup/backups" | debconf-set-selections
 $STD apt install -y urbackup-server
 msg_ok "Installed UrBackup Server"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Installation of `urbackup-server` package goes interactive and prompts user to enter a initial backup directory. We are setting it to `/opt/urbackup/backups` to avoid that. User can change the directory in the WebUI.
- Added relevant info to the website


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
