### PR TITLE
Omada - AVX-only support

### DIFF
--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -36,7 +36,7 @@ function update_script() {
     exit 10
   fi
 
-  JAVA_VERSION=21 setup_java
+  JAVA_VERSION="21" setup_java
 
   msg_info "Updating Omada Controller"
   OMADA_URL=$(curl -fsSL "https://support.omadanetworks.com/en/download/software/omada-controller/" |

--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-3072}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -32,19 +32,11 @@ function update_script() {
   if lscpu | grep -q 'avx'; then
     MONGO_VERSION="8.0" setup_mongodb
   else
-    msg_warn "No AVX detected: Using older MongoDB 4.4"
-    MONGO_VERSION="4.4" setup_mongodb
+    msg_error "No AVX detected (CPU-Flag)! We have discontinued support for this. You are welcome to try it manually with a Debian LXC, but due to the many issues with Omada, we currently only support AVX CPUs."
+    exit 10
   fi
 
-  msg_info "Checking if right Azul Zulu Java is installed"
-  java_version=$(java -version 2>&1 | awk -F[\"_] '/version/ {print $2}')
-  if [[ "$java_version" =~ ^1\.8\.* ]]; then
-    $STD apt remove --purge -y zulu8-jdk
-    $STD apt -y install zulu21-jre-headless
-    msg_ok "Updated Azul Zulu Java to 21"
-  else
-    msg_ok "Azul Zulu Java 21 already installed"
-  fi
+  JAVA_VERSION=21 setup_java
 
   msg_info "Updating Omada Controller"
   OMADA_URL=$(curl -fsSL "https://support.omadanetworks.com/en/download/software/omada-controller/" |

--- a/frontend/public/json/omada.json
+++ b/frontend/public/json/omada.json
@@ -23,7 +23,7 @@
                 "ram": 3072,
                 "hdd": 8,
                 "os": "debian",
-                "version": "13"
+                "version": "12"
             }
         }
     ],

--- a/install/omada-install.sh
+++ b/install/omada-install.sh
@@ -17,22 +17,14 @@ msg_info "Installing Dependencies"
 $STD apt install -y jsvc
 msg_ok "Installed Dependencies"
 
-msg_info "Checking CPU Features"
+JAVA_VERSION=21 setup_java
+
 if lscpu | grep -q 'avx'; then
-  MONGODB_VERSION="8.0"
-  msg_ok "AVX detected: Using MongoDB 8.0"
   MONGO_VERSION="8.0" setup_mongodb
 else
-  MONGO_VERSION="4.4" setup_mongodb
+  msg_error "No AVX detected (CPU-Flag)! We have discontinued support for this. You are welcome to try it manually with a Debian LXC, but due to the many issues with Omada, we currently only support AVX CPUs."
+  exit 10
 fi
-
-msg_info "Installing Azul Zulu Java"
-curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xB1998361219BD9C9" -o "/etc/apt/trusted.gpg.d/zulu-repo.asc"
-curl -fsSL "https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb" -o zulu-repo.deb
-$STD dpkg -i zulu-repo.deb
-$STD apt update
-$STD apt -y install zulu21-jre-headless
-msg_ok "Installed Azul Zulu Java"
 
 
 if ! dpkg -l | grep -q 'libssl1.1'; then
@@ -50,14 +42,9 @@ OMADA_URL=$(curl -fsSL "https://support.omadanetworks.com/en/download/software/o
 OMADA_PKG=$(basename "$OMADA_URL")
 curl -fsSL "$OMADA_URL" -o "$OMADA_PKG"
 $STD dpkg -i "$OMADA_PKG"
+rm -rf "$OMADA_PKG"
 msg_ok "Installed Omada Controller"
 
 motd_ssh
 customize
-
-msg_info "Cleaning up"
-rm -rf "$OMADA_PKG" zulu-repo.deb
-$STD apt -y autoremove
-$STD apt -y autoclean
-$STD apt -y clean
-msg_ok "Cleaned"
+cleanup_lxc

--- a/install/omada-install.sh
+++ b/install/omada-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y jsvc
 msg_ok "Installed Dependencies"
 
-JAVA_VERSION=21 setup_java
+JAVA_VERSION="21" setup_java
 
 if lscpu | grep -q 'avx'; then
   MONGO_VERSION="8.0" setup_mongodb
@@ -25,7 +25,6 @@ else
   msg_error "No AVX detected (CPU-Flag)! We have discontinued support for this. You are welcome to try it manually with a Debian LXC, but due to the many issues with Omada, we currently only support AVX CPUs."
   exit 10
 fi
-
 
 if ! dpkg -l | grep -q 'libssl1.1'; then
   msg_info "Installing libssl (if needed)"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Discontinue support for non-AVX CPUs in Omada installation scripts, exiting with an error if AVX is not detected. Simplify Java installation by using a setup_java function and remove manual Azul Zulu Java installation steps. Update default Omada version from 13 to 12 in scripts and JSON config. Replace manual cleanup steps with cleanup_lxc.


## 🔗 Related PR / Issue  
Link: #9273


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
