### PR TITLE
Apache-guacamole: fixed to early rm

### DIFF
--- a/install/apache-guacamole-install.sh
+++ b/install/apache-guacamole-install.sh
@@ -72,7 +72,6 @@ curl -fsSL "https://downloads.apache.org/guacamole/${RELEASE_SERVER}/binary/guac
 $STD tar -xf ~/guacamole-auth-jdbc-$RELEASE_SERVER.tar.gz
 mv ~/guacamole-auth-jdbc-$RELEASE_SERVER/mysql/guacamole-auth-jdbc-mysql-$RELEASE_SERVER.jar /etc/guacamole/extensions/
 rm -rf ~/mysql-connector-j-9.3.0{,.tar.gz}
-rm -rf ~/guacamole-auth-jdbc-$RELEASE_SERVER{,.tar.gz}
 msg_ok "Setup Apache Guacamole"
 
 msg_info "Setup Database"
@@ -98,6 +97,7 @@ cat *.sql | mariadb -u root ${DB_NAME}
   echo "mysql-password: $DB_PASS"
 
 } >>/etc/guacamole/guacamole.properties
+rm -rf ~/guacamole-auth-jdbc-$RELEASE_SERVER{,.tar.gz}
 msg_ok "Setup Database"
 
 msg_info "Setup Service"


### PR DESCRIPTION
Issue 9458

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Guacamole installation script error --> premature dir deletion


## 🔗 Related PR / Issue  
Link: #9458


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
