### PR TITLE
Add explicit exit calls to update_script functions

### DIFF
--- a/ct/alpine-adguard.sh
+++ b/ct/alpine-adguard.sh
@@ -32,7 +32,6 @@ function update_script() {
   msg_info "Restarting AdGuard Home"
   $STD rc-service adguardhome restart
   msg_ok "Restarted AdGuard Home"
-
   exit 0
 }
 

--- a/ct/alpine-bitmagnet.sh
+++ b/ct/alpine-bitmagnet.sh
@@ -75,7 +75,6 @@ function update_script() {
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
   fi
-
   exit 0
 }
 

--- a/ct/alpine-caddy.sh
+++ b/ct/alpine-caddy.sh
@@ -32,7 +32,7 @@ function update_script() {
   msg_info "Restarting Caddy"
   rc-service caddy restart
   msg_ok "Restarted Caddy"
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-docker.sh
+++ b/ct/alpine-docker.sh
@@ -41,6 +41,7 @@ function update_script() {
       ;;
     esac
   done
+  exit 0
 }
 
 start

--- a/ct/alpine-forgejo.sh
+++ b/ct/alpine-forgejo.sh
@@ -31,7 +31,6 @@ function update_script() {
   msg_info "Restarting Forgejo"
   $STD rc-service forgejo restart
   msg_ok "Restarted Forgejo"
-
   exit 0
 }
 

--- a/ct/alpine-garage.sh
+++ b/ct/alpine-garage.sh
@@ -50,7 +50,7 @@ function update_script() {
   else
     msg_ok "No update required. Garage is already at ${GITEA_RELEASE}"
   fi
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-gatus.sh
+++ b/ct/alpine-gatus.sh
@@ -48,7 +48,6 @@ function update_script() {
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
   fi
-
   exit 0
 }
 

--- a/ct/alpine-gitea.sh
+++ b/ct/alpine-gitea.sh
@@ -32,7 +32,7 @@ function update_script() {
   msg_info "Restarting Gitea"
   rc-service gitea restart
   msg_ok "Restarted Gitea"
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-grafana.sh
+++ b/ct/alpine-grafana.sh
@@ -54,6 +54,7 @@ function update_script() {
       ;;
     esac
   done
+  exit 0
 }
 
 start

--- a/ct/alpine-it-tools.sh
+++ b/ct/alpine-it-tools.sh
@@ -41,7 +41,6 @@ function update_script() {
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
   fi
-
   exit 0
 }
 

--- a/ct/alpine-komodo.sh
+++ b/ct/alpine-komodo.sh
@@ -55,7 +55,7 @@ function update_script() {
   $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env pull
   $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env up -d
   msg_ok "Updated ${APP}"
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-mariadb.sh
+++ b/ct/alpine-mariadb.sh
@@ -31,7 +31,6 @@ function update_script() {
   msg_info "Restarting MariaDB"
   $STD rc-service mariadb restart
   msg_ok "Restarted MariaDB"
-
   exit 0
 }
 

--- a/ct/alpine-nextcloud.sh
+++ b/ct/alpine-nextcloud.sh
@@ -50,6 +50,7 @@ function update_script() {
       ;;
     esac
   done
+  exit 0
 }
 
 start

--- a/ct/alpine-node-red.sh
+++ b/ct/alpine-node-red.sh
@@ -31,7 +31,6 @@ function update_script() {
   msg_info "Updating Node-RED"
   $STD npm install -g --unsafe-perm node-red
   msg_ok "Updated Node-RED"
-
   exit 0
 }
 

--- a/ct/alpine-postgresql.sh
+++ b/ct/alpine-postgresql.sh
@@ -31,7 +31,6 @@ function update_script() {
   msg_info "Restarting PostgreSQL"
   $STD rc-service postgresql restart
   msg_ok "Restarted PostgreSQL"
-
   exit 0
 }
 

--- a/ct/alpine-prometheus.sh
+++ b/ct/alpine-prometheus.sh
@@ -31,7 +31,6 @@ function update_script() {
   msg_info "Restarting Prometheus"
   $STD rc-service prometheus restart
   msg_ok "Restarted Prometheus"
-
   exit 0
 }
 

--- a/ct/alpine-rclone.sh
+++ b/ct/alpine-rclone.sh
@@ -38,7 +38,6 @@ function update_script() {
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
   fi
-
   exit 0
 }
 

--- a/ct/alpine-redlib.sh
+++ b/ct/alpine-redlib.sh
@@ -41,9 +41,8 @@ function update_script() {
   msg_info "Starting Service"
   $STD rc-service redlib start
   msg_ok "Started Service"
-
   msg_ok "Update Successful"
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-syncthing.sh
+++ b/ct/alpine-syncthing.sh
@@ -31,8 +31,7 @@ function update_script() {
   msg_info "Restarting Syncthing"
   $STD rc-service syncthing restart
   msg_ok "Restarted Syncthing"
-
-  exit 1
+  exit 0
 }
 
 start

--- a/ct/alpine-teamspeak-server.sh
+++ b/ct/alpine-teamspeak-server.sh
@@ -44,7 +44,6 @@ function update_script() {
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"
   fi
-
   exit 0
 }
 

--- a/ct/alpine-traefik.sh
+++ b/ct/alpine-traefik.sh
@@ -28,7 +28,7 @@ function update_script() {
   msg_info "Upgrading traefik from edge"
   $STD apk add traefik --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
   msg_ok "Upgraded traefik"
-  exit
+  exit 0
 }
 
 start

--- a/ct/alpine-transmission.sh
+++ b/ct/alpine-transmission.sh
@@ -31,8 +31,7 @@ function update_script() {
   msg_info "Restarting Transmission"
   $STD rc-service transmission-daemon restart
   msg_ok "Restarted Transmission"
-
-  exit 1
+  exit 0
 }
 
 start

--- a/ct/alpine-wireguard.sh
+++ b/ct/alpine-wireguard.sh
@@ -36,7 +36,6 @@ function update_script() {
     $STD ./wgd.sh start
     msg_ok "WGDashboard updated"
   fi
-
   exit 0
 }
 

--- a/ct/bytestash.sh
+++ b/ct/bytestash.sh
@@ -54,8 +54,9 @@ function update_script() {
       msg_error "PLEASE MAKE A BACKUP FIRST!"
       exit
     fi
-    msg_ok "Updated Successfully"
+    msg_ok "Updated Successfully!"
   fi
+  exit
 }
 
 start

--- a/ct/cosmos.sh
+++ b/ct/cosmos.sh
@@ -28,6 +28,7 @@ function update_script() {
     exit
   fi
   msg_ok "${APP} updates itself automatically!"
+  exit
 }
 
 start

--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -62,7 +62,6 @@ function update_script() {
       sed -i "s/localhost:3012/${IP}:3012/g" /opt/cronicle/conf/config.json
       $STD /opt/cronicle/bin/control.sh start
       msg_ok "Installed Cronicle Worker"
-
       echo -e "\n Add Masters secret key to /opt/cronicle/conf/config.json \n"
       exit
     fi

--- a/ct/freshrss.sh
+++ b/ct/freshrss.sh
@@ -20,23 +20,24 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/freshrss ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/freshrss ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
 
-    if [ ! -x /opt/freshrss/cli/sensitive-log.sh ]; then
-        msg_info "Fixing wrong permissions"
-        chmod +x /opt/freshrss/cli/sensitive-log.sh
-        systemctl restart apache2
-        msg_ok "Fixed wrong permissions"
-    else
-        msg_error "FreshRSS should be updated via the user interface."
-        exit
-    fi
+  if [ ! -x /opt/freshrss/cli/sensitive-log.sh ]; then
+    msg_info "Fixing wrong permissions"
+    chmod +x /opt/freshrss/cli/sensitive-log.sh
+    systemctl restart apache2
+    msg_ok "Fixed wrong permissions"
+    exit
+  else
+    msg_error "FreshRSS should be updated via the user interface."
+    exit
+  fi
 }
 
 start

--- a/ct/globaleaks.sh
+++ b/ct/globaleaks.sh
@@ -31,6 +31,7 @@ function update_script() {
   $STD apt update
   $STD apt -y upgrade
   msg_ok "Updated $APP LXC"
+  exit
 }
 
 start

--- a/ct/lyrionmusicserver.sh
+++ b/ct/lyrionmusicserver.sh
@@ -50,6 +50,7 @@ function update_script() {
   else
     msg_ok "$APP is already up to date (${RELEASE})"
   fi
+  exit
 }
 
 start

--- a/ct/oauth2-proxy.sh
+++ b/ct/oauth2-proxy.sh
@@ -40,6 +40,7 @@ function update_script() {
     msg_ok "Started Service"
     msg_ok "Updated successfully!\n"
   fi
+  exit
 }
 
 start

--- a/ct/salt.sh
+++ b/ct/salt.sh
@@ -40,6 +40,7 @@ function update_script() {
   else
     msg_ok "${APP} is already up to date (${RELEASE})"
   fi
+  exit
 }
 
 start


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Added or standardized 'exit' calls at the end of update_script functions across multiple container setup scripts to ensure proper script termination after updates or checks. Also made minor formatting improvements and fixed a message in bytestash.sh.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
