### PR TITLE
dokploy: require unprivileged LXC environment

### DIFF
--- a/ct/dokploy.sh
+++ b/ct/dokploy.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_unprivileged="${var_unprivileged:-1}"
+var_unprivileged="${var_unprivileged:-0}"
 
 header_info "$APP"
 variables

--- a/frontend/public/json/dokploy.json
+++ b/frontend/public/json/dokploy.json
@@ -7,7 +7,7 @@
     "date_created": "2025-12-09",
     "type": "ct",
     "updateable": true,
-    "privileged": false,
+    "privileged": true,
     "interface_port": 3000,
     "documentation": "https://docs.dokploy.com/",
     "config_path": "/etc/dokploy",


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Dokploy requires running in an unprivileged LXC environment to ensure proper Swarm networking and service communication. Privileged containers break overlay networking and lead to Redis/Postgres connection failures (ECONNREFUSED). This update documents the requirement and prevents misconfiguration.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
