### PR TITLE
fix:ct/openwebui.sh adding progressbar and minimize service downtime

### DIFF
--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -96,22 +96,18 @@ if [ -x "/usr/bin/ollama" ]; then
     msg_info "Checking for Ollama Update"
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
-    
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
       msg_info "Ollama update available: v$OLLAMA_VERSION -> v$RELEASE"
-      
-      msg_info "Downloading Ollama v$RELEASE"
-      # Removing -s (silent) and adding -# (progress bar), visual improvement because it might look like a 'system hang' leading to unnecessary user intervention
-      curl -fSLO -C - -# https://ollama.com/download/ollama-linux-amd64.tgz
+      msg_info "Downloading Ollama v$RELEASE \n"
+      curl -fS#LO https://ollama.com/download/ollama-linux-amd64.tgz
       msg_ok "Download Complete"
-      
-      # basic integrity check -f
+
       if [ -f "ollama-linux-amd64.tgz" ]; then
 
         msg_info "Stopping Ollama Service"
         systemctl stop ollama
         msg_ok "Stopped Service"
-        
+
         msg_info "Installing Ollama"
         rm -rf /usr/lib/ollama
         rm -rf /usr/bin/ollama
@@ -122,7 +118,7 @@ if [ -x "/usr/bin/ollama" ]; then
         msg_info "Starting Ollama Service"
         systemctl start ollama
         msg_ok "Started Service"
-        
+
         msg_ok "Ollama updated to version $RELEASE"
       else
         msg_error "Ollama download failed. Aborting update."

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -92,7 +92,7 @@ EOF
     exit
   fi
 
-if [ -x "/usr/bin/ollama" ]; then
+  if [ -x "/usr/bin/ollama" ]; then
     msg_info "Checking for Ollama Update"
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -5,11 +5,6 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://openwebui.com/
 
-# Co-Author: jobben2025
-# Updated: 2025-12-11 - curl removed silent, adding progress bar; 
-# changing order of stopping service to 2nd step for minimal downtime (first download ollama file); 
-# slow internet/ollama server speeds may cause extremely long downtimes;
-
 APP="Open WebUI"
 var_tags="${var_tags:-ai;interface}"
 var_cpu="${var_cpu:-4}"

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -102,7 +102,7 @@ if [ -x "/usr/bin/ollama" ]; then
       
       msg_info "Downloading Ollama v$RELEASE"
       # Removing -s (silent) and adding -# (progress bar), visual improvement because it might look like a 'system hang' leading to unnecessary user intervention
-      curl -fsSLO -C - -# https://ollama.com/download/ollama-linux-amd64.tgz
+      curl -fSLO -C - -# https://ollama.com/download/ollama-linux-amd64.tgz
       msg_ok "Download Complete"
       
       # basic integrity check -f


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When running ‚update‘ command the ollama service is taken down and then the download runs eventually 'really long' (low speed internet/ollama server connection), this could lead to unnecessary user intervention or even wrongly re-installations.
At least the long service downtime might affect users during daytime.

## 🔗 Related Issue

Fixes #
Adding the curl progress bar using -# and not -s (silent); changing the order of the steps to first download the file and if file is present then taking down ollama service and doing the update procedure.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.
- [x] **syntax** - Ran syntax and shellcheck.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
