### PR TITLE
core: skip -features flag when empty

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1047,7 +1047,7 @@ advanced_settings() {
   local _enable_mknod="${var_mknod:-0}"
   local _mount_fs="${var_mount_fs:-}"
   local _protect_ct="${var_protection:-no}"
-  
+
   # Detect host timezone for default (if not set via var_timezone)
   local _host_timezone=""
   if command -v timedatectl >/dev/null 2>&1; then
@@ -2630,9 +2630,14 @@ build_container() {
   export DEV_MODE_DRYRUN="${DEV_MODE_DRYRUN:-false}"
 
   # Build PCT_OPTIONS as multi-line string
-  PCT_OPTIONS_STRING="  -features $FEATURES
-  -hostname $HN
+  PCT_OPTIONS_STRING="  -hostname $HN
   -tags $TAGS"
+
+  # Only add -features if FEATURES is not empty
+  if [ -n "$FEATURES" ]; then
+    PCT_OPTIONS_STRING="  -features $FEATURES
+$PCT_OPTIONS_STRING"
+  fi
 
   # Add storage if specified
   if [ -n "$SD" ]; then


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Fixes '400 too many arguments' error when creating privileged containers without nesting/fuse features enabled.
If a user selects a privileged container (CT_TYPE=0) in Advanced Settings AND disables nesting AND no FUSE, $FEATURES is empty. The old code still added -features (with an empty value) to the pct create command. pct interprets the next argument (-hostname) as the value for -features → “400 too many arguments.”

## 🔗 Related Issue

Fixes #9868

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
