### PR TITLE
fix(opnsense-vm): improve script  and add single-interface mode

### DIFF
--- a/vm/opnsense-vm.sh
+++ b/vm/opnsense-vm.sh
@@ -9,12 +9,12 @@ source /dev/stdin <<<$(curl -fsSL https://raw.githubusercontent.com/community-sc
 function header_info {
   clear
   cat <<"EOF"
-   ____  ____  _   __                        
-  / __ \/ __ \/ | / /_______  ____  ________ 
+   ____  ____  _   __
+  / __ \/ __ \/ | / /_______  ____  ________
  / / / / /_/ /  |/ / ___/ _ \/ __ \/ ___/ _ \
 / /_/ / ____/ /|  (__  )  __/ / / (__  )  __/
-\____/_/   /_/ |_/____/\___/_/ /_/____/\___/ 
-                                                                         
+\____/_/   /_/ |_/____/\___/_/ /_/____/\___/
+
 EOF
 }
 header_info
@@ -137,7 +137,7 @@ function send_line_to_vm() {
     "U") character="shift-u" ;;
     "V") character="shift-v" ;;
     "W") character="shift-w" ;;
-    "X") character="shift=x" ;;
+    "X") character="shift-x" ;;
     "Y") character="shift-y" ;;
     "Z") character="shift-z" ;;
     "!") character="shift-1" ;;
@@ -155,9 +155,6 @@ function send_line_to_vm() {
   done
   qm sendkey $VMID ret
 }
-
-TEMP_DIR=$(mktemp -d)
-pushd $TEMP_DIR >/dev/null
 
 if (whiptail --backtitle "Proxmox VE Helper Scripts" --title "OPNsense VM" --yesno "This will create a New OPNsense VM. Proceed?" 10 58); then
   :
@@ -278,12 +275,27 @@ function default_settings() {
   fi
   echo -e "${DGN}Using LAN VLAN: ${BGN}Default${CL}"
   echo -e "${DGN}Using LAN MAC Address: ${BGN}${MAC}${CL}"
-  echo -e "${DGN}Using WAN MAC Address: ${BGN}${WAN_MAC}${CL}"
-  if ! grep -q "^iface ${WAN_BRG}" /etc/network/interfaces; then
-    msg_error "Bridge '${WAN_BRG}' does not exist in /etc/network/interfaces"
-    exit
+
+  if NETWORK_MODE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "NETWORK CONFIGURATION" --radiolist --cancel-button Exit-Script \
+    "Choose network setup mode for OPNsense:\n" 14 70 2 \
+    "dual" "Dual Interface (Traditional Firewall/Router)" ON \
+    "single" "Single Interface (Proxy/VPN/IDS Server)" OFF \
+    3>&1 1>&2 2>&3); then
+    if [ "$NETWORK_MODE" = "dual" ]; then
+      echo -e "${DGN}Network Mode: ${BGN}Dual Interface (Firewall)${CL}"
+      echo -e "${DGN}Using WAN MAC Address: ${BGN}${WAN_MAC}${CL}"
+      if ! grep -q "^iface ${WAN_BRG}" /etc/network/interfaces; then
+        msg_error "Bridge '${WAN_BRG}' does not exist in /etc/network/interfaces"
+        exit
+      else
+        echo -e "${DGN}Using WAN Bridge: ${BGN}${WAN_BRG}${CL}"
+      fi
+    else
+      echo -e "${DGN}Network Mode: ${BGN}Single Interface (Proxy/VPN/IDS)${CL}"
+      WAN_BRG=""
+    fi
   else
-    echo -e "${DGN}Using WAN Bridge: ${BGN}${WAN_BRG}${CL}"
+    exit-script
   fi
   echo -e "${DGN}Using Interface MTU Size: ${BGN}Default${CL}"
   echo -e "${DGN}Start VM when completed: ${BGN}yes${CL}"
