### PR TITLE
PhotoPrism: export env variables for CLI tools

### DIFF
--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -31,8 +31,7 @@ function update_script() {
     msg_info "Stopping PhotoPrism"
     systemctl stop photoprism
     msg_ok "Stopped PhotoPrism"
-
-    # Ensure CLI tools have access to env variables (for existing installations)
+    
     if ! grep -q "photoprism/config/.env" ~/.bashrc 2>/dev/null; then
       msg_info "Adding environment export for CLI tools"
       echo '# Load PhotoPrism environment variables for CLI tools' >>~/.bashrc

--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -32,6 +32,14 @@ function update_script() {
     systemctl stop photoprism
     msg_ok "Stopped PhotoPrism"
 
+    # Ensure CLI tools have access to env variables (for existing installations)
+    if ! grep -q "photoprism/config/.env" ~/.bashrc 2>/dev/null; then
+      msg_info "Adding environment export for CLI tools"
+      echo '# Load PhotoPrism environment variables for CLI tools' >>~/.bashrc
+      echo 'export $(grep -v "^#" /opt/photoprism/config/.env | xargs)' >>~/.bashrc
+      msg_ok "Added environment export"
+    fi
+
     fetch_and_deploy_gh_release "photoprism" "photoprism/photoprism" "prebuild" "latest" "/opt/photoprism" "*linux-amd64.tar.gz"
 
     LIBHEIF_URL=$(curl -fsSL "https://dl.photoprism.app/dist/libheif/" | grep -oP "libheif-bookworm-amd64-v[0-9\.]+\.tar\.gz" | sort -V | tail -n 1)

--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -28,6 +28,8 @@ $STD apt install -y \
   lsb-release
 
 echo 'export PATH=/usr/local:$PATH' >>~/.bashrc
+echo '# Load PhotoPrism environment variables for CLI tools' >>~/.bashrc
+echo 'export $(grep -v "^#" /opt/photoprism/config/.env | xargs)' >>~/.bashrc
 export PATH=/usr/local:$PATH
 msg_ok "Installed Dependencies"
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The PhotoPrism CLI tools (photoprism users add, etc.) require the environment variables from /opt/photoprism/config/.env to use the correct configuration. Previously, these were only loaded via systemd's EnvironmentFile directive, making them unavailable to CLI sessions.

This adds an export command to ~/.bashrc so CLI tools use the same config as the service (e.g., correct database connection).

## 🔗 Related Issue

Fixes #9962

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
