### PR TITLE
Change backup directory to /opt for paperless-ngx

### DIFF
--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -122,7 +122,7 @@ function update_script() {
 
       $STD systemctl daemon-reload
       msg_info "Backing up user data and configuration"
-      BACKUP_DIR="/tmp/paperless_backup_$$"
+      BACKUP_DIR="/opt/paperless_backup_$$"
       mkdir -p "$BACKUP_DIR"
 
       for dir in /opt/paperless/*/; do

--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -35,7 +35,7 @@ function update_script() {
     if grep -q "uv run" /etc/systemd/system/paperless-webserver.service; then
 
       msg_info "Backing up user data and configuration"
-      local BACKUP_DIR="/tmp/paperless_backup_$$"
+      local BACKUP_DIR="/opt/paperless_backup_$$"
       mkdir -p "$BACKUP_DIR"
       for dir in /opt/paperless/*/; do
         dir_name=$(basename "$dir")
@@ -84,7 +84,7 @@ function update_script() {
       find /opt/paperless -name "__pycache__" -type d -exec rm -rf {} +
 
       msg_info "Backing up user data and configuration"
-      local BACKUP_DIR="/tmp/paperless_backup_$$"
+      local BACKUP_DIR="/opt/paperless_backup_$$"
       mkdir -p "$BACKUP_DIR"
 
       for dir in /opt/paperless/*/; do


### PR DESCRIPTION
## ✍️ Description  

Using /tmp for the backup is risky since many installations host it with tmpfs and thereby in RAM.

Having a bigger document base will deplete the memory on backup.

## 🔗 Related PR / Issue  
Link: https://github.com/community-scripts/ProxmoxVE/discussions/9143

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
