### PR TITLE
fix(recyclarr): remove update script systemctl commands

### DIFF
--- a/ct/recyclarr.sh
+++ b/ct/recyclarr.sh
@@ -29,15 +29,10 @@ function update_script() {
   fi
   if check_for_gh_release "recyclarr" "recyclarr/recyclarr"; then
 
-    msg_info "Stopping Service"
-    systemctl stop recyclarr
-    msg_ok "Stopped Service"
+    msg_info "Updating ${APP}"
 
     fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-x64.tar.xz"
 
-    msg_info "Starting Service"
-    systemctl start recyclarr
-    msg_ok "Started Service"
     msg_ok "Updated successfully!"
   fi
   exit


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Bug was introduced via 9305a4c -- recyclarr.service does not exist, and as a result causes the update script to fail.


## 🔗 Related PR / Issue  
Link: n/a


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
