### PR TITLE
tools: prevent awk errors in setup_rust on restricted containers

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4424,7 +4424,7 @@ function setup_rust() {
   # Get currently installed version
   local CURRENT_VERSION=""
   if command -v rustc &>/dev/null; then
-    CURRENT_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}')
+    CURRENT_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}' 2>/dev/null) || true
   fi
 
   # Scenario 1: Rustup not installed - fresh install
@@ -4443,7 +4443,8 @@ function setup_rust() {
       return 1
     fi
 
-    local RUST_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}')
+    local RUST_VERSION
+    RUST_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}' 2>/dev/null) || true
     if [[ -z "$RUST_VERSION" ]]; then
       msg_error "Failed to determine Rust version"
       return 1
@@ -4474,7 +4475,8 @@ function setup_rust() {
     # Ensure PATH is updated for current shell session
     export PATH="$CARGO_BIN:$PATH"
 
-    local RUST_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}')
+    local RUST_VERSION
+    RUST_VERSION=$(rustc --version 2>/dev/null | awk '{print $2}' 2>/dev/null) || true
     if [[ -z "$RUST_VERSION" ]]; then
       msg_error "Failed to determine Rust version after update"
       return 1


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add error suppression and || true to awk commands that parse rustc version. Prevents 'Operation not permitted' errors in containers with restricted syscalls.

## 🔗 Related Issue

Fixes #9983

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
