### PR TITLE
github: add verbose mode check to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,6 +22,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: verbose_run
+    attributes:
+      label: 🔎 Did you run the script with verbose mode enabled?
+      description: "Required for debugging any script issue. A verbose log is mandatory."
+      options:
+        - "Yes, verbose mode was enabled and the output is included below"
+        - "No (this issue will likely be closed automatically)"
+    validations:
+      required: true
+
   - type: input
     id: script_name
     attributes:


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
This PR improves the Issue Template for script-related bug reports.
A new required dropdown was added to explicitly confirm whether the script was executed in verbose mode.
Many users previously ignored the verbose requirement, resulting in incomplete and non-actionable reports.
The new field makes the requirement highly visible and prevents accidental submissions without proper debugging output.
The template also clarifies that issues without verbose logs may be closed automatically.
No functional changes to scripts or logic are included in this PR.
This update is solely focused on improving support quality and reducing repetitive maintainer questions.
It helps ensure that every reported issue includes the diagnostic data required for troubleshooting.


## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
