### PR TITLE
Improve NVIDIA device detection for container passthrough

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2442,9 +2442,16 @@ build_container() {
       msg_custom "🎮" "${GN}" "Detected NVIDIA GPU"
 
       # Simple passthrough - just bind /dev/nvidia* devices if they exist
-      for d in /dev/nvidia* /dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm /dev/nvidia-uvm-tools; do
-        [[ -e "$d" ]] && NVIDIA_DEVICES+=("$d")
+      # Only include character devices (-c), skip directories like /dev/nvidia-caps
+      for d in /dev/nvidia*; do
+        [[ -c "$d" ]] && NVIDIA_DEVICES+=("$d")
       done
+      # Also check for devices inside /dev/nvidia-caps/ directory
+      if [[ -d /dev/nvidia-caps ]]; then
+        for d in /dev/nvidia-caps/*; do
+          [[ -c "$d" ]] && NVIDIA_DEVICES+=("$d")
+        done
+      fi
 
       if [[ ${#NVIDIA_DEVICES[@]} -gt 0 ]]; then
         msg_custom "🎮" "${GN}" "Found ${#NVIDIA_DEVICES[@]} NVIDIA device(s) for passthrough"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Refines the logic to only include character devices when binding /dev/nvidia* for container passthrough, avoiding directories like /dev/nvidia-caps. Also adds support for detecting NVIDIA devices inside the /dev/nvidia-caps directory.

cannot test it, dont have an nvidia for test, user should test after merge

## 🔗 Related PR / Issue  
Link: #9664


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
