### PR TITLE
Fix: mariadb repo in update_scripts

### DIFF
--- a/ct/2fauth.sh
+++ b/ct/2fauth.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "2fauth" "Bubka/2FAuth"; then
     $STD apt update
     $STD apt -y upgrade

--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -20,16 +20,16 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/apache-guacamole ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    setup_mariadb
-    msg_error "Currently we don't provide an update function for this ${APP}."
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/apache-guacamole ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  setup_mariadb
+  msg_error "Currently we don't provide an update function for this ${APP}."
+  exit
 }
 
 start

--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -27,6 +27,7 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
+    setup_mariadb
     msg_error "Currently we don't provide an update function for this ${APP}."
     exit
 }

--- a/ct/booklore.sh
+++ b/ct/booklore.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "booklore" "booklore-app/BookLore"; then
     msg_info "Stopping Service"
     systemctl stop booklore

--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "bookstack" "BookStackApp/BookStack"; then
     msg_info "Stopping Apache2"
     systemctl stop apache2

--- a/ct/dolibarr.sh
+++ b/ct/dolibarr.sh
@@ -20,16 +20,16 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /usr/share/dolibarr ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    setup_mariadb
-    msg_error "To update ${APP}, use the applications web interface."
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /usr/share/dolibarr ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  setup_mariadb
+  msg_error "To update ${APP}, use the applications web interface."
+  exit
 }
 
 start

--- a/ct/dolibarr.sh
+++ b/ct/dolibarr.sh
@@ -27,6 +27,7 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
+    setup_mariadb
     msg_error "To update ${APP}, use the applications web interface."
     exit
 }

--- a/ct/domain-monitor.sh
+++ b/ct/domain-monitor.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
 
   if ! grep -Fq "root /usr/bin/php /opt/domain-monitor/cron/check_domains.php" /etc/crontab; then
     echo "0 0 * * * root /usr/bin/php /opt/domain-monitor/cron/check_domains.php" >>/etc/crontab

--- a/ct/firefly.sh
+++ b/ct/firefly.sh
@@ -28,7 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "firefly" "firefly-iii/firefly-iii"; then
     systemctl stop apache2
     cp /opt/firefly/.env /opt/.env

--- a/ct/ghost.sh
+++ b/ct/ghost.sh
@@ -23,6 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
+  setup_mariadb
 
   NODE_VERSION="22" setup_nodejs
 

--- a/ct/glpi.sh
+++ b/ct/glpi.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   RELEASE=$(curl -fsSL https://api.github.com/repos/glpi-project/glpi/releases/latest | grep '"tag_name"' | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')
   if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
     msg_error "Currently we don't provide an update function for this ${APP}."

--- a/ct/hortusfox.sh
+++ b/ct/hortusfox.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "hortusfox" "danielbrendel/hortusfox-web"; then
     msg_info "Stopping Service"
     systemctl stop apache2

--- a/ct/invoiceninja.sh
+++ b/ct/invoiceninja.sh
@@ -28,7 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "invoiceninja" "invoiceninja/invoiceninja"; then
     msg_info "Stopping Services"
     systemctl stop supervisor nginx php8.4-fpm

--- a/ct/itsm-ng.sh
+++ b/ct/itsm-ng.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit 1
   fi
+  setup_mariadb
 
   msg_info "Updating LXC"
   $STD apt update

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -30,6 +30,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
 
   PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" setup_php
   setup_composer

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -35,7 +35,7 @@ function update_script() {
   PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" setup_php
   setup_composer
 
-    if check_for_gh_release "kimai" "kimai/kimai"; then
+  if check_for_gh_release "kimai" "kimai/kimai"; then
     BACKUP_DIR="/opt/kimai_backup"
 
     msg_info "Stopping Apache2"

--- a/ct/leantime.sh
+++ b/ct/leantime.sh
@@ -28,7 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "leantime" "Leantime/leantime"; then
     msg_info "Creating Backup"
     mariadb-dump leantime >"/opt/${APP}_db_backup_$(date +%F).sql"

--- a/ct/librenms.sh
+++ b/ct/librenms.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   msg_info "Updating LibreNMS"
   su librenms
   cd /opt/librenms

--- a/ct/limesurvey.sh
+++ b/ct/limesurvey.sh
@@ -20,17 +20,17 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /opt/limesurvey ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    setup_mariadb
-
-    msg_warn "Application is updated via Web Interface"
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/limesurvey ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  setup_mariadb
+
+  msg_warn "Application is updated via Web Interface"
+  exit
 }
 
 start

--- a/ct/limesurvey.sh
+++ b/ct/limesurvey.sh
@@ -27,6 +27,7 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
+    setup_mariadb
 
     msg_warn "Application is updated via Web Interface"
     exit

--- a/ct/managemydamnlife.sh
+++ b/ct/managemydamnlife.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "mmdl" "intri-in/manage-my-damn-life-nextjs"; then
     msg_info "Stopping service"
     systemctl stop mmdl

--- a/ct/mariadb.sh
+++ b/ct/mariadb.sh
@@ -20,19 +20,19 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -d /etc/mysql/mariadb.conf.d ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    setup_mariadb
-    msg_info "Updating ${APP} LXC"
-    $STD apt update
-    $STD apt -y upgrade
-    msg_ok "Updated successfully!"
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /etc/mysql/mariadb.conf.d ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  setup_mariadb
+  msg_info "Updating ${APP} LXC"
+  $STD apt update
+  $STD apt -y upgrade
+  msg_ok "Updated successfully!"
+  exit
 }
 
 start

