### PR TITLE
wanderer: add meilisearch dumpless upgrade for database migration

### DIFF
--- a/ct/wanderer.sh
+++ b/ct/wanderer.sh
@@ -55,7 +55,8 @@ function update_script() {
         systemctl stop wanderer-web
         msg_ok "Stopped service"
 
-    		fetch_and_deploy_gh_release "meilisearch" "meilisearch/meilisearch" "binary" "latest" "/opt/wanderer/source/search"
+        fetch_and_deploy_gh_release "meilisearch" "meilisearch/meilisearch" "binary" "latest" "/opt/wanderer/source/search"
+        grep -q -- '--experimental-dumpless-upgrade' /opt/wanderer/start.sh || sed -i 's|meilisearch --master-key|meilisearch --experimental-dumpless-upgrade --master-key|' /opt/wanderer/start.sh
 
         msg_info "Starting service"
         systemctl start wanderer-web

--- a/install/wanderer-install.sh
+++ b/install/wanderer-install.sh
@@ -52,7 +52,7 @@ cat <<EOF >/opt/wanderer/start.sh
 
 trap "kill 0" EXIT
 
-cd /opt/wanderer/source/search && meilisearch --master-key \$MEILI_MASTER_KEY &
+cd /opt/wanderer/source/search && meilisearch --experimental-dumpless-upgrade --master-key \$MEILI_MASTER_KEY &
 sleep 1
 cd /opt/wanderer/source/db && ./pocketbase serve --http=\$PB_URL --dir=\$PB_DB_LOCATION &
 cd /opt/wanderer/source/web && node build &


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When meilisearch is updated to a new version, the database format may change and require migration. This adds --experimental-dumpless-upgrade flag temporarily during the first start after update to allow meilisearch to migrate the database automatically.

Fixes #9729

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
