### PR TITLE
fix: karakeep strip "v" from release version

### DIFF
--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -59,7 +59,7 @@ function update_script() {
     if command -v corepack >/dev/null; then
       $STD corepack disable
     fi
-    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
+    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1] | ltrimstr("v")' /opt/karakeep/package.json)"
     NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
     msg_info "Updating Karakeep"

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -59,7 +59,7 @@ function update_script() {
     if command -v corepack >/dev/null; then
       $STD corepack disable
     fi
-    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1] /opt/karakeep/package.json)"
+    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/karakeep/package.json)"
     NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
     msg_info "Updating Karakeep"

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -59,7 +59,7 @@ function update_script() {
     if command -v corepack >/dev/null; then
       $STD corepack disable
     fi
-    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1] | ltrimstr("v")' /opt/karakeep/package.json)"
+    MODULE_VERSION="$(jq -r '.packageManager | split("@")[1] /opt/karakeep/package.json)"
     NODE_VERSION="22" NODE_MODULE="pnpm@${MODULE_VERSION}" setup_nodejs
 
     msg_info "Updating Karakeep"
@@ -82,7 +82,7 @@ function update_script() {
     cd /opt/karakeep/packages/db
     $STD pnpm migrate
     $STD pnpm store prune
-    sed -i "s/^SERVER_VERSION=.*$/SERVER_VERSION=${CHECK_UPDATE_RELEASE}/" /etc/karakeep/karakeep.env
+    sed -i "s/^SERVER_VERSION=.*$/SERVER_VERSION=${CHECK_UPDATE_RELEASE#v}/" /etc/karakeep/karakeep.env
     msg_ok "Updated Karakeep"
 
     msg_info "Starting Services"

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -64,7 +64,7 @@ export DATA_DIR=/opt/karakeep_data
 karakeep_SECRET=$(openssl rand -base64 36 | cut -c1-24)
 mkdir -p /etc/karakeep
 cat <<EOF >/etc/karakeep/karakeep.env
-SERVER_VERSION="$(cat ~/.karakeep)"
+SERVER_VERSION="$(sed 's/^v//' ~/.karakeep)"
 NEXTAUTH_SECRET="$karakeep_SECRET"
 NEXTAUTH_URL="http://localhost:3000"
 DATA_DIR=${DATA_DIR}


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Fix this bug: https://github.com/karakeep-app/karakeep/issues/2133


## 🔗 Related PR / Issue  
Link: #https://github.com/karakeep-app/karakeep/issues/2133


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
