### PR TITLE
paperless-ai: backup data and recreate venv during update

### DIFF
--- a/ct/paperless-ai.sh
+++ b/ct/paperless-ai.sh
@@ -33,10 +33,23 @@ function update_script() {
     systemctl stop paperless-ai paperless-rag
     msg_ok "Stopped Service"
 
+    msg_info "Backing up data"
+    cp -r /opt/paperless-ai/data /opt/paperless-ai-data-backup
+    msg_ok "Backed up data"
+
     fetch_and_deploy_gh_release "paperless-ai" "clusterzx/paperless-ai"
+
+    msg_info "Restoring data"
+    cp -r /opt/paperless-ai-data-backup/* /opt/paperless-ai/data/
+    rm -rf /opt/paperless-ai-data-backup
+    msg_ok "Restored data"
 
     msg_info "Updating Paperless-AI"
     cd /opt/paperless-ai
+    if [[ ! -d /opt/paperless-ai/venv ]]; then
+      msg_info "Recreating Python venv"
+      $STD python3 -m venv /opt/paperless-ai/venv
+    fi
     source /opt/paperless-ai/venv/bin/activate
     $STD pip install --upgrade pip
     $STD pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The update script failed because fetch_and_deploy_gh_release overwrites the entire /opt/paperless-ai directory, including the venv folder.

Changes:
- Backup data directory before deploying new release
- Restore data after deployment
- Recreate venv if it doesn't exist after update

## 🔗 Related Issue

Fixes #9649

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
