### PR TITLE
Bump bazarr to Debian 13

### DIFF
--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -28,14 +28,14 @@ function update_script() {
     exit
   fi
   if check_for_gh_release "bazarr" "morpheus65535/bazarr"; then
-    PYTHON_VERSION="3.13" setup_uv
+    setup_uv
     fetch_and_deploy_gh_release "bazarr" "morpheus65535/bazarr" "prebuild" "latest" "/opt/bazarr" "bazarr.zip"
 
     msg_info "Setup Bazarr"
     mkdir -p /var/lib/bazarr/
     chmod 775 /opt/bazarr /var/lib/bazarr/
     sed -i.bak 's/--only-binary=Pillow//g' /opt/bazarr/requirements.txt
-    $STD uv pip install -r /opt/bazarr/requirements.txt --system
+    $STD uv pip install -r /opt/bazarr/requirements.txt --python /opt/bazarr/venv/bin/python3
     msg_ok "Setup Bazarr"
     msg_ok "Updated Successfully"
   fi

--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -46,6 +46,7 @@ function update_script() {
     sed -i.bak 's/--only-binary=Pillow//g' /opt/bazarr/requirements.txt
     $STD uv pip install -r /opt/bazarr/requirements.txt --python /opt/bazarr/venv/bin/python3
     msg_ok "Setup Bazarr"
+    
     msg_info "Starting Service"
     systemctl start bazarr
     msg_ok "Started Service"

--- a/frontend/public/json/bazarr.json
+++ b/frontend/public/json/bazarr.json
@@ -23,7 +23,7 @@
         "ram": 1024,
         "hdd": 4,
         "os": "debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-setup_uv
+PYTHON_VERSION="3.12" setup_uv
 fetch_and_deploy_gh_release "bazarr" "morpheus65535/bazarr" "prebuild" "latest" "/opt/bazarr" "bazarr.zip"
 
 msg_info "Installing Bazarr"

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -13,20 +13,15 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Setup Python3"
-$STD apt-get install -y \
-  python3 \
-  python3-dev
-msg_ok "Setup Python3"
-
-PYTHON_VERSION="3.13" setup_uv
+setup_uv
 fetch_and_deploy_gh_release "bazarr" "morpheus65535/bazarr" "prebuild" "latest" "/opt/bazarr" "bazarr.zip"
 
 msg_info "Installing Bazarr"
 mkdir -p /var/lib/bazarr/
 chmod 775 /opt/bazarr /var/lib/bazarr/
 sed -i.bak 's/--only-binary=Pillow//g' /opt/bazarr/requirements.txt
-$STD uv pip install -r /opt/bazarr/requirements.txt --system
+$STD uv venv /opt/bazarr/venv --python 3.12
+$STD uv pip install -r /opt/bazarr/requirements.txt --python /opt/bazarr/venv/bin/python3
 msg_ok "Installed Bazarr"
 
 msg_info "Creating Service"
@@ -41,7 +36,7 @@ UMask=0002
 Restart=on-failure
 RestartSec=5
 Type=simple
-ExecStart=/usr/bin/python3 /opt/bazarr/bazarr.py
+ExecStart=/opt/bazarr/venv/bin/python3 /opt/bazarr/bazarr.py
 KillSignal=SIGINT
 TimeoutStopSec=20
 SyslogIdentifier=bazarr


### PR DESCRIPTION
- Removes unnecessary python3 install
- Use uv to create proper 3.12 venv (bazarr will give warnings about 3.13)

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Also:
- Removes unnecessary python3 install (setup_uv is used afterwards)
- Use uv to create proper 3.12 venv (bazarr will give warnings about 3.13) instead of pushing everything to the system python


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
