### PR TITLE
Remove Debian from GPU passthrough

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2391,7 +2391,7 @@ build_container() {
   GPU_APPS=(
     "immich" "channels" "emby" "ersatztv" "frigate"
     "jellyfin" "plex" "scrypted" "tdarr" "unmanic"
-    "ollama" "fileflows" "open-webui" "tunarr" "debian"
+    "ollama" "fileflows" "open-webui" "tunarr"
     "handbrake" "sunshine" "moonlight" "kodi" "stremio"
     "viseron"
   )


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Remove Debian from GPU passthrough, so no one cry because it Set an passthrough as Default.

## 🔗 Related Issue

Fixes #9753

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
