### PR TITLE
core: remove uv cache clean command

### DIFF
--- a/misc/core.func
+++ b/misc/core.func
@@ -392,8 +392,6 @@ cleanup_lxc() {
 
   # Python pip
   if command -v pip &>/dev/null; then $STD pip cache purge || true; fi
-  # Python uv
-  if command -v uv &>/dev/null; then $STD uv cache clean || true; fi
   # Node.js npm
   if command -v npm &>/dev/null; then $STD npm cache clean --force || true; fi
   # Node.js yarn


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Removed the cache clean command for uv.
UV uses aggresive cache methods, so it can be only cleared with --force, thats in my opinion to unsafe for productive usage:

Example: 
root@paperless-ngx:~# uv cache prune
Cache is currently in-use, waiting for other uv processes to finish (use `--force` to override)

Example with force:
root@paperless-ngx:~# uv cache clean --force
Clearing cache at: .cache/uv
Removed 118567 files (1.4GiB)


## 🔗 Related PR / Issue  
Link: #9411


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
