### PR TITLE
stirling-pdf: add native jbig2 dep to installation script

### DIFF
--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -26,7 +26,8 @@ $STD apt install -y \
   unpaper \
   fonts-urw-base35 \
   qpdf \
-  poppler-utils
+  poppler-utils \
+  jbig2
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.12" setup_uv
@@ -69,23 +70,11 @@ $STD uv pip install \
   ocrmypdf \
   pillow \
   pdf2image
-
 $STD apt install -y python3-uno python3-pip
-$STD pip3 install --break-system-packages unoserver
+$STD pip3 install --break-system-packages --timeout=120 unoserver
 ln -sf /opt/.venv/bin/python3 /usr/local/bin/python3
 ln -sf /opt/.venv/bin/pip /usr/local/bin/pip
 msg_ok "Installed Python Dependencies"
-
-msg_info "Installing JBIG2"
-$STD curl -fsSL -o /tmp/jbig2enc.tar.gz https://github.com/agl/jbig2enc/archive/refs/tags/0.30.tar.gz
-mkdir -p /opt/jbig2enc
-tar -xzf /tmp/jbig2enc.tar.gz -C /opt/jbig2enc --strip-components=1
-cd /opt/jbig2enc
-$STD bash ./autogen.sh
-$STD bash ./configure
-$STD make
-$STD make install
-msg_ok "Installed JBIG2"
 
 msg_info "Installing Language Packs (Patience)"
 $STD apt install -y 'tesseract-ocr-*'


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- use native jbig2 dependency -> buildtime should be faster ~40%
- added an timeout for user with very slow network for pyPi

## 🔗 Related PR / Issue  
Link: #8856 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
