### PR TITLE
tools: handle flat repositories in setup_deb822_repo

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1249,7 +1249,10 @@ setup_deb822_repo() {
     echo "Types: deb"
     echo "URIs: $repo_url"
     echo "Suites: $suite"
-    echo "Components: $component"
+    # Flat repositories (suite="./" or absolute path) must not have Components
+    if [[ "$suite" != "./" && -n "$component" ]]; then
+      echo "Components: $component"
+    fi
     [[ -n "$architectures" ]] && echo "Architectures: $architectures"
     echo "Signed-By: /etc/apt/keyrings/${name}.gpg"
   } >/etc/apt/sources.list.d/${name}.sources


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Flat repositories (where suite is './' or an absolute path) must not include a Components line in deb822 format. APT rejects sources files with 'absolute Suite Component' when Components is specified for flat repos.

## 🔗 Related Issue

Fixes #9993

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
