### PR TITLE
core: load app defaults before applying base_settings / fix composer cleanup after install/update

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2148,8 +2148,8 @@ install_script() {
         header_info
         echo -e "${DEFAULT}${BOLD}${BL}Using App Defaults for ${APP} on node $PVEHOST_NAME${CL}"
         METHOD="appdefaults"
-        base_settings
         load_vars_file "$(get_app_defaults_path)"
+        base_settings
         echo_default
         defaults_target="$(get_app_defaults_path)"
         break

--- a/misc/core.func
+++ b/misc/core.func
@@ -828,7 +828,7 @@ cleanup_lxc() {
   # Ruby gem
   if command -v gem &>/dev/null; then $STD gem cleanup || true; fi
   # Composer (PHP)
-  if command -v composer &>/dev/null; then COMPOSER_ALLOW_SUPERUSER=1 $STD composer clear-cache || true; fi
+  if command -v composer &>/dev/null; then COMPOSER_ALLOW_SUPERUSER=1 && $STD composer clear-cache || true; fi
 
   if command -v journalctl &>/dev/null; then
     $STD journalctl --vacuum-time=10m || true

--- a/misc/core.func
+++ b/misc/core.func
@@ -828,7 +828,7 @@ cleanup_lxc() {
   # Ruby gem
   if command -v gem &>/dev/null; then $STD gem cleanup || true; fi
   # Composer (PHP)
-  if command -v composer &>/dev/null; then $STD composer clear-cache || true; fi
+  if command -v composer &>/dev/null; then COMPOSER_ALLOW_SUPERUSER=1 $STD composer clear-cache || true; fi
 
   if command -v journalctl &>/dev/null; then
     $STD journalctl --vacuum-time=10m || true


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
App defaults were loaded after base_settings, causing saved values to be ignored. Now loads var_* from app defaults file before calling base_settings.


## 🔗 Related Issue

Fixes #9955 #9950

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
