### PR TITLE
libretranslate: pin uv python to 3.12 (pytorch fix)

### DIFF
--- a/ct/libretranslate.sh
+++ b/ct/libretranslate.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  setup_uv
+  PYTHON_VERSION="3.12" setup_uv
 
   if check_for_gh_release "libretranslate" "LibreTranslate/LibreTranslate"; then
     msg_info "Stopping Service"
@@ -39,7 +39,7 @@ function update_script() {
     msg_info "Updating LibreTranslate"
     cd /opt/libretranslate
     source .venv/bin/activate
-    $STD pip install -U libretranslate
+    $STD uv pip install -U libretranslate
     msg_ok "Updated LibreTranslate"
 
     msg_info "Starting Service"

--- a/install/libretranslate-install.sh
+++ b/install/libretranslate-install.sh
@@ -32,7 +32,7 @@ $STD apt install -y \
   python3-icu
 msg_ok "Setup Python3"
 
-setup_uv
+PYTHON_VERSION="3.12" setup_uv
 fetch_and_deploy_gh_release "libretranslate" "LibreTranslate/LibreTranslate"
 
 msg_info "Setup LibreTranslate (Patience)"
@@ -42,7 +42,7 @@ if [[ -z "$TORCH_VERSION" ]]; then
   TORCH_VERSION="2.5.0"
 fi
 cd /opt/libretranslate
-$STD uv venv .venv
+$STD uv venv .venv --python 3.12
 $STD source .venv/bin/activate
 $STD uv pip install --upgrade pip setuptools
 $STD uv pip install Babel==2.12.1


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.  
PRs without prior testing will be closed. -->
## ✍️ Description  
PyTorch versions below 2.5.0 don't provide wheels for Python 3.13 (cp313). Debian 13 uses Python 3.13 by default, causing the installation to fail with 'no wheels with a matching Python ABI tag'.

Use uv venv --python 3.12 to create the virtual environment with Python 3.12, ensuring compatibility with all PyTorch versions.


## 🔗 Related PR / Issue  
Link: #9696


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [ ] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
- [ ] 🆕 **New script** – A fully functional and tested script or script set.  
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.  
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.  
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.  
