### PR TITLE
documenso: switch to npm peer-.deps to get build running

### DIFF
--- a/ct/documenso.sh
+++ b/ct/documenso.sh
@@ -46,7 +46,13 @@ function update_script() {
     export NEXT_TELEMETRY_DISABLED=1
     export CYPRESS_INSTALL_BINARY=0
     export NODE_OPTIONS="--max-old-space-size=4096"
-    $STD npm ci
+    $STD turbo prune --scope=@documenso/remix --docker
+    cd out
+    $STD cp ../lingui.config.ts .
+    $STD cp ../turbo.json .
+    $STD cp -r json/* .
+    $STD npm install --legacy-peer-deps
+    $STD cp -r full/* .
     $STD turbo run build --filter=@documenso/remix
     $STD npm run prisma:migrate-deploy
     $STD turbo daemon stop

--- a/install/documenso-install.sh
+++ b/install/documenso-install.sh
@@ -76,7 +76,7 @@ cd out
 $STD cp ../lingui.config.ts .
 $STD cp ../turbo.json .
 $STD cp -r json/* .
-$STD npm ci
+$STD npm install --legacy-peer-deps
 $STD cp -r full/* .
 $STD turbo run build --filter=@documenso/remix
 $STD npm run prisma:migrate-deploy


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Replaces npm ci with npm install --legacy-peer-deps in install and update scripts due massive peer dependency issues. 

<img width="905" height="439" alt="image" src="https://github.com/user-attachments/assets/9be99d52-34fd-4eb0-8707-11f1e93123b1" />


## 🔗 Related PR / Issue  
Link: #9433 #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
