### PR TITLE
Kimai: remove deprecated admin_lte section

### DIFF
--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -56,6 +56,7 @@ function update_script() {
     [ -f "$BACKUP_DIR/local.yaml" ] && cp "$BACKUP_DIR/local.yaml" /opt/kimai/config/packages/
     rm -rf "$BACKUP_DIR"
     cd /opt/kimai
+    sed -i '/^admin_lte:/,/^[^[:space:]]/d' config/local.yaml
     $STD composer install --no-dev --optimize-autoloader
     $STD bin/console kimai:update
     msg_ok "Updated Kimai"

--- a/install/kimai-install.sh
+++ b/install/kimai-install.sh
@@ -71,9 +71,6 @@ kimai:
                 begin: 15
                 end: 15
 
-admin_lte:
-    options:
-        default_avatar: build/apple-touch-icon.png
 EOF
 msg_ok "Installed Kimai"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Remove old deprecated admin_lte section in loyal.yaml, Maintainer say its Not used since 3 years, but in the official docu it still exist, he update the docu afterwards


## 🔗 Related PR / Issue  
Link: #9152


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
