### PR TITLE
core: extend storage type support (rbd, nfs, cifs) and validation (iscidirect, isci, zfs, cephfs, pbs)

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3211,42 +3211,29 @@ create_lxc_container() {
     fi
   fi
 
-  # Validate content types
-  msg_info "Validating content types of storage '$CONTAINER_STORAGE'"
-  STORAGE_CONTENT=$(grep -A4 -E "^(zfspool|dir|lvmthin|lvm|linstor): $CONTAINER_STORAGE" /etc/pve/storage.cfg | grep content | awk '{$1=""; print $0}' | xargs)
-  msg_debug "Storage '$CONTAINER_STORAGE' has content types: $STORAGE_CONTENT"
+  msg_info "Validating storage '$CONTAINER_STORAGE'"
+  STORAGE_TYPE=$(grep -E "^[^:]+: $CONTAINER_STORAGE$" /etc/pve/storage.cfg | cut -d: -f1 | head -1)
 
-  # Check storage type for special handling
-  STORAGE_TYPE=$(grep -E "^[^:]+: $CONTAINER_STORAGE$" /etc/pve/storage.cfg | cut -d: -f1)
-  if [[ "$STORAGE_TYPE" == "linstor" ]]; then
-    msg_info "Detected LINSTOR storage - verifying cluster connectivity"
-    if ! pvesm status -storage "$CONTAINER_STORAGE" &>/dev/null; then
-      msg_error "LINSTOR storage '$CONTAINER_STORAGE' not accessible. Check LINSTOR cluster health."
-      exit 217
-    fi
-  fi
+  case "$STORAGE_TYPE" in
+  iscsidirect) exit 212 ;;
+  iscsi | zfs) exit 213 ;;
+  cephfs) exit 219 ;;
+  pbs) exit 224 ;;
+  linstor | rbd | nfs | cifs)
+    pvesm status -storage "$CONTAINER_STORAGE" &>/dev/null || exit 217
+    ;;
+  esac
 
-  grep -qw "rootdir" <<<"$STORAGE_CONTENT" || {
-    msg_error "Storage '$CONTAINER_STORAGE' does not support 'rootdir'. Cannot create LXC."
-    exit 217
-  }
-  $STD msg_ok "Storage '$CONTAINER_STORAGE' supports 'rootdir'"
+  pvesm status -content rootdir 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "$CONTAINER_STORAGE" || exit 213
+  msg_ok "Storage '$CONTAINER_STORAGE' ($STORAGE_TYPE) validated"
 
-  msg_info "Validating content types of template storage '$TEMPLATE_STORAGE'"
-  TEMPLATE_CONTENT=$(grep -A4 -E "^[^:]+: $TEMPLATE_STORAGE" /etc/pve/storage.cfg | grep content | awk '{$1=""; print $0}' | xargs)
-  msg_debug "Template storage '$TEMPLATE_STORAGE' has content types: $TEMPLATE_CONTENT"
-
-  # Check if template storage is LINSTOR (may need special handling)
+  msg_info "Validating template storage '$TEMPLATE_STORAGE'"
   TEMPLATE_TYPE=$(grep -E "^[^:]+: $TEMPLATE_STORAGE$" /etc/pve/storage.cfg | cut -d: -f1)
-  if [[ "$TEMPLATE_TYPE" == "linstor" ]]; then
-    msg_info "Template storage uses LINSTOR - ensuring resource availability"
-  fi
 
-  if ! grep -qw "vztmpl" <<<"$TEMPLATE_CONTENT"; then
-    msg_warn "Template storage '$TEMPLATE_STORAGE' does not declare 'vztmpl'. This may cause pct create to fail."
-  else
-    $STD msg_ok "Template storage '$TEMPLATE_STORAGE' supports 'vztmpl'"
+  if ! pvesm status -content vztmpl 2>/dev/null | awk 'NR>1{print $1}' | grep -qx "$TEMPLATE_STORAGE"; then
+    msg_warn "Template storage '$TEMPLATE_STORAGE' may not support 'vztmpl'"
   fi
+  msg_ok "Template storage '$TEMPLATE_STORAGE' validated"
 
   # Free space check
   STORAGE_FREE=$(pvesm status | awk -v s="$CONTAINER_STORAGE" '$1 == s { print $6 }')
