### PR TITLE
pdm: add rsyslog to fix /dev/log Connection refused errors

### DIFF
--- a/install/proxmox-datacenter-manager-install.sh
+++ b/install/proxmox-datacenter-manager-install.sh
@@ -13,6 +13,11 @@ setting_up_container
 network_check
 update_os
 
+msg_info "Installing Dependencies"
+$STD apt-get install -y rsyslog
+systemctl enable -q --now rsyslog
+msg_ok "Installed Dependencies"
+
 msg_info "Installing Proxmox Datacenter Manager"
 curl -fsSL https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg -o /usr/share/keyrings/proxmox-archive-keyring.gpg
 setup_deb822_repo \
@@ -21,21 +26,21 @@ setup_deb822_repo \
   "http://download.proxmox.com/debian/pdm" \
   "trixie" \
   "pdm-no-subscription"
-  
-cat <<EOF >/etc/apt/sources.list.d/pdm-test.sources
-Types: deb
-URIs: http://download.proxmox.com/debian/pdm
-Suites: trixie
-Components: pdm-test
-Signed-By: /usr/share/keyrings/proxmox-archive-keyring.gpg
-Enabled: false
-EOF
-$STD apt update
+
+setup_deb822_repo \
+  "pdm-test" \
+  "https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg" \
+  "http://download.proxmox.com/debian/pdm" \
+  "trixie" \
+  "pdm-test" \
+  "" \
+  "false"
+
 DEBIAN_FRONTEND=noninteractive
 $STD apt -o Dpkg::Options::="--force-confdef" \
-        -o Dpkg::Options::="--force-confold" \
-        install -y proxmox-datacenter-manager \
-        proxmox-datacenter-manager-ui
+  -o Dpkg::Options::="--force-confold" \
+  install -y proxmox-datacenter-manager \
+  proxmox-datacenter-manager-ui
 msg_ok "Installed Proxmox Datacenter Manager"
 
 motd_ssh

--- a/install/proxmox-datacenter-manager-install.sh
+++ b/install/proxmox-datacenter-manager-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt-get install -y rsyslog
+$STD apt install -y rsyslog
 systemctl enable -q --now rsyslog
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Debian 13 minimal containers don't have rsyslog installed by default, causing 'logger: socket /dev/log: Connection refused' errors when system utilities try to log messages.
Install and enable rsyslog to provide the /dev/log socket.

## 🔗 Related Issue

Fixes #9964

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
