### PR TITLE
Update domain-locker-install.sh to enable auto-start after reboot

### DIFF
--- a/install/domain-locker-install.sh
+++ b/install/domain-locker-install.sh
@@ -64,7 +64,7 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable --now -q domain-locker
+systemctl enable -q --now domain-locker
 msg_info "Created Service"
 
 motd_ssh

--- a/install/domain-locker-install.sh
+++ b/install/domain-locker-install.sh
@@ -64,7 +64,7 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl start --now -q domain-locker
+systemctl enable --now -q domain-locker
 msg_info "Created Service"
 
 motd_ssh


### PR DESCRIPTION
## ✍️ Description

It should be `systemctl enable --now`, so service would start again after reboot.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x ] **Self-review completed** – Code follows project standards.
- [ x] **Tested thoroughly** – Changes work as expected.
- [x ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
