### PR TITLE
Archivebox: add Chromium and Node modules

### DIFF
--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -28,12 +28,18 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="22" setup_nodejs
+  NODE_VERSION="22" NODE_MODULE="@postlight/parser@latest,single-file-cli@latest" setup_nodejs
   PYTHON_VERSION="3.13" setup_uv
 
-  msg_info "Stopping ArchiveBox"
+  if ! dpkg -l | grep -q "^ii  chromium "; then
+    msg_info "Installing System Dependencies"
+    $STD apt-get install -y chromium
+    msg_ok "Installed System Dependencies"
+  fi
+
+  msg_info "Stopping Service"
   systemctl stop archivebox
-  msg_ok "Stopped ArchiveBox"
+  msg_ok "Stopped Service"
 
   msg_info "Upgrading Playwright"
   $STD uv pip install playwright --system
@@ -46,11 +52,10 @@ function update_script() {
   sudo -u archivebox archivebox init
   msg_ok "Updated ArchiveBox"
 
-  msg_info "Starting ArchiveBox"
+  msg_info "Starting Service"
   systemctl start archivebox
-  msg_ok "Started ArchiveBox"
-
-  msg_ok "Updated Successfully"
+  msg_ok "Started Service"
+  msg_ok "Updated Successfully!"
   exit
 }
 

--- a/install/archivebox-install.sh
+++ b/install/archivebox-install.sh
@@ -22,7 +22,8 @@ $STD apt-get install -y \
   libsasl2-dev \
   procps \
   dnsutils \
-  ripgrep
+  ripgrep \
+  chromium
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Python Dependencies"
@@ -32,7 +33,7 @@ $STD apt-get install -y \
   python3-regex
 msg_ok "Installed Python Dependencies"
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="22" NODE_MODULE="@postlight/parser@latest,single-file-cli@latest" setup_nodejs
 PYTHON_VERSION="3.13" setup_uv
 
 msg_info "Installing Playwright"
@@ -40,7 +41,7 @@ $STD uv pip install playwright --system
 $STD playwright install-deps chromium
 msg_ok "Installed Playwright"
 
-msg_info "Installing Chromium and ArchiveBox"
+msg_info "Installing ArchiveBox"
 mkdir -p /opt/archivebox/{data,.npm,.cache,.local}
 $STD adduser --system --shell /bin/bash --gecos 'Archive Box User' --group --disabled-password --home /home/archivebox archivebox
 chown -R archivebox:archivebox /opt/archivebox/{data,.npm,.cache,.local}
@@ -92,6 +93,7 @@ motd_ssh
 customize
 
 msg_info "Cleaning up"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+$STD apt -y autoremove
+$STD apt -y autoclean
+$STD apt -y clean
 msg_ok "Cleaned"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Updated install and update scripts to ensure Chromium is installed as a dependency and to include @postlight/parser and single-file-cli Node modules during setup. Improved messaging for service management and added additional apt clean-up steps.

## 🔗 Related PR / Issue  
Link: #8674


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
