### PR TITLE
MediaManager: fix BASE_PATH error preventing main page load

### DIFF
--- a/ct/mediamanager.sh
+++ b/ct/mediamanager.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2025 community-scripts ORG
 # Author: vhsdream
@@ -42,14 +42,12 @@ function update_script() {
     export FRONTEND_FILES_DIR="${MM_DIR}/web/build"
     export BASE_PATH=""
     export PUBLIC_VERSION=""
-    export PUBLIC_API_URL="${BASE_PATH}/api/v1"
-    export BASE_PATH="${BASE_PATH}/web"
+    export PUBLIC_API_URL=""
     cd /opt/mediamanager/web
     $STD npm ci
     $STD npm run build
     rm -rf "$FRONTEND_FILES_DIR"/build
     cp -r build "$FRONTEND_FILES_DIR"
-    export BASE_PATH=""
     export VIRTUAL_ENV="/opt/${MM_DIR}/venv"
     cd /opt/mediamanager
     rm -rf "$MM_DIR"/{media_manager,alembic*}

--- a/install/mediamanager-install.sh
+++ b/install/mediamanager-install.sh
@@ -47,14 +47,13 @@ export CONFIG_DIR="${MM_DIR}/config"
 export FRONTEND_FILES_DIR="${MM_DIR}/web/build"
 export BASE_PATH=""
 export PUBLIC_VERSION=""
-export PUBLIC_API_URL="${BASE_PATH}/api/v1"
-export BASE_PATH="${BASE_PATH}/web"
+export PUBLIC_API_URL=""
+export BASE_PATH=""
 cd /opt/mediamanager/web
 $STD npm ci
 $STD npm run build
 mkdir -p {"$MM_DIR"/web,"$MEDIA_DIR","$CONFIG_DIR"}
 cp -r build "$FRONTEND_FILES_DIR"
-export BASE_PATH=""
 export VIRTUAL_ENV="${MM_DIR}/venv"
 cd /opt/mediamanager
 cp -r {media_manager,alembic*} "$MM_DIR"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- most of that BASE_PATH/PUBLIC_API_URL business is to help Vite during build and run while in Docker. Seems I created a bit of a mess with it, but this fixes it.

## 🔗 Related PR / Issue  
Link: #8813 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