@@ -359,7 +371,7 @@ function advanced_settings() {
   fi
 
   if VM_NAME=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set Hostname" 8 58 OPNsense --title "HOSTNAME" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
-    if [ -z $VM_NAME ]; then
+    if [ -z "$VM_NAME" ]; then
       HN="OPNsense"
     else
       HN=$(echo ${VM_NAME,,} | tr -d ' ')
@@ -370,7 +382,7 @@ function advanced_settings() {
   fi
 
   if CORE_COUNT=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Allocate CPU Cores" 8 58 4 --title "CORE COUNT" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
-    if [ -z $CORE_COUNT ]; then
+    if [ -z "$CORE_COUNT" ]; then
       CORE_COUNT="2"
     fi
     echo -e "${DGN}Allocated Cores: ${BGN}$CORE_COUNT${CL}"
@@ -566,12 +578,11 @@ fi
 msg_ok "Using ${CL}${BL}$STORAGE${CL} ${GN}for Storage Location."
 msg_ok "Virtual Machine ID is ${CL}${BL}$VMID${CL}."
 msg_info "Retrieving the URL for the OPNsense Qcow2 Disk Image"
-URL=https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/amd64/Latest/FreeBSD-14.2-RELEASE-amd64.qcow2.xz
-sleep 2
-msg_ok "${CL}${BL}${URL}${CL}"
+URL="https://download.freebsd.org/releases/VM-IMAGES/14.2-RELEASE/amd64/Latest/FreeBSD-14.2-RELEASE-amd64.qcow2.xz"
+msg_ok "Download URL: ${CL}${BL}${URL}${CL}"
 curl -f#SL -o "$(basename "$URL")" "$URL"
 echo -en "\e[1A\e[0K"
-FILE=Fressbsd.qcow2
+FILE=FreeBSD.qcow2
 unxz -cv $(basename $URL) >${FILE}
 msg_ok "Downloaded ${CL}${BL}${FILE}${CL}"
 
@@ -623,7 +634,7 @@ DESCRIPTION=$(
       <img src='https://img.shields.io/badge/&#x2615;-Buy us a coffee-blue' alt='spend Coffee' />
     </a>
   </p>
-  
+
   <span style='margin: 0 10px;'>
     <i class="fa fa-github fa-fw" style="color: #f5f5f5;"></i>
     <a href='https://github.com/community-scripts/ProxmoxVE' target='_blank' rel='noopener noreferrer' style='text-decoration: none; color: #00617f;'>GitHub</a>
@@ -652,9 +663,13 @@ qm start $VMID
 sleep 90
 send_line_to_vm "root"
 send_line_to_vm "fetch https://raw.githubusercontent.com/opnsense/update/master/src/bootstrap/opnsense-bootstrap.sh.in"
-qm set $VMID \
-  -net1 virtio,bridge=${WAN_BRG},macaddr=${WAN_MAC} &>/dev/null
-sleep 10
+if [ -n "$WAN_BRG" ]; then
+  msg_info "Adding WAN interface"
+  qm set $VMID \
+    -net1 virtio,bridge=${WAN_BRG},macaddr=${WAN_MAC} &>/dev/null
+  msg_ok "WAN interface added"
+  sleep 5  # Brief pause after adding network interface
+fi
 send_line_to_vm "sh ./opnsense-bootstrap.sh.in -y -f -r 25.1"
 msg_ok "OPNsense VM is being installed, do not close the terminal, or the installation will fail."
 #We need to wait for the OPNsense build proccess to finish, this takes a few minutes
@@ -689,9 +704,9 @@ else
   send_line_to_vm "n"
   send_line_to_vm "n"
 fi
-#we need to wait for the Config changes to be saved
+#Wait for config changes to be saved
 sleep 20
-if [ "$WAN_IP_ADDR" != "" ]; then
+if [ -n "$WAN_BRG" ] && [ "$WAN_IP_ADDR" != "" ]; then
   send_line_to_vm "2"
   send_line_to_vm "2"
   send_line_to_vm "n"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  

Okay, I'm going to divide this PR into two parts. In short, this current version doesn't fix the bug https://github.com/community-scripts/ProxmoxVE/issues/6183. In fact, I managed to reproduce two of them intentionally. And I think I can solve it later by bringing a more robust solution than just sleeping after this PR https://github.com/community-scripts/ProxmoxVE/pull/9540 was accepted, because I see this improvement feature being better used as a core for reuse in future VMs scripts.

The first part will be this one where I make adjustments to some steps that I would like to have in this installation.

The second part will be about improving download speed and installation without long or insufficient sleep periods.

---

This PR adds the option to deploy OPNsense VM with a single network interface, supporting use cases where OPNsense is not intended to be the primary router/firewall.

#### Background

Not everyone wants to use OPNsense as a full router replacement (like me). Many users run hybrid network topologies where an existing router (like MikroTik, pfSense hardware, or ISP equipment) handles routing/NAT, and OPNsense is deployed as a specialized service for:

- **Proxy server** (Squid for caching/filtering)
- **VPN gateway** (OpenVPN/WireGuard endpoint)
- **IDS/IPS** (Suricata/Zenarmor)
- **DNS filtering** (in addition to AdGuard/Pi-hole)

#### Example Topology (Single Interface Mode)

```
Internet
    │
    ▼
┌─────────┐
│   ONU   │ (Bridge Mode)
└────┬────┘
     │
     ▼
┌──────────────┐
│   MikroTik   │ ◄── Primary Router (DHCP, NAT, Firewall)
│  192.168.1.1 │
└──────┬───────┘
       │
       │ [Single Cable]
       ▼
┌──────────────────────────────────────┐
│            Proxmox Host              │
│           192.168.1.10               │
│  ┌────────────────────────────────┐  │
│  │     Bridge: vmbr0 (eth0)       │  │
│  └───────┬───────────────┬────────┘  │
│          │               │           │
│          ▼               ▼           │
│   ┌────────────┐  ┌────────────┐     │
│   │  OPNsense  │  │  AdGuard   │     │
│   │ (Proxy/VPN)│  │   (DNS)    │     │
│   │192.168.1.20│  │192.168.1.53│     │
│   └────────────┘  └────────────┘     │
└──────────────────────────────────────┘
```

In this setup:
- MikroTik remains the **primary gateway** handling all routing
- OPNsense provides **specialized services** (Squid proxy, VPN, IDS)
- Only **one physical NIC** is needed on the Proxmox host
- All VMs share the same bridge (`vmbr0`) - no WAN bridge required

#### Changes

1. **Added network mode selection in default settings**
   - `dual`: Traditional firewall/router mode (LAN + WAN interfaces)
   - `single`: Proxy/VPN/IDS server mode (LAN interface only)

2. **Conditional WAN interface configuration**
   - WAN bridge (`vmbr1`) is only validated and configured when dual mode is selected
   - Skips WAN-related prompts and configuration in single mode

3. **Improved WAN configuration logic**
   - WAN interface is now added only if `WAN_BRG` is set
   - WAN IP configuration only runs when both `WAN_BRG` and `WAN_IP_ADDR` are defined

#### Use Cases

| Mode | Use Case | Network Interfaces |
|------|----------|-------------------|
| **Dual** | Full router/firewall replacing existing equipment | LAN (vmbr0) + WAN (vmbr1) |
| **Single** | Proxy, VPN endpoint, or IDS behind existing router | LAN only (vmbr0) |

#### Testing

- [x] Tested single interface mode deployment
- [ ] Tested dual interface mode (existing functionality)
- [x] Verified OPNsense boots and configures correctly in both modes (partial - single mode)

NOTE: I tested the script twice, and in both instances, the installation went perfectly (single mode). I was only unable to test the LAN and WAN version because I won't be able to generate a sandbox environment, as I'm short on time this end of the year. I would need one more willing person to test the full version.

#### Additional Notes

- Fix typo in send_line_to_vm: 'shift=x' -> 'shift-x' for uppercase X
- Fix typo in FILE variable: 'Fressbsd.qcow2' -> 'FreeBSD.qcow2'
- Add proper quoting for VM_NAME and CORE_COUNT variable checks
- Improve download URL message formatting
- Remove sleep 2 delay before URL display
- Clean up whitespace and formatting inconsistencies
- Remove orphaned TEMP_DIR initialization

## 🔗 Related PR / Issue  
Link: #


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