@@ -3261,7 +3248,7 @@ create_lxc_container() {
     msg_info "Checking cluster quorum"
     if ! pvecm status | awk -F':' '/^Quorate/ { exit ($2 ~ /Yes/) ? 0 : 1 }'; then
       msg_error "Cluster is not quorate. Start all nodes or configure quorum device (QDevice)."
-      exit 201
+      exit 210
     fi
     msg_ok "Cluster is quorate"
   fi
@@ -3297,6 +3284,14 @@ create_lxc_container() {
 
   ONLINE_TEMPLATE=""
   [[ ${#ONLINE_TEMPLATES[@]} -gt 0 ]] && ONLINE_TEMPLATE="${ONLINE_TEMPLATES[-1]}"
+
+  if [[ ${#ONLINE_TEMPLATES[@]} -gt 0 ]]; then
+    count=0
+    for idx in "${!ONLINE_TEMPLATES[@]}"; do
+      ((count++))
+      [[ $count -ge 3 ]] && break
+    done
+  fi
 
   if [[ ${#LOCAL_TEMPLATES[@]} -gt 0 ]]; then
     TEMPLATE="${LOCAL_TEMPLATES[-1]}"
@@ -3525,7 +3520,7 @@ create_lxc_container() {
   if [[ "$PCT_OSTYPE" == "debian" ]]; then
     OSVER="$(parse_template_osver "$TEMPLATE")"
     if [[ -n "$OSVER" ]]; then
-      # Proactive, but without abort – only offer
+      # Proactive, aber ohne Abbruch – nur Angebot
       offer_lxc_stack_upgrade_and_maybe_retry "no" || true
     fi
   fi
@@ -3554,7 +3549,7 @@ create_lxc_container() {
   }
   flock -w 60 9 || {
     msg_error "Timeout while waiting for template lock."
-    exit 202
+    exit 211
   }
 
   LOGFILE="/tmp/pct_create_${CTID}_$(date +%Y%m%d_%H%M%S)_${SESSION_ID}.log"
@@ -3603,12 +3598,12 @@ create_lxc_container() {
             0) : ;; # success - container created, continue
             2)
               echo "Upgrade was declined. Please update and re-run:
-                apt update && apt install --only-upgrade pve-container lxc-pve"
-              exit 213
+  apt update && apt install --only-upgrade pve-container lxc-pve"
+              exit 231
               ;;
             3)
               echo "Upgrade and/or retry failed. Please inspect: $LOGFILE"
-              exit 213
+              exit 231
               ;;
             esac
           else
@@ -3635,12 +3630,12 @@ create_lxc_container() {
           0) : ;; # success - container created, continue
           2)
             echo "Upgrade was declined. Please update and re-run:
-              apt update && apt install --only-upgrade pve-container lxc-pve"
-            exit 213
+  apt update && apt install --only-upgrade pve-container lxc-pve"
+            exit 231
             ;;
           3)
             echo "Upgrade and/or retry failed. Please inspect: $LOGFILE"
-            exit 213
+            exit 231
             ;;
           esac
         else

--- a/misc/build.func
+++ b/misc/build.func
@@ -3520,7 +3520,6 @@ create_lxc_container() {
   if [[ "$PCT_OSTYPE" == "debian" ]]; then
     OSVER="$(parse_template_osver "$TEMPLATE")"
     if [[ -n "$OSVER" ]]; then
-      # Proactive, aber ohne Abbruch – nur Angebot
       offer_lxc_stack_upgrade_and_maybe_retry "no" || true
     fi
   fi

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -34,9 +34,9 @@
 #   * Node.js/npm errors (243-249, 254)
 #   * Python/pip/uv errors (210-212)
 #   * PostgreSQL errors (231-234)
-#   * MySQL/MariaDB errors (260-263)
-#   * MongoDB errors (251-253)
-#   * Proxmox custom codes (200-209, 213-223, 225)
+#   * MySQL/MariaDB errors (241-244)
+#   * MongoDB errors (251-254)
+#   * Proxmox custom codes (200-231)
 # - Returns description string for given exit code
 # ------------------------------------------------------------------------------
 explain_exit_code() {
@@ -79,38 +79,43 @@ explain_exit_code() {
   234) echo "PostgreSQL: Fatal error in query / syntax" ;;
 
   # --- MySQL / MariaDB ---
-  260) echo "MySQL/MariaDB: Connection failed (server not running / wrong socket)" ;;
-  261) echo "MySQL/MariaDB: Authentication failed (bad user/password)" ;;
-  262) echo "MySQL/MariaDB: Database does not exist" ;;
-  263) echo "MySQL/MariaDB: Fatal error in query / syntax" ;;
+  241) echo "MySQL/MariaDB: Connection failed (server not running / wrong socket)" ;;
+  242) echo "MySQL/MariaDB: Authentication failed (bad user/password)" ;;
+  243) echo "MySQL/MariaDB: Database does not exist" ;;
+  244) echo "MySQL/MariaDB: Fatal error in query / syntax" ;;
 
   # --- MongoDB ---
   251) echo "MongoDB: Connection failed (server not running)" ;;
   252) echo "MongoDB: Authentication failed (bad user/password)" ;;
   253) echo "MongoDB: Database not found" ;;
