### PR TITLE
Fix: filebrowser-quantum update

### DIFF
--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -109,8 +109,10 @@ if [[ -f "$INSTALL_PATH" ]]; then
   read -r update_prompt
   if [[ "${update_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_info "Updating ${APP}"
-    curl -fsSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$INSTALL_PATH"
-    chmod +x "$INSTALL_PATH"
+    TMP_BIN="/tmp/filebrowser.$$"
+    curl -fsSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$TMP_BIN"
+    chmod +x "$TMP_BIN"
+    mv -f "$TMP_BIN" /usr/local/bin/filebrowser
     msg_ok "Updated ${APP}"
     exit 0
   else

--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -30,6 +30,7 @@ INSTALL_PATH="/usr/local/bin/filebrowser"
 CONFIG_PATH="/usr/local/community-scripts/fq-config.yaml"
 DEFAULT_PORT=8080
 SRC_DIR="/"
+TMP_BIN="/tmp/filebrowser.$$"
 
 # Get primary IP
 IFACE=$(ip -4 route | awk '/default/ {print $5; exit}')
@@ -109,7 +110,6 @@ if [[ -f "$INSTALL_PATH" ]]; then
   read -r update_prompt
   if [[ "${update_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_info "Updating ${APP}"
-    TMP_BIN="/tmp/filebrowser.$$"
     curl -fsSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$TMP_BIN"
     chmod +x "$TMP_BIN"
     mv -f "$TMP_BIN" /usr/local/bin/filebrowser
@@ -135,8 +135,9 @@ fi
 
 msg_info "Installing ${APP} on ${OS}"
 $PKG_MANAGER curl ffmpeg &>/dev/null
-curl -fsSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$INSTALL_PATH"
-chmod +x "$INSTALL_PATH"
+curl -fsSL https://github.com/gtsteffaniak/filebrowser/releases/latest/download/linux-amd64-filebrowser -o "$TMP_BIN"
+chmod +x "$TMP_BIN"
+mv -f "$TMP_BIN" /usr/local/bin/filebrowser
 msg_ok "Installed ${APP}"
 
 msg_info "Preparing configuration directory"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

fixes update using tmp path -> download the filebrowser binary to a temporary location before moving it to the final installation path.

## 🔗 Related PR / Issue  
Link: #9111


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
