### PR TITLE
Revert Zammad: use Debian 12 and dynamic APT source version

### DIFF
--- a/ct/zammad.sh
+++ b/ct/zammad.sh
@@ -11,7 +11,7 @@ var_disk="${var_disk:-8}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/zammad.json
+++ b/frontend/public/json/zammad.json
@@ -23,7 +23,7 @@
         "ram": 4096,
         "hdd": 8,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/install/zammad-install.sh
+++ b/install/zammad-install.sh
@@ -21,15 +21,12 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up Elasticsearch"
-curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
-cat <<EOF | sudo tee /etc/apt/sources.list.d/elasticsearch.sources >/dev/null
-Types: deb
-URIs: https://artifacts.elastic.co/packages/7.x/apt
-Suites: stable
-Components: main
-Signed-By: /usr/share/keyrings/elasticsearch-keyring.gpg
-EOF
-$STD apt update
+setup_deb822_repo \
+  "elasticsearch" \
+  "https://artifacts.elastic.co/GPG-KEY-elasticsearch" \
+  "https://artifacts.elastic.co/packages/7.x/apt" \
+  "stable" \
+  "main"
 $STD apt -y install elasticsearch
 echo "-Xms2g" >>/etc/elasticsearch/jvm.options
 echo "-Xmx2g" >>/etc/elasticsearch/jvm.options
@@ -39,15 +36,12 @@ systemctl restart -q elasticsearch
 msg_ok "Setup Elasticsearch"
 
 msg_info "Installing Zammad"
-curl -fsSL https://dl.packager.io/srv/zammad/zammad/key | gpg --dearmor | sudo tee /etc/apt/keyrings/pkgr-zammad.gpg >/dev/null
-cat <<EOF | sudo tee /etc/apt/sources.list.d/zammad.sources >/dev/null
-Types: deb
-URIs: https://dl.packager.io/srv/deb/zammad/zammad/stable/debian
-Suites: 12
-Components: main
-Signed-By: /etc/apt/keyrings/pkgr-zammad.gpg
-EOF
-$STD apt update
+setup_deb822_repo \
+  "zammad" \
+  "https://dl.packager.io/srv/zammad/zammad/key" \
+  "https://dl.packager.io/srv/deb/zammad/zammad/stable/debian" \
+  "$(get_os_info version_id)" \
+  "main"
 $STD apt -y install zammad
 $STD zammad run rails r "Setting.set('es_url', 'http://localhost:9200')"
 $STD zammad run rake zammad:searchindex:rebuild


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Edit; Zammad has removed the deb13 stable repo to alpha, so i switched back to debian 12. 


Old PR-Description; 
```
- Set default to Debian 13 for stable Zammad support
- Make APT source use dynamic VERSION_ID (from tools.func) instead of hardcoded value, This will automatically work when Zammad 7.0 stable releases with Debian 13 support.
```

## 🔗 Related Issue

Fixes #9725

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
