### PR TITLE
fixed grammar on alert that pops up when you copy the curl command

### DIFF
--- a/frontend/src/components/ui/code-copy-button.tsx
+++ b/frontend/src/components/ui/code-copy-button.tsx
@@ -34,7 +34,7 @@ export default function CodeCopyButton({
       localStorage.setItem("warning", "1");
       setTimeout(() => {
         toast.error(
-          "Be careful when copying scripts from the internet. Always remember check the source!",
+          "Be careful when copying scripts from the internet. Always remember to check the source!",
           { duration: 8000 },
         );
       }, 500);


### PR DESCRIPTION
it was bugging me out every time i copied something

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
when you copy something on the site, like the curl command, an alert pops up, it asks you to "Always remember check the source", this made no sense to me, A better wording would be "Always remember to check the source" and I wanted to bring forth this change.

I agree to the fact my contribution may not be of acceptable quality, and I am sorry for that.

## 🔗 Related Issue

Fixes #
changed "Always remember check the source" to "Always remember to check the source" as that's objectively better grammar

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
