### PR TITLE
add Zabbix version selection to install and update scripts

### DIFF
--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -46,7 +46,20 @@ function update_script() {
   systemctl stop "$AGENT_SERVICE"
   msg_ok "Stopped Services"
 
-  msg_info "Updating Zabbix"
+  read -rp "Choose Zabbix version [1] 7.0 LTS  [2] 7.4 (Latest Stable)  [3] Latest available (default: 2): " ZABBIX_CHOICE
+  ZABBIX_CHOICE=${ZABBIX_CHOICE:-2}
+  case "$ZABBIX_CHOICE" in
+  1) ZABBIX_VERSION="7.0" ;;
+  2) ZABBIX_VERSION="7.4" ;;
+  3) ZABBIX_VERSION=$(curl -fsSL https://repo.zabbix.com/zabbix/ |
+    grep -oP '(?<=href=")[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1) ;;
+  *)
+    ZABBIX_VERSION="7.4"
+    echo "Invalid choice. Defaulting to 7.4."
+    ;;
+  esac
+
+  msg_info "Updating Zabbix to $ZABBIX_VERSION"
   mkdir -p /opt/zabbix-backup/
   cp /etc/zabbix/zabbix_server.conf /opt/zabbix-backup/
   cp /etc/apache2/conf-enabled/zabbix.conf /opt/zabbix-backup/
@@ -54,10 +67,8 @@ function update_script() {
 
   rm -Rf /etc/apt/sources.list.d/zabbix.list
   cd /tmp
-  curl -fsSL "$(curl -fsSL https://repo.zabbix.com/zabbix/ |
-    grep -oP '(?<=href=")[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1 |
-    xargs -I{} echo "https://repo.zabbix.com/zabbix/{}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb")" \
-    -o /tmp/zabbix-release_latest+debian13_all.deb
+  ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb"
+  curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/zabbix-release_latest+debian13_all.deb
   $STD dpkg -i zabbix-release_latest+debian13_all.deb
   rm -rf /tmp/zabbix-release_latest+debian13_all.deb
   $STD apt update


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Prompts user to select Zabbix version (7.0 LTS, 7.4, or latest) during installation and update. Refactors download logic to use the chosen version


## 🔗 Related PR / Issue  
Link: #9319


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
