### PR TITLE
[LibreNMS] Correcting mariadb sed string for Debian 13 default in install/librenms-install.sh, website config for Debian 13 #9369

### DIFF
--- a/frontend/public/json/librenms.json
+++ b/frontend/public/json/librenms.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 4,
         "os": "Debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/librenms-install.sh
+++ b/install/librenms-install.sh
@@ -65,7 +65,7 @@ chmod -R ug=rwX /opt/librenms/bootstrap/cache /opt/librenms/storage /opt/librenm
 msg_ok "Configured LibreNMS"
 
 msg_info "Configure MariaDB"
-sed -i "/\[mysqld\]/a innodb_file_per_table=1\nlower_case_table_names=0" /etc/mysql/mariadb.conf.d/50-server.cnf
+sed -i "/\[mariadb\]/a innodb_file_per_table=1\nlower_case_table_names=0" /etc/mysql/mariadb.conf.d/50-server.cnf
 systemctl enable -q --now mariadb
 msg_ok "Configured MariaDB"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Correcting sed string in `install/librenms-install.sh` to search for the `[mariadb]` header used in Debian 13 instead of `[mysqld]` previously used in Debian 12. 

Updated `frontend/public/json/librenms.json` to reflect Debian 13 default already used in `ct/librenms.sh`

## 🔗 Related PR / Issue  
Link: # https://github.com/community-scripts/ProxmoxVE/issues/9369


## ✅ Prerequisites  (**X** in brackets) 

- [ X ] **Self-review completed** – Code follows project standards.  
- [ X ] **Tested thoroughly** – Changes work as expected.  
- [ X ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ X ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ X ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
