### PR TITLE
Domain Locker: Fix required RAM

### DIFF
--- a/ct/domain-locker.sh
+++ b/ct/domain-locker.sh
@@ -8,7 +8,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="Domain-Locker"
 var_tags="${var_tags:-Monitoring}"
 var_cpu="${var_cpu:-4}"
-var_ram="${var_ram:-10240}"
+var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"

--- a/install/domain-locker-install.sh
+++ b/install/domain-locker-install.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021-2025 community-scripts ORG
 # Author: CrazyWolf13
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
-# Source: https://github.com/CrazyWolf13/domain-locker
+# Source: https://github.com/Lissy93/domain-locker
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
 color


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

When installing [Domain Locker](https://domain-locker.com/), I noticed it created a machine with 10 GB of RAM (10240 MB), which is probably a typo meant to be: `1024`, which should be plenty enough. cc @Lissy93.

_Edit:_ It turns out this is not a typo! We can't get pass the installation script with 1 GB. I'm trying to figure out a reasonable amount of memory, because 10 GB seems excessive for a small web app.

## 🔗 Related PR / Issue  

N/A

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
