### PR TITLE
mariadb: website json change adminer -> phpMyAdmin

### DIFF
--- a/frontend/public/json/mariadb.json
+++ b/frontend/public/json/mariadb.json
@@ -48,7 +48,7 @@
       "type": "info"
     },
     {
-      "text": "Access Adminer Web UI at `http://<CONTAINER_IP>/adminer.php`",
+      "text": "Access phpMyAdmin Web UI at `http://<CONTAINER_IP>/phpMyAdmin`",
       "type": "info"
     }
   ]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

The mariadb installation script prompts you to install phpMyAdmin, not Adminer, unlike the Postgres script for example.
See install/mariadb-install.sh line 23

## 🔗 Related Issue

## ✅ Prerequisites (**X** in brackets)

- [**X** ] **Self-review completed** – Code follows project standards.
- [ **X**] **Tested thoroughly** – Changes work as expected.
- [**X** ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [**X** ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
