### PR TITLE
Joplin Server: Increase RAM for LXC

### DIFF
--- a/ct/joplin-server.sh
+++ b/ct/joplin-server.sh
@@ -8,7 +8,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="Joplin-Server"
 var_tags="${var_tags:-notes}"
 var_cpu="${var_cpu:-2}"
-var_ram="${var_ram:-4096}"
+var_ram="${var_ram:-6144}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"

--- a/frontend/public/json/joplin-server.json
+++ b/frontend/public/json/joplin-server.json
@@ -20,7 +20,7 @@
       "script": "ct/joplin-server.sh",
       "resources": {
         "cpu": 2,
-        "ram": 4096,
+        "ram": 6144,
         "hdd": 20,
         "os": "Debian",
         "version": "13"
@@ -34,6 +34,10 @@
   "notes": [
     {
       "text": "Application can take some time to build, depending on your host speed. Please be patient.",
+      "type": "info"
+    },
+    {
+      "text": "Default RAM size for LXC is set to 6GB because of Node.js building process. You can lower it after application installs",
       "type": "info"
     }
   ]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
- Increased default RAM size to 6GB because Node.js fails to build if set to lower.
- Added information to website about RAM usage.


## 🔗 Related PR / Issue  
Link: #9455 


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