--- a/ct/mariadb.sh
+++ b/ct/mariadb.sh
@@ -27,6 +27,7 @@ function update_script() {
         msg_error "No ${APP} Installation Found!"
         exit
     fi
+    setup_mariadb
     msg_info "Updating ${APP} LXC"
     $STD apt update
     $STD apt -y upgrade

--- a/ct/miniflux.sh
+++ b/ct/miniflux.sh
@@ -34,7 +34,7 @@ function update_script() {
   msg_ok "Service Stopped"
 
   fetch_and_deploy_gh_release "miniflux" "miniflux/v2" "binary" "latest"
-  
+
   msg_info "Updating Miniflux"
   $STD miniflux -migrate -config-file /etc/miniflux.conf
   msg_ok "Updated Miniflux"

--- a/ct/monica.sh
+++ b/ct/monica.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
 
   NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
 

--- a/ct/passbolt.sh
+++ b/ct/passbolt.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   msg_info "Updating $APP LXC"
   $STD apt update
   $STD apt upgrade -y

--- a/ct/paymenter.sh
+++ b/ct/paymenter.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
 
   CURRENT_PHP=$(php -v 2>/dev/null | awk '/^PHP/{print $2}' | cut -d. -f1,2)
   if [[ "$CURRENT_PHP" != "8.3" ]]; then

--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   CURRENT_PHP=$(php -v 2>/dev/null | awk '/^PHP/{print $2}' | cut -d. -f1,2)
 
   if [[ "$CURRENT_PHP" != "8.4" ]]; then

--- a/ct/phpipam.sh
+++ b/ct/phpipam.sh
@@ -27,7 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "phpipam" "phpipam/phpipam"; then
     msg_info "Stopping Service"
     systemctl stop apache2

--- a/ct/plant-it.sh
+++ b/ct/plant-it.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if check_for_gh_release "plant-it" "MDeLuise/plant-it"; then
     msg_info "Stopping Service"
     systemctl stop plant-it

--- a/ct/projectsend.sh
+++ b/ct/projectsend.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
 
   if check_for_gh_release "projectsend" "projectsend/projectsend"; then
     msg_info "Stopping Service"

--- a/ct/pterodactyl-panel.sh
+++ b/ct/pterodactyl-panel.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   CURRENT_PHP=$(php -v 2>/dev/null | awk '/^PHP/{print $2}' | cut -d. -f1,2)
 
   if [[ "$CURRENT_PHP" != "8.4" ]]; then

--- a/ct/shinobi.sh
+++ b/ct/shinobi.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   msg_info "Updating Shinobi"
   cd /opt/Shinobi
   $STD sh UPDATE.sh

--- a/ct/snipeit.sh
+++ b/ct/snipeit.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   if ! grep -q "client_max_body_size[[:space:]]\+100M;" /etc/nginx/conf.d/snipeit.conf; then
     sed -i '/index index.php;/i \        client_max_body_size 100M;' /etc/nginx/conf.d/snipeit.conf
   fi

--- a/ct/wallabag.sh
+++ b/ct/wallabag.sh
@@ -28,7 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "wallabag" "wallabag/wallabag"; then
     msg_info "Stopping Services"
     systemctl stop nginx php8.3-fpm

--- a/ct/wavelog.sh
+++ b/ct/wavelog.sh
@@ -27,7 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-
+  setup_mariadb
   if check_for_gh_release "wavelog" "wavelog/wavelog"; then
     msg_info "Stopping Services"
     systemctl stop apache2

--- a/ct/wordpress.sh
+++ b/ct/wordpress.sh
@@ -27,6 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  setup_mariadb
   msg_error "Wordpress should be updated via the user interface."
   exit
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When MariaDB is installed with a specific version (e.g. 12.1.1), the
repository URL becomes stale when that version is removed from mirrors.
This causes 'apt update' to fail with 404 errors.

Adding setup_mariadb to update_script ensures the MariaDB repository
is updated to the current version before any apt operations run.

## 🔗 Related Issue

Fixes #9933

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
