### PR TITLE
fix(tools): handle repos with 30+ pre-releases in check_for_gh_release

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1453,15 +1453,32 @@ check_for_gh_release() {
 
   ensure_dependencies jq
 
-  # Fetch releases and exclude drafts/prereleases
-  local releases_json
-  releases_json=$(curl -fsSL --max-time 20 \
-    -H 'Accept: application/vnd.github+json' \
-    -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "https://api.github.com/repos/${source}/releases") || {
-    msg_error "Unable to fetch releases for ${app}"
-    return 1
-  }
+  # Try /latest endpoint for non-pinned versions (most efficient)
+  local releases_json=""
+  
+  if [[ -z "$pinned_version_in" ]]; then
+    releases_json=$(curl -fsSL --max-time 20 \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "https://api.github.com/repos/${source}/releases/latest" 2>/dev/null)
+    
+    if [[ $? -eq 0 ]] && [[ -n "$releases_json" ]]; then
+      # Wrap single release in array for consistent processing
+      releases_json="[$releases_json]"
+    fi
+  fi
+  
+  # If no releases yet (pinned version OR /latest failed), fetch up to 100
+  if [[ -z "$releases_json" ]]; then
+    # Fetch releases and exclude drafts/prereleases
+    releases_json=$(curl -fsSL --max-time 20 \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "https://api.github.com/repos/${source}/releases?per_page=100") || {
+      msg_error "Unable to fetch releases for ${app}"
+      return 1
+    }
+  fi
 
   mapfile -t raw_tags < <(jq -r '.[] | select(.draft==false and .prerelease==false) | .tag_name' <<<"$releases_json")
   if ((${#raw_tags[@]} == 0)); then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

When attempting to update via https://github.com/morpheus65535/bazarr, the script failed with "no stable releases found". This repo has more than 30 pre-releases, and as a result, the script fails to find a stable release. I have made the following changes in this PR:

- Try /releases/latest first for non-pinned versions
- Increase per_page to 100 when fetching all releases

## 🔗 Related Issue

Fixes n/a

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
