### PR TITLE
Add auth via requirepass to Valkey

### DIFF
--- a/frontend/public/json/valkey.json
+++ b/frontend/public/json/valkey.json
@@ -35,6 +35,6 @@
     {
       "text": "Show Login Credentials, type `cat /root/.valkey_pass.txt` in the LXC console",
       "type": "info"
-    },
+    }
   ]
 }

--- a/frontend/public/json/valkey.json
+++ b/frontend/public/json/valkey.json
@@ -31,5 +31,10 @@
     "username": null,
     "password": null
   },
-  "notes": ["On first launch, a random password is set for the default user using `requirepass`; the generated password is stored in `/root/.valkey_pass.txt inside the container`." ]
+  "notes": [
+    {
+      "text": "Show Login Credentials, type `cat /root/.valkey_pass.txt` in the LXC console",
+      "type": "info"
+    },
+  ]
 }

--- a/frontend/public/json/valkey.json
+++ b/frontend/public/json/valkey.json
@@ -31,5 +31,5 @@
     "username": null,
     "password": null
   },
-  "notes": []
+  "notes": ["On first launch, a random password is set for the default user using `requirepass`; the generated password is stored in `/root/.valkey_pass.txt inside the container`." ]
 }

--- a/frontend/public/json/valkey.json
+++ b/frontend/public/json/valkey.json
@@ -33,7 +33,7 @@
   },
   "notes": [
     {
-      "text": "Show Login Credentials, type `cat /root/.valkey_pass.txt` in the LXC console",
+      "text": "Show Login Credentials, type `cat ~/valkey.creds` in the LXC console",
       "type": "info"
     }
   ]

--- a/install/valkey-install.sh
+++ b/install/valkey-install.sh
@@ -24,7 +24,6 @@ chmod 600 /root/valkey_pass.txt
 systemctl enable -q --now valkey-server
 systemctl restart valkey-server
 msg_ok "Installed Valkey"
-msg_ok "Valkey password saved to /root/valkey_pass.txt"
 
 motd_ssh
 customize

--- a/install/valkey-install.sh
+++ b/install/valkey-install.sh
@@ -19,8 +19,8 @@ $STD apt install -y valkey openssl
 sed -i 's/^bind .*/bind 0.0.0.0/' /etc/valkey/valkey.conf
 PASS="$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c32)"
 echo "requirepass $PASS" >> /etc/valkey/valkey.conf
-echo "$PASS" >/root/valkey_pass.txt
-chmod 600 /root/valkey_pass.txt
+echo "$PASS" >~/valkey.creds
+chmod 600 ~/valkey.creds
 systemctl enable -q --now valkey-server
 systemctl restart valkey-server
 msg_ok "Installed Valkey"

--- a/install/valkey-install.sh
+++ b/install/valkey-install.sh
@@ -15,11 +15,16 @@ update_os
 
 msg_info "Installing Valkey"
 $STD apt update
-$STD apt install -y valkey
+$STD apt install -y valkey openssl
 sed -i 's/^bind .*/bind 0.0.0.0/' /etc/valkey/valkey.conf
+PASS="$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c32)"
+echo "requirepass $PASS" >> /etc/valkey/valkey.conf
+echo "$PASS" >/root/valkey_pass.txt
+chmod 600 /root/valkey_pass.txt
 systemctl enable -q --now valkey-server
 systemctl restart valkey-server
 msg_ok "Installed Valkey"
+msg_ok "Valkey password saved to /root/valkey_pass.txt"
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
On firstboot, the container auto-configures a random password via `requirepass`; the password is stored in `/root/.valkey_pass.txt` inside the container.


## 🔗 Related PR / Issue  
Link: # [Discussion #3446](https://github.com/community-scripts/ProxmoxVE/discussions/3446)


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [X] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [X] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
