### PR TITLE
MediaManager: add LOG_FILE to start.sh script; fix BASE_PATH and PUBLIC_API_URL

### DIFF
--- a/ct/mediamanager.sh
+++ b/ct/mediamanager.sh
@@ -40,19 +40,24 @@ function update_script() {
     MM_DIR="/opt/mm"
     export CONFIG_DIR="${MM_DIR}/config"
     export FRONTEND_FILES_DIR="${MM_DIR}/web/build"
-    export BASE_PATH=""
     export PUBLIC_VERSION=""
     export PUBLIC_API_URL=""
+    export BASE_PATH="/web"
     cd /opt/mediamanager/web
-    $STD npm ci
+    $STD npm ci --no-fund --no-audit
     $STD npm run build
     rm -rf "$FRONTEND_FILES_DIR"/build
     cp -r build "$FRONTEND_FILES_DIR"
+    export BASE_PATH=""
     export VIRTUAL_ENV="/opt/${MM_DIR}/venv"
     cd /opt/mediamanager
     rm -rf "$MM_DIR"/{media_manager,alembic*}
     cp -r {media_manager,alembic*} "$MM_DIR"
     $STD /usr/local/bin/uv sync --locked --active -n -p cpython3.13 --managed-python
+    if ! grep -q "LOG_FILE" "$MM_DIR"/start.sh; then
+      sed -i "\|build\"$|a\export LOG_FILE=\"$CONFIG_DIR/media_manager.log\"" "$MM_DIR"/start.sh
+    fi
+
     msg_ok "Updated $APP"
 
     msg_info "Starting Service"

--- a/install/mediamanager-install.sh
+++ b/install/mediamanager-install.sh
@@ -45,15 +45,15 @@ MM_DIR="/opt/mm"
 MEDIA_DIR="${MM_DIR}/media"
 export CONFIG_DIR="${MM_DIR}/config"
 export FRONTEND_FILES_DIR="${MM_DIR}/web/build"
-export BASE_PATH=""
 export PUBLIC_VERSION=""
 export PUBLIC_API_URL=""
-export BASE_PATH=""
+export BASE_PATH="/web"
 cd /opt/mediamanager/web
-$STD npm ci
+$STD npm ci --no-fund --no-audit
 $STD npm run build
 mkdir -p {"$MM_DIR"/web,"$MEDIA_DIR","$CONFIG_DIR"}
 cp -r build "$FRONTEND_FILES_DIR"
+export BASE_PATH=""
 export VIRTUAL_ENV="${MM_DIR}/venv"
 cd /opt/mediamanager
 cp -r {media_manager,alembic*} "$MM_DIR"
@@ -81,8 +81,9 @@ cat <<EOF >"$MM_DIR"/start.sh
 
 export CONFIG_DIR="$CONFIG_DIR"
 export FRONTEND_FILES_DIR="$FRONTEND_FILES_DIR"
+export LOG_FILE="$CONFIG_DIR/media_manager.log"
 export BASE_PATH=""
-cd "$MM_DIR"
+cd $MM_DIR
 source ./venv/bin/activate
 /usr/local/bin/uv run alembic upgrade head
 /usr/local/bin/uv run fastapi run ./media_manager/main.py --port 8000


### PR DESCRIPTION
## ✍️ Description  

- fixes the failure to launch due to incorrect log path in #8925 
- fixes blank screen on page load #8925 
- Adds LOG_FILE export to start.sh during install; checks for the var during update, adds it if not found

## 🔗 Related PR / Issue  
Link: #8925 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
