### PR TITLE
Joplin-Server: Bump Node.js version from 22 to 24

### DIFF
--- a/ct/joplin-server.sh
+++ b/ct/joplin-server.sh
@@ -28,6 +28,8 @@ function update_script() {
     exit
   fi
 
+  NODE_VERSION=24 NODE_MODULE="yarn,npm,pm2" setup_nodejs
+
   if check_for_gh_release "joplin-server" "laurent22/joplin"; then
     msg_info "Stopping Services"
     systemctl stop joplin-server

--- a/install/joplin-server-install.sh
+++ b/install/joplin-server-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 PG_VERSION="17" setup_postgresql
-NODE_VERSION=22 NODE_MODULE="yarn,npm,pm2" setup_nodejs
+NODE_VERSION=24 NODE_MODULE="yarn,npm,pm2" setup_nodejs
 mkdir -p /opt/pm2
 export PM2_HOME=/opt/pm2
 $STD pm2 install pm2-logrotate


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Bumped Node.js to 24


## 🔗 Related PR / Issue  
Link: #9401 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
