### PR TITLE
evcc: add missing fi in update 

### DIFF
--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -35,6 +35,7 @@ function update_script() {
       "https://dl.evcc.io/public/evcc/stable/deb/debian/" \
       "$(get_os_info codename)" \
       "main"
+  fi
   msg_info "Updating evcc LXC"
   $STD apt update
   $STD apt --only-upgrade install -y evcc


### PR DESCRIPTION
Added missing "fi" at line 38

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
The script was corrupted since there was a missing `fi` . The `fi` was added at line 38.


## 🔗 Related PR / Issue  
Link: #
I haven't opened an issue since I directly wrote this patch.


## ✅ Prerequisites  (**X** in brackets) 

- [ X ] **Self-review completed** – Code follows project standards.  
- [ X ] **Tested thoroughly** – Changes work as expected.  
- [ X ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ X ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