+  254) echo "MongoDB: Fatal query error" ;;
 
   # --- Proxmox Custom Codes ---
-  200) echo "Custom: Failed to create lock file" ;;
-  201) echo "Custom: Cluster not quorate" ;;
-  202) echo "Custom: Timeout waiting for template lock (concurrent download in progress)" ;;
-  203) echo "Custom: Missing CTID variable" ;;
-  204) echo "Custom: Missing PCT_OSTYPE variable" ;;
-  205) echo "Custom: Invalid CTID (<100)" ;;
-  206) echo "Custom: CTID already in use (check 'pct list' and /etc/pve/lxc/)" ;;
-  207) echo "Custom: Password contains unescaped special characters (-, /, \\, *, etc.)" ;;
-  208) echo "Custom: Invalid configuration (DNS/MAC/Network format error)" ;;
-  209) echo "Custom: Container creation failed (check logs for pct create output)" ;;
-  213) echo "Custom: LXC stack upgrade/retry failed (outdated pve-container - check https://github.com/community-scripts/ProxmoxVE/discussions/8126)" ;;
-  214) echo "Custom: Not enough storage space" ;;
-  215) echo "Custom: Container created but not listed (ghost state - check /etc/pve/lxc/)" ;;
-  216) echo "Custom: RootFS entry missing in config (incomplete creation)" ;;
-  217) echo "Custom: Storage does not support rootdir (check storage capabilities)" ;;
-  218) echo "Custom: Template file corrupted or incomplete download (size <1MB or invalid archive)" ;;
-  220) echo "Custom: Unable to resolve template path" ;;
-  221) echo "Custom: Template file exists but not readable (check file permissions)" ;;
-  222) echo "Custom: Template download failed after 3 attempts (network/storage issue)" ;;
-  223) echo "Custom: Template not available after download (storage sync issue)" ;;
-  225) echo "Custom: No template available for OS/Version (check 'pveam available')" ;;
+  200) echo "Proxmox: Failed to create lock file" ;;
+  203) echo "Proxmox: Missing CTID variable" ;;
+  204) echo "Proxmox: Missing PCT_OSTYPE variable" ;;
+  205) echo "Proxmox: Invalid CTID (<100)" ;;
+  206) echo "Proxmox: CTID already in use" ;;
+  207) echo "Proxmox: Password contains unescaped special characters" ;;
+  208) echo "Proxmox: Invalid configuration (DNS/MAC/Network format)" ;;
+  209) echo "Proxmox: Container creation failed" ;;
+  210) echo "Proxmox: Cluster not quorate" ;;
+  211) echo "Proxmox: Timeout waiting for template lock" ;;
+  212) echo "Proxmox: Storage type 'iscsidirect' does not support containers (VMs only)" ;;
+  213) echo "Proxmox: Storage type does not support 'rootdir' content" ;;
+  214) echo "Proxmox: Not enough storage space" ;;
+  215) echo "Proxmox: Container created but not listed (ghost state)" ;;
+  216) echo "Proxmox: RootFS entry missing in config" ;;
+  217) echo "Proxmox: Storage not accessible" ;;
+  219) echo "Proxmox: CephFS does not support containers - use RBD" ;;
+  224) echo "Proxmox: PBS storage is for backups only" ;;
+  218) echo "Proxmox: Template file corrupted or incomplete" ;;
+  220) echo "Proxmox: Unable to resolve template path" ;;
+  221) echo "Proxmox: Template file not readable" ;;
+  222) echo "Proxmox: Template download failed" ;;
+  223) echo "Proxmox: Template not available after download" ;;
+  225) echo "Proxmox: No template available for OS/Version" ;;
+  231) echo "Proxmox: LXC stack upgrade failed" ;;
 
   # --- Default ---
   *) echo "Unknown error" ;;


### PR DESCRIPTION
Extend storage type detection and add a little pre-flight validation.
=> Previously only supported: zfspool, dir, lvmthin, lvm, linstor

New supported storage types:
- rbd (Ceph RBD)
- nfs (Network File System)
- cifs (SMB/CIFS shares)

New blocked storage types (incompatible with containers):
- iscsidirect (212): VMs only
- iscsi/zfs (213): no rootdir support
- cephfs (219): use RBD instead
- pbs (224): backup storage only

Network storage now includes connectivity check (exit 217 on failure):
- linstor, rbd, nfs, cifs


Also reorganized Proxmox error codes (200-231) for consistency.


## 🔗 Related PR / Issue  
Link: #https://discord.com/channels/1302816934508630047/1446107913423950005


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
