### PR TITLE
update pdm repo to stable

### DIFF
--- a/ct/proxmox-datacenter-manager.sh
+++ b/ct/proxmox-datacenter-manager.sh
@@ -37,6 +37,20 @@ function update_script() {
     msg_ok "Updated old sources"
   fi
 
+  if grep -q 'Debian GNU/Linux 13' /etc/os-release; then
+    if [ -f "/etc/apt/sources.list.d/pdm-test.sources" ]; then
+      if ! grep -qx "Enabled: false" "/etc/apt/sources.list.d/pdm-test.sources"; then
+          echo "Enabled: false" >> "/etc/apt/sources.list.d/pdm-test.sources"
+          setup_deb822_repo \
+            "pdm" \
+            "https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg" \
+            "http://download.proxmox.com/debian/pdm" \
+            "trixie" \
+            "pdm-no-subscription"
+      fi
+    fi
+  fi
+
   msg_info "Updating $APP LXC"
   $STD apt update
   $STD apt -y upgrade

--- a/frontend/public/json/proxmox-datacenter-manager.json
+++ b/frontend/public/json/proxmox-datacenter-manager.json
@@ -35,10 +35,6 @@
     {
       "text": "Set a root password if using autologin. This will be the Proxmox-Datacenter-Manager password. `sudo passwd root`",
       "type": "info"
-    },
-    {
-      "text": "Proxmox Datacenter Manager is in an alpha stage of development. Use it cautiously, as bugs, incomplete features, and potential instabilities are expected.",
-      "type": "warning"
     }
   ]
 }

--- a/install/proxmox-datacenter-manager-install.sh
+++ b/install/proxmox-datacenter-manager-install.sh
@@ -15,12 +15,20 @@ update_os
 
 msg_info "Installing Proxmox Datacenter Manager"
 curl -fsSL https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg -o /usr/share/keyrings/proxmox-archive-keyring.gpg
+setup_deb822_repo \
+  "pdm" \
+  "https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg" \
+  "http://download.proxmox.com/debian/pdm" \
+  "trixie" \
+  "pdm-no-subscription"
+  
 cat <<EOF >/etc/apt/sources.list.d/pdm-test.sources
 Types: deb
 URIs: http://download.proxmox.com/debian/pdm
 Suites: trixie
 Components: pdm-test
 Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
+Enabled: false
 EOF
 $STD apt update
 DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
PDM has reached stable, we should switch our default to stable and add disabled pdm-test.


## 🔗 Related PR / Issue  
Link: https://forum.proxmox.com/threads/proxmox-datacenter-manager-1-0-stable.177321/


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
