### PR TITLE
MongoDB: install script now use setup_mongodb

### DIFF
--- a/install/mongodb-install.sh
+++ b/install/mongodb-install.sh
@@ -15,25 +15,12 @@ update_os
 
 read -p "${TAB3}Do you want to install MongoDB 8.0 instead of 7.0? [y/N]: " install_mongodb_8
 if [[ "$install_mongodb_8" =~ ^[Yy]$ ]]; then
-  MONGODB_VERSION="8.0"
+  MONGO_VERSION="8.0" setup_mongodb
 else
-  MONGODB_VERSION="7.0"
+  MONGO_VERSION="7.0" setup_mongodb
 fi
-
-msg_info "Installing MongoDB $MONGODB_VERSION"
-curl -fsSL "https://www.mongodb.org/static/pgp/server-${MONGODB_VERSION}.asc" | gpg --dearmor >/usr/share/keyrings/mongodb-server-${MONGODB_VERSION}.gpg
-cat <<EOF >/etc/apt/sources.list.d/mongodb-org-${MONGODB_VERSION}.sources
-Types: deb
-URIs: http://repo.mongodb.org/apt/debian
-Suites: $(grep '^VERSION_CODENAME=' /etc/os-release | cut -d'=' -f2)/mongodb-org/${MONGODB_VERSION}
-Components: main
-Signed-By: /usr/share/keyrings/mongodb-server-${MONGODB_VERSION}.gpg
-EOF
-$STD apt update
-$STD apt install -y mongodb-org
 sed -i 's/bindIp: 127.0.0.1/bindIp: 0.0.0.0/' /etc/mongod.conf
-systemctl enable -q --now mongod
-msg_ok "Installed MongoDB $MONGODB_VERSION"
+msg_ok "Installed MongoDB $MONGO_VERSION"
 
 motd_ssh
 customize


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Replaces inline MongoDB installation logic with a call to setup_mongodb, passing the selected version via MONGO_VERSION. Updates messaging to use the new variable and removes redundant code.



## 🔗 Related PR / Issue  
Link: #8895


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
