### PR TITLE
Downgrade Swizzin to Debian 12 Bookworm

### DIFF
--- a/ct/swizzin.sh
+++ b/ct/swizzin.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/swizzin.json
+++ b/frontend/public/json/swizzin.json
@@ -23,7 +23,7 @@
         "ram": 4096,
         "hdd": 20,
         "os": "Debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/install/swizzin-install.sh
+++ b/install/swizzin-install.sh
@@ -27,9 +27,4 @@ bash <(curl -sL s5n.sh)
 
 motd_ssh
 customize
-
-msg_info "Cleaning up"
-$STD apt -y autoremove
-$STD apt -y autoclean
-$STD apt -y clean
-msg_ok "Cleaned"
+cleanup_lxc


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Downgrade Swizzin to debian 12, because trixie not supported

"ERROR   Your release (trixie) of Debian is not supported." 

## 🔗 Related PR / Issue  
Link: #9099


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
