### PR TITLE
Add proper Adguard Home update

### DIFF
--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -30,7 +30,6 @@ function update_script() {
   if check_for_gh_release "AdGuardHome" "AdguardTeam/AdGuardHome"; then
     read -r -p "It is recommended to update AdGuard Home from the web interface. Would you like to continue with a manual update? <y/N> " prompt
     if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
-      # After stopping Adguard Home service, github.com might not resolve anymore -> first install into temp location
       msg_info "Installing AdGuard Home to temporary location"
       fetch_and_deploy_gh_release "AdGuardHome" "AdguardTeam/AdGuardHome" "prebuild" "latest" "/opt/AdGuardHome.temp" "AdGuardHome_linux_amd64.tar.gz"
       msg_ok "Installed AdGuard Home to temporary location"

--- a/ct/adguard.sh
+++ b/ct/adguard.sh
@@ -27,7 +27,39 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  msg_error "Adguard Home can only be updated via the user interface."
+  if check_for_gh_release "AdGuardHome" "AdguardTeam/AdGuardHome"; then
+    read -r -p "It is recommended to update AdGuard Home from the web interface. Would you like to continue with a manual update? <y/N> " prompt
+    if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
+      # After stopping Adguard Home service, github.com might not resolve anymore -> first install into temp location
+      msg_info "Installing AdGuard Home to temporary location"
+      fetch_and_deploy_gh_release "AdGuardHome" "AdguardTeam/AdGuardHome" "prebuild" "latest" "/opt/AdGuardHome.temp" "AdGuardHome_linux_amd64.tar.gz"
+      msg_ok "Installed AdGuard Home to temporary location"
+
+      msg_info "Stopping Service"
+      systemctl stop AdGuardHome
+      msg_ok "Stopped Service"
+
+      msg_info "Backing up Configuration"
+      cp /opt/AdGuardHome/AdGuardHome.yaml /opt/AdGuardHome.yaml
+      cp -r /opt/AdGuardHome/data /opt/AdGuardHome_data
+      msg_ok "Backed up Configuration"
+
+      msg_info "Moving new AdGuard Home to correct location"
+      rm -rf /opt/AdGuardHome
+      mv /opt/AdGuardHome.temp /opt/AdGuardHome
+      msg_ok "Moved new AdGuard Home to correct location"
+
+      msg_info "Restoring Configuration"
+      mv /opt/AdGuardHome.yaml /opt/AdGuardHome/AdGuardHome.yaml
+      rm -rf /opt/AdGuardHome/data
+      mv /opt/AdGuardHome_data /opt/AdGuardHome/data
+      msg_ok "Restored Configuration"
+      
+      msg_info "Starting Service"
+      systemctl start AdGuardHome
+      msg_ok "Started Service"
+    fi
+  fi
   exit
 }
 

--- a/frontend/public/json/adguard.json
+++ b/frontend/public/json/adguard.json
@@ -44,7 +44,7 @@
   },
   "notes": [
     {
-      "text": "AdGuard Home can only be updated via the user interface.",
+      "text": "It is recommended to update AdGuard Home via its web interface. Use the update function only if this fails.",
       "type": "info"
     }
   ]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Currently Adguard is listed as updateable, but the only thing it does is `msg_error ...`. Update via the web interface might fail though (happened to me this morning), which is why Adguard has also provided [manual instructions](https://adguard-dns.io/kb/adguard-home/faq/#manual-update). This PR will implement the manual update. It also takes into account that github.com might not resolve anymore after stopping the Adguard service (again, happened to me, as Adguard is my only DNS server :P), so it first installs Adguard into a temporary location, and then stops the service and moves it to the correct location.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
