### PR TITLE
fix: restart apache2 after installing zabbix config

### DIFF
--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -108,7 +108,7 @@ else
   AGENT_SERVICE="zabbix-agent"
 fi
 
-systemctl restart zabbix-server
+systemctl restart zabbix-server apache2
 systemctl enable -q --now zabbix-server $AGENT_SERVICE apache2
 msg_ok "Started Services"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

After installing `zabbix-apache-conf` package, Apache does not automatically reload its configuration. This causes the `/zabbix` endpoint to return 404 until Apache is manually restarted.

This PR adds an explicit `systemctl restart apache2` command before the enable step to ensure the Zabbix configuration is immediately loaded and functional after installation completes.

**Testing:** Verified that `/zabbix` endpoint is accessible immediately after installation without requiring manual intervention.

## 🔗 Related PR / Issue  
Link: N/A (Bug discovered during installation testing)

## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.