### PR TITLE
tools.func: handle GitHub 300 Multiple Choices in tarball mode

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1728,12 +1728,13 @@ function fetch_and_deploy_gh_release() {
 
   ### Tarball Mode ###
   if [[ "$mode" == "tarball" || "$mode" == "source" ]]; then
-    url=$(echo "$json" | jq -r '.tarball_url // empty')
-    [[ -z "$url" ]] && url="https://github.com/$repo/archive/refs/tags/v$version.tar.gz"
+    # GitHub API's tarball_url/zipball_url can return HTTP 300 Multiple Choices
+    # when a branch and tag share the same name. Use explicit refs/tags/ URL instead.
+    local direct_tarball_url="https://github.com/$repo/archive/refs/tags/$tag_name.tar.gz"
     filename="${app_lc}-${version}.tar.gz"
 
-    curl $download_timeout -fsSL -o "$tmpdir/$filename" "$url" || {
-      msg_error "Download failed: $url"
+    curl $download_timeout -fsSL -o "$tmpdir/$filename" "$direct_tarball_url" || {
+      msg_error "Download failed: $direct_tarball_url"
       rm -rf "$tmpdir"
       return 1
     }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
Pangolin has a branch and tag with the same name (`1.12.3`). GitHub's `tarball_url` returns HTTP 300 (not a redirect), so curl saves JSON instead of the tarball → "gzip: stdin: not in gzip format".

Fixed / Improved -> Use explicit refs/tags URL which always returns a proper redirect:
```bash
https://github.com/$repo/archive/refs/tags/$tag_name.tar.gz
```

Example:
```http
GET https://api.github.com/repos/fosrl/pangolin/tarball/1.12.3

HTTP/2 300
{
  "message": "Multiple resource types were returned for this ref",
  "resources": [
    {"type": "branch", "url": ".../refs/heads/1.12.3"},
    {"type": "tag", "url": ".../refs/tags/1.12.3"}
  ]
}
```

`curl -fsSL` doesn't follow 300 responses (only 301/302), so it saves the JSON body as the file → `tar -xzf` fails with "gzip: stdin: not in gzip format".


## 🔗 Related PR / Issue  
Link: #9694



## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [x] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
