### PR TITLE
Removed errant ` from wireguard.json

### DIFF
--- a/frontend/public/json/wireguard.json
+++ b/frontend/public/json/wireguard.json
@@ -48,7 +48,7 @@
       "type": "info"
     },
     {
-      "text": "WGDashboard installation is optional.`",
+      "text": "WGDashboard installation is optional.",
       "type": "info"
     }
   ]


### PR DESCRIPTION
Noticed this while going about installing WireGuard, thought I'd fix it

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  