### PR TITLE
Matterbridge: Fix ExecStart command in service install script to allow childbridge mode

### DIFF
--- a/install/matterbridge-install.sh
+++ b/install/matterbridge-install.sh
@@ -26,7 +26,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=matterbridge -bridge -service
+ExecStart=matterbridge -service
 WorkingDirectory=/root/Matterbridge
 StandardOutput=inherit
 StandardError=inherit


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Using `matterbridge --bridge` forces Matterbridge to load in bridge mode, even if one tries to configure it as **Childbridge** in the UI. Omitting that flag solves it.

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [X] **Self-review completed** – Code follows project standards.  
- [X] **Tested thoroughly** – Changes work as expected.  
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
