### PR TITLE
2fauth: update PHP version from 8.3 to 8.4 in update_script

### DIFF
--- a/ct/2fauth.sh
+++ b/ct/2fauth.sh
@@ -34,14 +34,14 @@ function update_script() {
 
     msg_info "Creating Backup"
     mv "/opt/2fauth" "/opt/2fauth-backup"
-    if ! dpkg -l | grep -q 'php8.3'; then
+    if ! dpkg -l | grep -q 'php8.4'; then
       cp /etc/nginx/conf.d/2fauth.conf /etc/nginx/conf.d/2fauth.conf.bak
     fi
     msg_ok "Backup Created"
 
-    if ! dpkg -l | grep -q 'php8.3'; then
-      PHP_VERSION="8.3" PHP_MODULE="common,ctype,fileinfo,mysql,cli,tokenizer,dom,redis,session,openssl" PHP_FPM="YES" setup_php
-      sed -i 's/php8.2/php8.3/g' /etc/nginx/conf.d/2fauth.conf
+    if ! dpkg -l | grep -q 'php8.4'; then
+      PHP_VERSION="8.4" PHP_MODULE="common,ctype,fileinfo,mysql,cli,tokenizer,dom,redis,session,openssl" PHP_FPM="YES" setup_php
+      sed -i 's/php8\.[0-9]/php8.4/g' /etc/nginx/conf.d/2fauth.conf
     fi
     fetch_and_deploy_gh_release "2fauth" "Bubka/2FAuth"
     setup_composer


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The install script uses PHP 8.4, but the update_script was still checking for and upgrading to PHP 8.3. I missed that. This aligns the update with the install configuration.

Also improved the sed pattern to handle any 8.x version.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
