### PR TITLE
Remove backup files post Paperless-ngx update

### DIFF
--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -48,6 +48,7 @@ function update_script() {
 
       msg_info "Updating Paperless-ngx"
       cp -r /opt/paperless/backup/* /opt/paperless/
+      rm -r /opt/paperless/backup/*
       cd /opt/paperless
       $STD uv sync --all-extras
       cd /opt/paperless/src


### PR DESCRIPTION
## ✍️ Description  

To avoid orphans which are generated by not deleting the backup if documents got deleted or moved by storage paths.
Remark: The two copies could also be done as one move, but I would ask if this backup is anyhow needed in this case?

## 🔗 Related PR / Issue  
Link: #8959

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
