### PR TITLE
Remove redundant cleanup steps from update scripts (ct/ Folder) 

### DIFF
--- a/ct/2fauth.sh
+++ b/ct/2fauth.sh
@@ -57,15 +57,6 @@ function update_script() {
     $STD composer install --no-dev --prefer-dist
     php artisan 2fauth:install
     $STD systemctl restart nginx
-
-    msg_info "Cleaning Up"
-    if dpkg -l | grep -q 'php8.2'; then
-      $STD apt remove --purge -y php8.2*
-    fi
-    $STD apt -y autoremove
-    $STD apt -y autoclean
-    $STD apt -y clean
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -62,6 +62,7 @@ function update_script() {
     cd /opt/adventurelog/frontend || exit
     $STD pnpm i
     $STD pnpm build
+    rm -rf /opt/adventurelog-backup
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Services"
@@ -69,10 +70,6 @@ function update_script() {
     systemctl start adventurelog-backend
     systemctl start adventurelog-frontend
     msg_ok "Services Started"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/adventurelog-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/apache-tika.sh
+++ b/ct/apache-tika.sh
@@ -38,15 +38,13 @@ function update_script() {
     curl -fsSL -o tika-server-standard-${RELEASE}.jar "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.jar"
     mv --force tika-server-standard.jar tika-server-standard-prev-version.jar
     mv tika-server-standard-${RELEASE}.jar tika-server-standard.jar
+    rm -rf /opt/apache-tika/tika-server-standard-prev-version.jar
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start apache-tika
     msg_ok "Started Service"
-    msg_info "Cleaning Up"
-    rm -rf /opt/apache-tika/tika-server-standard-prev-version.jar
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/authelia.sh
+++ b/ct/authelia.sh
@@ -31,15 +31,11 @@ function update_script() {
   fi
 
   if check_for_gh_release "authelia" "authelia/authelia"; then
-    $STD apt-get update
-    $STD apt-get -y upgrade
+    $STD apt update
+    $STD apt -y upgrade
 
     fetch_and_deploy_gh_release "authelia" "authelia/authelia" "binary"
 
-    msg_info "Cleaning Up"
-    $STD apt-get -y autoremove
-    $STD apt-get -y autoclean
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/backrest.sh
+++ b/ct/backrest.sh
@@ -39,16 +39,13 @@ function update_script() {
     curl -fsSL "https://github.com/garethgeorge/backrest/releases/download/v${RELEASE}/backrest_Linux_x86_64.tar.gz" -o "$temp_file"
     tar xzf $temp_file -C /opt/backrest/bin
     chmod +x /opt/backrest/bin/backrest
+    rm -f "$temp_file"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to ${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start backrest
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -f "$temp_file"
-    msg_ok "Cleaned up"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/baikal.sh
+++ b/ct/baikal.sh
@@ -47,15 +47,12 @@ function update_script() {
     chmod -R 755 /opt/baikal/
     cd /opt/baikal
     $STD composer install
+    rm -rf /opt/baikal-backup
     msg_ok "Configured Baikal"
 
     msg_info "Starting Service"
     systemctl start apache2
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/baikal-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/bar-assistant.sh
+++ b/ct/bar-assistant.sh
@@ -54,15 +54,12 @@ function update_script() {
     $STD php artisan route:cache
     $STD php artisan event:cache
     chown -R www-data:www-data /opt/bar-assistant
+    rm -rf /opt/bar-assistant-backup
     msg_ok "Updated Bar-Assistant"
 
     msg_info "Starting nginx"
     systemctl start nginx
     msg_ok "Started nginx"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/bar-assistant-backup
-    msg_ok "Cleaned"
   fi
 
   if check_for_gh_release "vue-salt-rim" "karlomikus/vue-salt-rim"; then
@@ -81,15 +78,12 @@ function update_script() {
     cd /opt/vue-salt-rim
     $STD npm install
     $STD npm run build
+    rm -rf /opt/vue-salt-rim-backup
     msg_ok "Updated Vue Salt Rim"
 
     msg_info "Starting nginx"
     systemctl start nginx
     msg_ok "Started nginx"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/vue-salt-rim-backup
-    msg_ok "Cleaned"
   fi
 
   if check_for_gh_release "meilisearch" "meilisearch/meilisearch"; then

--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -57,15 +57,12 @@ function update_script() {
     chmod -R 755 /opt/bookstack /opt/bookstack/bootstrap/cache /opt/bookstack/public/uploads /opt/bookstack/storage
     chmod -R 775 /opt/bookstack/storage /opt/bookstack/bootstrap/cache /opt/bookstack/public/uploads
     chmod -R 640 /opt/bookstack/.env
+    rm -rf /opt/bookstack-backup
     msg_ok "Configured BookStack"
 
     msg_info "Starting Apache2"
     systemctl start apache2
     msg_ok "Started Apache2"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/bookstack-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/dispatcharr.sh
+++ b/ct/dispatcharr.sh
@@ -109,6 +109,7 @@ function update_script() {
     fi
     $STD uv run python manage.py migrate --noinput
     $STD uv run python manage.py collectstatic --noinput
+    rm -f /tmp/dispatcharr_db_*.sql
     msg_ok "Migrations Complete"
 
     msg_info "Starting Services"
@@ -117,10 +118,6 @@ function update_script() {
     systemctl start dispatcharr-celerybeat
     systemctl start dispatcharr-daphne
     msg_ok "Started Services"
-
-    msg_info "Cleaning up"
-    rm -f /tmp/dispatcharr_db_*.sql
-    msg_ok "Cleanup completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/docker.sh
+++ b/ct/docker.sh
@@ -76,11 +76,6 @@ function update_script() {
       portainer/agent
     msg_ok "Updated Portainer Agent"
   fi
-
-  msg_info "Cleaning up"
-  $STD apt-get -y autoremove
-  $STD apt-get -y autoclean
-  msg_ok "Cleanup complete"
   msg_ok "Updated successfully!"
   exit
 }

--- a/ct/documenso.sh
+++ b/ct/documenso.sh
@@ -50,16 +50,13 @@ function update_script() {
     $STD turbo run build --filter=@documenso/remix
     $STD npm run prisma:migrate-deploy
     $STD turbo daemon stop
+    rm -rf /opt/v${RELEASE}.zip
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Service"
     systemctl start documenso
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/v${RELEASE}.zip
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/emqx.sh
+++ b/ct/emqx.sh
@@ -47,16 +47,13 @@ function update_script() {
 
     msg_info "Installing EMQX"
     $STD apt-get install -y "$DEB_FILE"
+    rm -f "$DEB_FILE"
+    echo "$RELEASE" >~/.emqx
     msg_ok "Installed EMQX v${RELEASE}"
 
     msg_info "Starting EMQX"
     systemctl start emqx
-    echo "$RELEASE" >~/.emqx
     msg_ok "Started EMQX"
-
-    msg_info "Cleaning Up"
-    rm -f "$DEB_FILE"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. EMQX is already at v${RELEASE}"

--- a/ct/fileflows.sh
+++ b/ct/fileflows.sh
@@ -48,16 +48,13 @@ function update_script() {
     temp_file=$(mktemp)
     curl -fsSL https://fileflows.com/downloads/zip -o "$temp_file"
     $STD unzip -o -d /opt/fileflows "$temp_file"
+    rm -rf "$temp_file"
+    rm -rf "$backup_filename"
     msg_ok "Updated $APP to latest version"
 
     msg_info "Starting Service"
     systemctl start fileflows
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf "$temp_file"
-    rm -rf "$backup_filename"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at latest version"

--- a/ct/ghostfolio.sh
+++ b/ct/ghostfolio.sh
@@ -56,10 +56,6 @@ function update_script() {
     msg_info "Starting Service"
     systemctl start ghostfolio
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    $STD npm cache clean --force
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/keycloak.sh
+++ b/ct/keycloak.sh
@@ -49,15 +49,12 @@ function update_script() {
     cp -a keycloak.old/conf/. keycloak/conf/
     cp -a keycloak.old/providers/. keycloak/providers/ 2>/dev/null || true
     cp -a keycloak.old/themes/. keycloak/themes/ 2>/dev/null || true
+    rm -rf keycloak.old
     msg_ok "Updated Keycloak"
 
     msg_info "Restarting Service"
     systemctl restart keycloak
     msg_ok "Restarted Service"
-
-    msg_info "Cleaning up"
-    rm -rf keycloak.old
-    msg_ok "Cleanup complete"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/koillection.sh
+++ b/ct/koillection.sh
@@ -50,15 +50,12 @@ function update_script() {
     $STD yarn install
     $STD yarn build
     chown -R www-data:www-data /opt/koillection/public/uploads
+    rm -r /opt/koillection-backup
     msg_ok "Updated Koillection"
 
     msg_info "Starting Service"
     systemctl start apache2
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -r /opt/koillection-backup
-    msg_ok "Cleaned"
     msg_ok "Updated Successfully!"
   fi
   exit

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -52,17 +52,14 @@ function update_script() {
     $STD yarn web:build
     $STD yarn prisma:deploy
     [ -d /opt/data.bak ] && mv /opt/data.bak /opt/linkwarden/data
+    rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache ~/.rustup
+    rm -rf /root/.cache/yarn
+    rm -rf /opt/linkwarden/.next/cache
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Service"
     systemctl start linkwarden
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache ~/.rustup
-    rm -rf /root/.cache/yarn
-    rm -rf /opt/linkwarden/.next/cache
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/listmonk.sh
+++ b/ct/listmonk.sh
@@ -42,15 +42,12 @@ function update_script() {
     mv /opt/listmonk-backup/config.toml /opt/listmonk/config.toml
     mv /opt/listmonk-backup/uploads /opt/listmonk/uploads
     $STD /opt/listmonk/listmonk --upgrade --yes --config /opt/listmonk/config.toml
+    rm -rf /opt/listmonk-backup/
     msg_ok "Configured listmonk"
 
     msg_info "Starting Service"
     systemctl start listmonk
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/listmonk-backup/
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/lubelogger.sh
+++ b/ct/lubelogger.sh
@@ -53,15 +53,12 @@ function update_script() {
     msg_info "Configuring LubeLogger"
     chmod 700 /opt/lubelogger/CarCareTracker
     cp -rf /tmp/lubeloggerData/* /opt/lubelogger/
+    rm -rf /tmp/lubeloggerData
     msg_ok "Configured LubeLogger"
 
     msg_info "Starting Service"
     systemctl start lubelogger
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /tmp/lubeloggerData
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/lyrionmusicserver.sh
+++ b/ct/lyrionmusicserver.sh
@@ -38,15 +38,9 @@ function update_script() {
     curl -fsSL -o "$DEB_FILE" "$DEB_URL"
     $STD apt install "$DEB_FILE" -y
     systemctl restart lyrion
+    $STD rm -f "$DEB_FILE"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to ${RELEASE}"
-
-    msg_info "Cleaning up"
-    $STD rm -f "$DEB_FILE"
-    $STD apt -y autoremove
-    $STD apt -y autoclean
-    $STD apt -y clean
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "$APP is already up to date (${RELEASE})"

--- a/ct/minio.sh
+++ b/ct/minio.sh
@@ -55,17 +55,13 @@ function update_script() {
     mv /usr/local/bin/minio /usr/local/bin/minio_bak
     curl -fsSL "https://dl.min.io/server/minio/release/linux-amd64/minio" -o /usr/local/bin/minio
     chmod +x /usr/local/bin/minio
+    rm -f /usr/local/bin/minio_bak
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Service"
     systemctl start minio
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -f /usr/local/bin/minio_bak
-    msg_ok "Cleaned"
-
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/monica.sh
+++ b/ct/monica.sh
@@ -52,15 +52,12 @@ function update_script() {
     $STD php artisan monica:update --force
     chown -R www-data:www-data /opt/monica
     chmod -R 775 /opt/monica/storage
+    rm -r /opt/monica-backup
     msg_ok "Configured monica"
 
     msg_info "Starting Service"
     systemctl start apache2
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -r /opt/monica-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/netbox.sh
+++ b/ct/netbox.sh
@@ -57,17 +57,14 @@ function update_script() {
     fi
 
     $STD /opt/netbox/upgrade.sh
+    rm -r "/opt/v${RELEASE}.zip"
+    rm -r /opt/netbox-backup
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start netbox netbox-rq
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -r "/opt/v${RELEASE}.zip"
-    rm -r /opt/netbox-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/nextpvr.sh
+++ b/ct/nextpvr.sh
@@ -21,37 +21,34 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/nextpvr ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    msg_info "Stopping Service"
-    systemctl stop nextpvr-server
-    msg_ok "Stopped Service"
-
-    msg_info "Updating LXC packages"
-    $STD apt update
-    $STD apt -y upgrade
-    msg_ok "Updated LXC packages"
-
-    msg_info "Updating ${APP}"
-    cd /opt
-    curl -fsSL "https://nextpvr.com/nextpvr-helper.deb" -o $(basename "https://nextpvr.com/nextpvr-helper.deb")
-    $STD dpkg -i nextpvr-helper.deb
-    msg_ok "Updated ${APP}"
-
-    msg_info "Starting Service"
-    systemctl start nextpvr-server
-    msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/nextpvr-helper.deb
-    msg_ok "Cleaned"
-    msg_ok "Updated successfully!"
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/nextpvr ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  msg_info "Stopping Service"
+  systemctl stop nextpvr-server
+  msg_ok "Stopped Service"
+
+  msg_info "Updating LXC packages"
+  $STD apt update
+  $STD apt -y upgrade
+  msg_ok "Updated LXC packages"
+
+  msg_info "Updating ${APP}"
+  cd /opt
+  curl -fsSL "https://nextpvr.com/nextpvr-helper.deb" -o $(basename "https://nextpvr.com/nextpvr-helper.deb")
+  $STD dpkg -i nextpvr-helper.deb
+  rm -rf /opt/nextpvr-helper.deb
+  msg_ok "Updated ${APP}"
+
+  msg_info "Starting Service"
+  systemctl start nextpvr-server
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
+  exit
 }
 
 start

--- a/ct/nxwitness.sh
+++ b/ct/nxwitness.sh
@@ -42,17 +42,13 @@ function update_script() {
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NOWARNINGS=yes
     $STD dpkg -i nxwitness-server-$RELEASE-linux_x64.deb
+    rm -f /tmp/nxwitness-server-$RELEASE-linux_x64.deb
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Service"
     systemctl start networkoptix-root-tool networkoptix-mediaserver
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -f /tmp/nxwitness-server-$RELEASE-linux_x64.deb
-    msg_ok "Cleaned"
-
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/odoo.sh
+++ b/ct/odoo.sh
@@ -50,17 +50,13 @@ function update_script() {
     msg_info "Updating ${APP} to ${LATEST_VERSION}"
     curl -fsSL https://nightly.odoo.com/${RELEASE}/nightly/deb/odoo_${RELEASE}.latest_all.deb -o /opt/odoo.deb
     $STD apt install -y /opt/odoo.deb
+    rm -f /opt/odoo.deb
     echo "$LATEST_VERSION" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to ${LATEST_VERSION}"
 
-    msg_info "Starting ${APP} service"
+    msg_info "Starting Service"
     systemctl start odoo
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -f /opt/odoo.deb
-    msg_ok "Cleaned"
-
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${LATEST_VERSION}"

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -43,16 +43,13 @@ function update_script() {
     mkdir -p /usr/local/lib/ollama
     tar -xzf "${TMP_TAR}" -C /usr/local/lib/ollama
     ln -sf /usr/local/lib/ollama/bin/ollama /usr/local/bin/ollama
+    rm -f "${TMP_TAR}"
     echo "${RELEASE}" >/opt/Ollama_version.txt
     msg_ok "Updated Ollama to ${RELEASE}"
 
     msg_info "Starting Services"
     systemctl start ollama
     msg_ok "Started Services"
-
-    msg_info "Cleaning Up"
-    rm -f "${TMP_TAR}"
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. Ollama is already at ${RELEASE}"

--- a/ct/onedev.sh
+++ b/ct/onedev.sh
@@ -39,17 +39,14 @@ function update_script() {
     tar -xzf onedev-latest.tar.gz
     $STD /opt/onedev-latest/bin/upgrade.sh /opt/onedev
     RELEASE=$(cat /opt/onedev/release.properties | grep "version" | cut -d'=' -f2)
+    rm -rf /opt/onedev-latest
+    rm -rf /opt/onedev-latest.tar.gz
     echo "${RELEASE}" >"/opt/${APP}_version.txt"
     msg_ok "Updated ${APP} to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start onedev
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/onedev-latest
-    rm -rf /opt/onedev-latest.tar.gz
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}."

--- a/ct/paperless-ai.sh
+++ b/ct/paperless-ai.sh
@@ -65,17 +65,14 @@ EOF
     $STD pip install --no-cache-dir -r requirements.txt
     mkdir -p data/chromadb
     $STD npm install
+    rm -rf /opt/v${RELEASE}.zip
+    rm -rf /opt/paperless-ai_bak
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start paperless-ai
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/v${RELEASE}.zip
-    rm -rf /opt/paperless-ai_bak
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/paperless-gpt.sh
+++ b/ct/paperless-gpt.sh
@@ -20,48 +20,45 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/paperless-gpt ]]; then
-        msg_error "No Paperless-GPT installation found!"
-        exit
-    fi
-    RELEASE=$(curl -fsSL https://api.github.com/repos/icereed/paperless-gpt/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
-    if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
-        msg_info "Stopping Service"
-        systemctl stop paperless-gpt
-        msg_ok "Service Stopped"
-
-        msg_info "Updating Paperless-GPT to ${RELEASE}"
-        temp_file=$(mktemp)
-        curl -fsSL "https://github.com/icereed/paperless-gpt/archive/refs/tags/v${RELEASE}.tar.gz" -o "$temp_file"
-        tar zxf $temp_file
-        rm -rf /opt/paperless-gpt
-        mv paperless-gpt-${RELEASE} /opt/paperless-gpt
-        cd /opt/paperless-gpt/web-app
-        $STD npm install
-        $STD npm run build
-        cd /opt/paperless-gpt
-        go mod download
-        export CC=musl-gcc
-        CGO_ENABLED=1 go build -tags musl -o /dev/null github.com/mattn/go-sqlite3
-        CGO_ENABLED=1 go build -tags musl -o paperless-gpt .
-        echo "${RELEASE}" >"/opt/paperless-gpt_version.txt"
-        msg_ok "Updated Paperless-GPT to ${RELEASE}"
-
-        msg_info "Starting Service"
-        systemctl start paperless-gpt
-        msg_ok "Started Service"
-
-        msg_info "Cleaning Up"
-        rm -f $temp_file
-        msg_ok "Cleanup Completed"
-        msg_ok "Updated successfully!"
-    else
-        msg_ok "No update required. ${APP} is already at ${RELEASE}"
-    fi
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/paperless-gpt ]]; then
+    msg_error "No Paperless-GPT installation found!"
     exit
+  fi
+  RELEASE=$(curl -fsSL https://api.github.com/repos/icereed/paperless-gpt/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4) }')
+  if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
+    msg_info "Stopping Service"
+    systemctl stop paperless-gpt
+    msg_ok "Service Stopped"
+
+    msg_info "Updating Paperless-GPT to ${RELEASE}"
+    temp_file=$(mktemp)
+    curl -fsSL "https://github.com/icereed/paperless-gpt/archive/refs/tags/v${RELEASE}.tar.gz" -o "$temp_file"
+    tar zxf $temp_file
+    rm -rf /opt/paperless-gpt
+    mv paperless-gpt-${RELEASE} /opt/paperless-gpt
+    cd /opt/paperless-gpt/web-app
+    $STD npm install
+    $STD npm run build
+    cd /opt/paperless-gpt
+    go mod download
+    export CC=musl-gcc
+    CGO_ENABLED=1 go build -tags musl -o /dev/null github.com/mattn/go-sqlite3
+    CGO_ENABLED=1 go build -tags musl -o paperless-gpt .
+    rm -f $temp_file
+    echo "${RELEASE}" >"/opt/paperless-gpt_version.txt"
+    msg_ok "Updated Paperless-GPT to ${RELEASE}"
+
+    msg_info "Starting Service"
+    systemctl start paperless-gpt
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  else
+    msg_ok "No update required. ${APP} is already at ${RELEASE}"
+  fi
+  exit
 }
 
 start

--- a/ct/part-db.sh
+++ b/ct/part-db.sh
@@ -52,17 +52,14 @@ function update_script() {
     $STD php bin/console cache:clear
     $STD php bin/console doctrine:migrations:migrate -n
     chown -R www-data:www-data /opt/partdb
+    rm -r "/opt/v${RELEASE}.zip"
+    rm -r /opt/partdb-backup
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start apache2
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -r "/opt/v${RELEASE}.zip"
-    rm -r /opt/partdb-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -67,6 +67,7 @@ function update_script() {
     $STD php artisan migrate --seed --force
     chown -R www-data:www-data /opt/pelican-panel
     chmod -R 755 /opt/pelican-panel/storage /opt/pelican-panel/bootstrap/cache/
+    rm -rf "/opt/pelican-panel/panel.tar.gz"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
@@ -74,10 +75,6 @@ function update_script() {
     $STD php artisan queue:restart
     $STD php artisan up
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf "/opt/pelican-panel/panel.tar.gz"
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/pterodactyl-panel.sh
+++ b/ct/pterodactyl-panel.sh
@@ -70,6 +70,7 @@ EOF
     $STD php artisan migrate --seed --force --no-interaction
     chown -R www-data:www-data /opt/pterodactyl-panel/*
     chmod -R 755 /opt/pterodactyl-panel/storage /opt/pterodactyl-panel/bootstrap/cache/
+    rm -rf "/opt/pterodactyl-panel/panel.tar.gz"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
@@ -77,10 +78,6 @@ EOF
     $STD php artisan queue:restart
     $STD php artisan up
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf "/opt/pterodactyl-panel/panel.tar.gz"
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -43,14 +43,11 @@ function update_script() {
       $STD apt remove --purge -y dotnet-sdk-8.0
       $STD apt install -y dotnet-sdk-9.0
     fi
+    rm -rf /opt/rdtc-backup
 
     msg_info "Starting Service"
     systemctl start rdtc
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/rdtc-backup
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/reactive-resume.sh
+++ b/ct/reactive-resume.sh
@@ -54,6 +54,7 @@ function update_script() {
     cd /tmp
     curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio.deb -o minio.deb
     $STD dpkg -i minio.deb
+    rm -f /tmp/minio.deb
     msg_ok "Updated Minio"
 
     msg_info "Updating Browserless (Patience)"
@@ -75,16 +76,12 @@ function update_script() {
     $STD npm run build:function
     $STD npm prune production
     mv /opt/browserless.env /opt/browserless/.env
+    rm -f "$brwsr_tmp"
     msg_ok "Updated Browserless"
 
     msg_info "Restarting services"
     systemctl start minio Reactive-Resume browserless
     msg_ok "Restarted services"
-
-    msg_info "Cleaning Up"
-    rm -f /tmp/minio.deb
-    rm -f "$brwsr_tmp"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/revealjs.sh
+++ b/ct/revealjs.sh
@@ -41,15 +41,12 @@ function update_script() {
     $STD npm install
     cp -f /opt/index.html /opt/revealjs
     sed -i '25s/localhost/0.0.0.0/g' /opt/revealjs/gulpfile.js
+    rm -f /opt/index.html
     msg_ok "Updated $APP"
 
     msg_info "Starting Service"
     systemctl start revealjs
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -f /opt/index.html
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/slskd.sh
+++ b/ct/slskd.sh
@@ -61,15 +61,12 @@ function update_script() {
   $STD pip install -r requirements.txt
   mv /opt/config.ini.bak /opt/soularr/config.ini
   mv /opt/run.sh.bak /opt/soularr/run.sh
+  rm -rf /tmp/main.zip
   msg_ok "Updated soularr"
 
   msg_info "Starting soularr timer"
   systemctl start soularr.timer
   msg_ok "Started soularr timer"
-
-  msg_info "Cleaning Up"
-  rm -rf /tmp/main.zip
-  msg_ok "Cleanup Completed"
   exit
 }
 

--- a/ct/spoolman.sh
+++ b/ct/spoolman.sh
@@ -43,17 +43,13 @@ function update_script() {
     cd spoolman
     $STD pip3 install -r requirements.txt
     curl -fsSL "https://raw.githubusercontent.com/Donkie/Spoolman/master/.env.example" -o ".env"
+    rm -rf /opt/spoolman.zip
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to ${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start spoolman
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/spoolman.zip
-    msg_ok "Cleaned"
-
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/tandoor.sh
+++ b/ct/tandoor.sh
@@ -64,16 +64,13 @@ EOF
     cd /opt/tandoor
     $STD /opt/tandoor/.venv/bin/python manage.py migrate
     $STD /opt/tandoor/.venv/bin/python manage.py collectstatic --no-input
+    rm -rf /opt/tandoor.bak
     msg_ok "Updated Trandoor"
 
     msg_info "Starting Service"
     systemctl start tandoor
     systemctl reload nginx
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/tandoor.bak
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/tasmocompiler.sh
+++ b/ct/tasmocompiler.sh
@@ -45,16 +45,13 @@ function update_script() {
     export NODE_OPTIONS=--openssl-legacy-provider
     $STD npm i
     $STD yarn build
+    rm -r "/opt/v${RELEASE}.tar.gz"
+    echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated TasmoCompiler"
 
     msg_info "Starting Service"
     systemctl start tasmocompiler
     msg_ok "Started Service"
-
-    echo "${RELEASE}" >/opt/${APP}_version.txt
-    msg_info "Cleaning up"
-    rm -r "/opt/v${RELEASE}.tar.gz"
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/tdarr.sh
+++ b/ct/tdarr.sh
@@ -37,11 +37,8 @@ function update_script() {
   $STD unzip Tdarr_Updater.zip
   chmod +x Tdarr_Updater
   $STD ./Tdarr_Updater
-  msg_ok "Updated Tdarr"
-
-  msg_info "Cleaning up"
   rm -rf /opt/tdarr/Tdarr_Updater.zip
-  msg_ok "Cleaned up"
+  msg_ok "Updated Tdarr"
   msg_ok "Updated successfully!"
   exit
 }

--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -38,11 +38,8 @@ function update_script() {
     msg_info "Updating Technitium DNS"
     curl -fsSL "https://download.technitium.com/dns/DnsServerPortable.tar.gz" -o /opt/DnsServerPortable.tar.gz
     $STD tar zxvf /opt/DnsServerPortable.tar.gz -C /opt/technitium/dns/
-    msg_ok "Updated Technitium DNS"
-
-    msg_info "Cleaning up"
     rm -f /opt/DnsServerPortable.tar.gz
-    msg_ok "Cleaned up"
+    msg_ok "Updated Technitium DNS"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required.  Technitium DNS is already at v${RELEASE}."

--- a/ct/teddycloud.sh
+++ b/ct/teddycloud.sh
@@ -41,15 +41,12 @@ function update_script() {
 
     msg_info "Restoring data"
     cp -R /opt/teddycloud_bak/certs /opt/teddycloud_bak/config /opt/teddycloud_bak/data /opt/teddycloud
+    rm -rf /opt/teddycloud_bak
     msg_ok "Data restored"
 
     msg_info "Starting Service"
     systemctl start teddycloud
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/teddycloud_bak
-    msg_ok "Cleaned up"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/tianji.sh
+++ b/ct/tianji.sh
@@ -43,7 +43,7 @@ function update_script() {
 
     fetch_and_deploy_gh_release "tianji" "msgbyte/tianji"
 
-    msg_info "Updating ${APP}"
+    msg_info "Updating Tianji"
     cd /opt/tianji
     export NODE_OPTIONS="--max_old_space_size=4096"
     $STD pnpm install --filter @tianji/client... --config.dedupe-peer-dependents=false --frozen-lockfile
@@ -55,7 +55,11 @@ function update_script() {
     mv /opt/.env /opt/tianji/src/server/.env
     cd src/server
     $STD pnpm db:migrate:apply
-    msg_ok "Updated ${APP}"
+    rm -rf /opt/tianji_bak
+    rm -rf /opt/tianji/src/client
+    rm -rf /opt/tianji/website
+    rm -rf /opt/tianji/reporter
+    msg_ok "Updated Tianji"
 
     msg_info "Updating AppRise"
     $STD uv pip install apprise cryptography --system
@@ -64,13 +68,6 @@ function update_script() {
     msg_info "Starting Service"
     systemctl start tianji
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/tianji_bak
-    rm -rf /opt/tianji/src/client
-    rm -rf /opt/tianji/website
-    rm -rf /opt/tianji/reporter
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/traccar.sh
+++ b/ct/traccar.sh
@@ -50,18 +50,12 @@ function update_script() {
     mv /opt/traccar.xml /opt/traccar/conf
     [[ -d /opt/data ]] && mv /opt/data /opt/traccar
     [[ -d /opt/media ]] && mv /opt/media /opt/traccar
+    [ -f README.txt ] || [ -f traccar.run ] && rm -f README.txt traccar.run
     msg_ok "Data restored"
 
     msg_info "Starting Service"
     systemctl start traccar
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    [ -f README.txt ] || [ -f traccar.run ] && rm -f README.txt traccar.run
-    $STD apt -y autoremove
-    $STD apt -y autoclean
-    $STD apt -y clean
-    msg_ok "Cleaned up"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/trilium.sh
+++ b/ct/trilium.sh
@@ -55,14 +55,8 @@ function update_script() {
     msg_info "Restoring Database"
     mkdir -p "$(dirname "${DB_RESTORE_PATH}")"
     cp -r /opt/trilium_backup/$(basename "${DB_PATH}") "${DB_RESTORE_PATH}"
-    msg_ok "Restored Database"
-
-    msg_info "Cleaning up"
     rm -rf /opt/trilium_backup
-    $STD apt -y autoremove
-    $STD apt -y autoclean
-    $STD apt -y clean
-    msg_ok "Cleaned"
+    msg_ok "Restored Database"
 
     msg_info "Starting Service"
     systemctl start trilium

--- a/ct/uhf.sh
+++ b/ct/uhf.sh
@@ -43,12 +43,6 @@ function update_script() {
     msg_info "Starting Service"
     systemctl start uhf-server
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    $STD apt -y autoremove
-    $STD apt -y autoclean
-    $STD apt -y clean
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -57,11 +57,8 @@ function update_script() {
     else
       cp target/release/vaultwarden /opt/vaultwarden/bin/
     fi
-    msg_ok "Updated VaultWarden"
-
-    msg_info "Cleaning up"
     cd ~ && rm -rf vaultwarden
-    msg_ok "Cleaned"
+    msg_ok "Updated VaultWarden"
 
     msg_info "Starting Service"
     systemctl start vaultwarden
@@ -77,11 +74,8 @@ function update_script() {
     msg_info "Updating Web-Vault to $WVRELEASE"
     $STD curl -fsSLO https://github.com/dani-garcia/bw_web_builds/releases/download/"$WVRELEASE"/bw_web_"$WVRELEASE".tar.gz
     $STD tar -zxf bw_web_"$WVRELEASE".tar.gz -C /opt/vaultwarden/
-    msg_ok "Updated Web-Vault"
-
-    msg_info "Cleaning up"
     rm bw_web_"$WVRELEASE".tar.gz
-    msg_ok "Cleaned"
+    msg_ok "Updated Web-Vault"
 
     msg_info "Starting Service"
     systemctl start vaultwarden

--- a/ct/vikunja.sh
+++ b/ct/vikunja.sh
@@ -39,16 +39,13 @@ function update_script() {
     curl -fsSL "https://dl.vikunja.io/vikunja/$RELEASE/vikunja-$RELEASE-amd64.deb" -o $(basename "https://dl.vikunja.io/vikunja/$RELEASE/vikunja-$RELEASE-amd64.deb")
     export DEBIAN_FRONTEND=noninteractive
     $STD dpkg -i vikunja-"$RELEASE"-amd64.deb
+    rm -rf /opt/vikunja-"$RELEASE"-amd64.deb
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Service"
     systemctl start vikunja
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/vikunja-"$RELEASE"-amd64.deb
-    msg_ok "Cleaned"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at ${RELEASE}"

--- a/ct/wastebin.sh
+++ b/ct/wastebin.sh
@@ -73,16 +73,13 @@ EOF
     cp -f wastebin* /opt/wastebin/
     chmod +x /opt/wastebin/wastebin
     chmod +x /opt/wastebin/wastebin-ctl
+    rm -f "$temp_file"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated Wastebin"
 
     msg_info "Starting Wastebin"
     systemctl start wastebin
     msg_ok "Started Wastebin"
-
-    msg_info "Cleaning Up"
-    rm -f "$temp_file"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/watchyourlan.sh
+++ b/ct/watchyourlan.sh
@@ -37,10 +37,7 @@ function update_script() {
     fetch_and_deploy_gh_release "watchyourlan" "aceberg/WatchYourLAN" "binary"
     cp -R config.yaml /data/config.yaml
     sed -i 's|/etc/watchyourlan/config.yaml|/data/config.yaml|' /lib/systemd/system/watchyourlan.service
-
-    msg_info "Cleaning up"
     rm ~/config.yaml
-    msg_ok "Cleaned up"
 
     msg_info "Starting service"
     systemctl enable -q --now watchyourlan

--- a/ct/wger.sh
+++ b/ct/wger.sh
@@ -45,16 +45,13 @@ function update_script() {
     $STD python3 manage.py collectstatic --no-input
     $STD yarn install
     $STD yarn build:css:sass
+    rm -rf "$temp_file"
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated $APP to v${RELEASE}"
 
     msg_info "Starting Service"
     systemctl start wger
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf "$temp_file"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required. ${APP} is already at v${RELEASE}"

--- a/ct/wikijs.sh
+++ b/ct/wikijs.sh
@@ -54,15 +54,12 @@ function update_script() {
     msg_info "Restoring Data"
     cp -R /opt/wikijs-backup/* /opt/wikijs
     $SQLITE_INSTALL && $STD npm rebuild sqlite3
+    rm -rf /opt/wikijs-backup
     msg_ok "Restored Data"
 
     msg_info "Starting Service"
     systemctl start wikijs
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf /opt/wikijs-backup
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/wizarr.sh
+++ b/ct/wizarr.sh
@@ -56,15 +56,12 @@ function update_script() {
     if ! grep -q 'frozen' /opt/wizarr/start.sh; then
       sed -i 's/run/& --frozen/' /opt/wizarr/start.sh
     fi
+    rm -rf "$BACKUP_FILE"
     msg_ok "Updated Wizarr"
 
     msg_info "Starting Service"
     systemctl start wizarr
     msg_ok "Started Service"
-
-    msg_info "Cleaning Up"
-    rm -rf "$BACKUP_FILE"
-    msg_ok "Cleanup Completed"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -59,6 +59,7 @@ function update_script() {
     xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb")" \
     -o /tmp/zabbix-release_latest+debian13_all.deb
   $STD dpkg -i zabbix-release_latest+debian13_all.deb
+  rm -rf /tmp/zabbix-release_latest+debian13_all.deb
   $STD apt update
 
   $STD apt install --only-upgrade zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql
@@ -88,13 +89,6 @@ function update_script() {
   systemctl start "$AGENT_SERVICE"
   systemctl restart apache2
   msg_ok "Started Services"
-
-  msg_info "Cleaning Up"
-  rm -rf /tmp/zabbix-release_latest+debian13_all.deb
-  $STD apt -y autoremove
-  $STD apt -y autoclean
-  $STD apt -y clean
-  msg_ok "Cleaned"
   msg_ok "Updated successfully!"
   exit
 }

--- a/ct/zigbee2mqtt.sh
+++ b/ct/zigbee2mqtt.sh
@@ -47,18 +47,15 @@ function update_script() {
     rm -rf /opt/zigbee2mqtt/data
     mv /opt/z2m_backup/data /opt/zigbee2mqtt
     cd /opt/zigbee2mqtt
-    grep -q "^packageImportMethod" ./pnpm-workspace.yaml || echo "packageImportMethod: hardlink" >> ./pnpm-workspace.yaml
+    grep -q "^packageImportMethod" ./pnpm-workspace.yaml || echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
     $STD pnpm install --frozen-lockfile
     $STD pnpm build
+    rm -rf /opt/z2m_backup
     msg_ok "Updated Zigbee2MQTT"
 
     msg_info "Starting Service"
     systemctl start zigbee2mqtt
     msg_ok "Started Service"
-
-    msg_info "Cleaning up"
-    rm -rf /opt/z2m_backup
-    msg_ok "Cleaned up"
     msg_ok "Updated successfully!"
   fi
   exit


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Eliminated unnecessary 'Cleaning up' messages and duplicate cleanup commands from multiple service update scripts. Cleanup actions (such as removing backup files and temporary artifacts) are now performed directly without extra messaging, streamlining the update process and reducing log verbosity.


## 🔗 Related PR / Issue  
Link: #9354


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
