### PR TITLE
fix: update website URL in filebrowser.json

### DIFF
--- a/frontend/public/json/filebrowser.json
+++ b/frontend/public/json/filebrowser.json
@@ -11,7 +11,7 @@
   "privileged": false,
   "interface_port": 8080,
   "documentation": null,
-  "website": "https://filebrowser.org/features",
+  "website": "https://filebrowser.org/index.html#features",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/webp/file-browser.webp",
   "config_path": "",
   "description": "File Browser offers a user-friendly web interface for managing files within a designated directory. It allows you to perform various actions such as uploading, deleting, previewing, renaming, and editing files.",


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

The website URL in Filebrowser became 404 due to their official site structure changed.

## 🔗 Related PR / Issue  
Link: # N/A


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
