### PR TITLE
fix(pangolin-install): add network-online dependency

### DIFF
--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -230,6 +230,8 @@ systemctl enable -q --now gerbil
 cat <<'EOF' >/etc/systemd/system/traefik.service
 [Unit]
 Description=Traefik is an open-source Edge Router that makes publishing your services a fun and easy experience
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
## ✍️ Description
This patch adds a dependency on `network-online.service` for the generated `traefik.service`, to avoid the issue when traefik starts before the network is ready. Otherwise, it's unable to download the `badger` plugin, and most of the routes added via Pangolin will fail to resolve.

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
