### PR TITLE
Asterisk: add interactive version selection to installer

### DIFF
--- a/install/asterisk-install.sh
+++ b/install/asterisk-install.sh
@@ -13,8 +13,65 @@ setting_up_container
 network_check
 update_os
 
+ASTERISK_VERSIONS_URL="https://www.asterisk.org/downloads/asterisk/all-asterisk-versions/"
+html=$(curl -fsSL "$ASTERISK_VERSIONS_URL")
+
+LTS_VERSION=""
+for major in 20 22 24 26; do
+  block=$(echo "$html" | awk "/Asterisk $major - LTS/,/<ul>/")
+  ver=$(echo "$block" | grep -oE 'Download Latest - [0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/.* - //')
+  if [ -n "$ver" ]; then
+    LTS_VERSION="$LTS_VERSION $ver"
+  fi
+  unset ver block
+done
+LTS_VERSION=$(echo "$LTS_VERSION" | xargs | tr ' ' '\n' | sort -V | tail -n1)
+
+STD_VERSION=""
+for major in 21 23 25 27; do
+  block=$(echo "$html" | awk "/Asterisk $major</,/<ul>/")
+  ver=$(echo "$block" | grep -oE 'Download (Latest - )?[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1 | sed -E 's/.* - //;s/Download //')
+  if [ -n "$ver" ]; then
+    STD_VERSION="$STD_VERSION $ver"
+  fi
+  unset ver block
+done
+STD_VERSION=$(echo "$STD_VERSION" | xargs | tr ' ' '\n' | sort -V | tail -n1)
+
+cert_block=$(echo "$html" | awk '/Certified Asterisk/,/<ul>/')
+CERT_VERSION=$(echo "$cert_block" | grep -oE 'Download Latest - [0-9]+\.[0-9]+-cert[0-9]+' | head -n1 | sed -E 's/.* - //')
+
+cat <<EOF
+Choose Asterisk version to install:
+1) Latest Standard ($STD_VERSION)
+2) Latest LTS ($LTS_VERSION)
+3) Latest Certified ($CERT_VERSION)
+EOF
+read -rp "Enter choice [1-3]: " ASTERISK_CHOICE
+
+case "$ASTERISK_CHOICE" in
+2)
+  ASTERISK_VERSION="$LTS_VERSION"
+  ;;
+3)
+  ASTERISK_VERSION="$CERT_VERSION"
+  CERTIFIED=1
+  ;;
+*)
+  ASTERISK_VERSION="$STD_VERSION"
+  ;;
+esac
+
+if [[ "$CERTIFIED" == "1" ]]; then
+  RELEASE="certified-asterisk-${ASTERISK_VERSION}.tar.gz"
+  DOWNLOAD_URL="https://downloads.asterisk.org/pub/telephony/certified-asterisk/$RELEASE"
+else
+  RELEASE="asterisk-${ASTERISK_VERSION}.tar.gz"
+  DOWNLOAD_URL="https://downloads.asterisk.org/pub/telephony/asterisk/$RELEASE"
+fi
+
 msg_info "Installing Dependencies"
-$STD apt-get install -y \
+$STD apt install -y \
   libsrtp2-dev \
   build-essential \
   libedit-dev \
@@ -25,13 +82,12 @@ $STD apt-get install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Downloading Asterisk"
-RELEASE=$(curl -fsSL https://downloads.asterisk.org/pub/telephony/asterisk/ | grep -o 'asterisk-[0-9]\+-current\.tar\.gz' | sort -V | tail -n1)
 temp_file=$(mktemp)
-curl -fsSL "https://downloads.asterisk.org/pub/telephony/asterisk/${RELEASE}" -o "$temp_file"
+curl -fsSL "$DOWNLOAD_URL" -o "$temp_file"
 mkdir -p /opt/asterisk
 tar zxf "$temp_file" --strip-components=1 -C /opt/asterisk
 cd /opt/asterisk
-msg_ok "Downloaded Asterisk"
+msg_ok "Downloaded Asterisk ($RELEASE)"
 
 msg_info "Installing Asterisk"
 $STD ./contrib/scripts/install_prereq install
@@ -51,6 +107,7 @@ customize
 
 msg_info "Cleaning up"
 rm -f "$temp_file"
-$STD apt-get -y autoremove
-$STD apt-get -y autoclean
+$STD apt -y autoremove
+$STD apt -y autoclean
+$STD apt -y clean
 msg_ok "Cleaned"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
The install script now fetches available Asterisk versions (Standard, LTS, Certified) from the official website and prompts the user to select which version to install. The download and installation process adapts based on the user's choice. Also updated package management commands from 'apt-get' to 'apt' for consistency.



## 🔗 Related PR / Issue  
Link: #8721


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
