### PR TITLE
NetVisor: patch systemd file to fix new OIDC config

### DIFF
--- a/ct/netvisor.sh
+++ b/ct/netvisor.sh
@@ -79,6 +79,9 @@ function update_script() {
       -e 's| --server-port |:|' \
       /etc/systemd/system/netvisor-daemon.service
     sed -i '/^  \"server_target.*$/d' /root/.config/daemon/config.json
+    if ! grep -q "WorkingD" /etc/systemd/system/netvisor-server.service; then
+      sed -i '\|simple$|a\WorkingDirectory=/opt/netvisor/backend' /etc/systemd/system/netvisor-server.service
+    fi
     systemctl daemon-reload
 
     msg_info "Starting services"

--- a/frontend/public/json/netvisor.json
+++ b/frontend/public/json/netvisor.json
@@ -10,7 +10,7 @@
   "privileged": false,
   "interface_port": 60072,
   "documentation": "https://github.com/mayanayza/netvisor",
-  "config_path": "/opt/netvisor/.env",
+  "config_path": "/opt/netvisor/.env, OIDC: /opt/netvisor/oidc.toml",
   "website": "https://github.com/mayanayza/netvisor",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons/png/netvisor.png",
   "description": "Automatically discover and visually document network infrastructure",

--- a/install/netvisor-install.sh
+++ b/install/netvisor-install.sh
@@ -62,15 +62,9 @@ NETVISOR_INTEGRATED_DAEMON_URL=http://127.0.0.1:60073
 # NETVISOR_DISABLE_REGISTRATION=true
 ## - uncomment when using TLS
 # NETVISOR_USE_SECURE_SESSION_COOKIES=true
-
-### - OIDC (optional)
-# NETVISOR_OIDC_ISSUER_URL=
-# NETVISOR_OIDC_CLIENT_ID=
-# NETVISOR_OIDC_CLIENT_SECRET=
-# NETVISOR_OIDC_PROVIDER_NAME=
-# NETVISOR_OIDC_REDIRECT_URL=
-## - Callback URL for reference
-# http://your-netvisor-domain:60072/api/auth/oidc/callback
+## - see https://github.com/imbolc/axum-client-ip?tab=readme-ov-file#configurable-vs-specific-extractors
+## - before uncommenting the below
+# NETVISOR_CLIENT_IP_SOURCE=
 
 ### - SMTP (password reset and notifications - optional)
 # NETVISOR_SMTP_RELAY=smtp.gmail.com:587
@@ -83,6 +77,8 @@ NETVISOR_SERVER_URL=http://127.0.0.1:60072
 NETVISOR_BIND_ADDRESS=0.0.0.0
 NETVISOR_NAME="netvisor-daemon"
 NETVISOR_HEARTBEAT_INTERVAL=30
+
+### - see https://github.com/mayanayza/netvisor/blob/main/docs/CONFIGURATION.md for more options
 EOF
 
 cat <<EOF >/etc/systemd/system/netvisor-server.service
@@ -92,6 +88,7 @@ After=network.target postgresql.service
 
 [Service]
 Type=simple
+WorkingDirectory=/opt/netvisor/backend
 EnvironmentFile=/opt/netvisor/.env
 ExecStart=/usr/bin/netvisor-server
 Restart=always


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

- v0.11x changed the way OIDC is configured. It now uses an `oidc.toml` file in `/opt/netvisor` and the server checks for it at `../oidc.toml` which is hard-coded. Adding the `WorkingDirectory` key to the systemd service file allows the server to find the file.
- Users who have configured OIDC clients via the env file need to manually redo their config.
- Also added a new `NETVISOR_CLIENT_IP_SOURCE` env var (optional) if users want to ensure that the correct IP address is logged for auth when behind a reverse proxy.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
