### PR TITLE
radicale: fix config path in website documentation

### DIFF
--- a/frontend/public/json/radicale.json
+++ b/frontend/public/json/radicale.json
@@ -12,7 +12,7 @@
   "documentation": "https://radicale.org/master.html#documentation-1",
   "website": "https://radicale.org/",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/radicale.webp",
-  "config_path": "/etc/radicale/config or ~/.config/radicale/config",
+  "config_path": "/opt/radicale/config",
   "description": "Radicale is a small but powerful CalDAV (calendars, to-do lists) and CardDAV (contacts)",
   "install_methods": [
     {


### PR DESCRIPTION
## ✍️ Description  
The [live documentation](https://community-scripts.github.io/ProxmoxVE/scripts?id=radicale) states that Radicale's config can be found in either `/etc/radicale/config` or `~/.config/radicale/config`. Neither are correct as the config is located at `/opt/radicale/config` as per my latest install.

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
