### PR TITLE
fix(librespeed-rs): use correct service name

### DIFF
--- a/ct/librespeed-rust.sh
+++ b/ct/librespeed-rust.sh
@@ -30,13 +30,13 @@ function update_script() {
 
   if check_for_gh_release "librespeed-rust" "librespeed/speedtest-rust"; then
     msg_info "Stopping Services"
-    systemctl stop librespeed-rs
+    systemctl stop speedtest_rs
     msg_ok "Services Stopped"
 
     fetch_and_deploy_gh_release "librespeed-rust" "librespeed/speedtest-rust" "binary" "latest" "/opt/librespeed-rust" "librespeed-rs-x86_64-unknown-linux-gnu.deb"
 
     msg_info "Starting Service"
-    systemctl start librespeed-rs
+    systemctl start speedtest_rs
     msg_ok "Started Service"
     msg_ok "Updated successfully!"
   fi

--- a/install/librespeed-rust-install.sh
+++ b/install/librespeed-rust-install.sh
@@ -16,7 +16,7 @@ update_os
 fetch_and_deploy_gh_release "librespeed-rust" "librespeed/speedtest-rust" "binary" "latest" "/opt/librespeed-rust" "librespeed-rs-x86_64-unknown-linux-gnu.deb"
 
 msg_info "Enabling Service"
-systemctl enable -q --now librespeed-rs
+systemctl enable -q --now speedtest_rs
 msg_ok "Enabled Service"
 
 motd_ssh


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
The correct service name for librespeed is `speedtest_rs`.  This commit fixes the service name across both install and update scripts.

See https://github.com/librespeed/speedtest-rust/issues/36#issuecomment-3617532802.



## 🔗 Related PR / Issue  
Related to #9626.

## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
