### PR TITLE
PeaNUT: use clean install flag during update

### DIFF
--- a/ct/peanut.sh
+++ b/ct/peanut.sh
@@ -6,7 +6,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 # Source: https://github.com/Brandawg93/PeaNUT/
 
 APP="PeaNUT"
-var_tags="${var_tags:-network;ups;}"
+var_tags="${var_tags:-network;ups}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-7}"
@@ -35,7 +35,7 @@ function update_script() {
     systemctl stop peanut
     msg_info "Stopped Service"
 
-    fetch_and_deploy_gh_release "peanut" "Brandawg93/PeaNUT" "tarball" "latest" "/opt/peanut"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "peanut" "Brandawg93/PeaNUT" "tarball" "latest" "/opt/peanut"
 
     msg_info "Updating $APP"
     cd /opt/peanut


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- Fixes an issue with middleware update
- also removed semicolon from tags

## 🔗 Related PR / Issue  
When running `update` in the LXC console, I encountered this error:
```
> peanut@5.17.0 build
> next build

   ▲ Next.js 16.0.1 (Turbopack)


> Build error occurred
Error: Both middleware file "./src/src/middleware.ts" and proxy file "./src/src/proxy.ts" are detected. Please use "./src/src/proxy.ts" only. Learn more: https://nextjs.org/docs/messages/middleware-to-proxy
    at ignore-listed frames
 ELIFECYCLE  Command failed with exit code 1.

[ERROR] in line 43: exit code 0: while executing command $STD pnpm run build:local
```
I assumed it was because something was changed upstream but the app directory wasn't cleaned during install. Adding `CLEAN_INSTALL=1` solved the issue for me.


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
