### PR TITLE
endurain: remove unneeded deps

### DIFF
--- a/install/endurain-install.sh
+++ b/install/endurain-install.sh
@@ -14,8 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y \
-  build-essential
+$STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.13" setup_uv

--- a/install/endurain-install.sh
+++ b/install/endurain-install.sh
@@ -15,9 +15,7 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt install -y \
-  default-libmysqlclient-dev \
-  build-essential \
-  pkg-config
+  build-essential
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.13" setup_uv


### PR DESCRIPTION
updated deps for v0.16.0. MariaDB support was dropped.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

With Endurain 0.16.0 MariaDB support was dropped. The deps `default-libmysqlclient-dev` and `pkg-config` are no longer needed.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
