### PR TITLE
Fix Zabbix 7.0 repository URL structure

### DIFF
--- a/ct/zabbix.sh
+++ b/ct/zabbix.sh
@@ -67,10 +67,18 @@ function update_script() {
 
   rm -Rf /etc/apt/sources.list.d/zabbix.list
   cd /tmp
-  ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb"
-  curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/zabbix-release_latest+debian13_all.deb
-  $STD dpkg -i zabbix-release_latest+debian13_all.deb
-  rm -rf /tmp/zabbix-release_latest+debian13_all.deb
+
+  if [[ "$ZABBIX_VERSION" == "7.0" ]]; then
+    ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/debian/pool/main/z/zabbix-release/zabbix-release_latest_${ZABBIX_VERSION}+debian13_all.deb"
+    ZABBIX_DEB_FILE="zabbix-release_latest_${ZABBIX_VERSION}+debian13_all.deb"
+  else
+    ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb"
+    ZABBIX_DEB_FILE="zabbix-release_latest+debian13_all.deb"
+  fi
+
+  curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/"$ZABBIX_DEB_FILE"
+  $STD dpkg -i /tmp/"$ZABBIX_DEB_FILE"
+  rm -rf /tmp/zabbix-release_*.deb
   $STD apt update
 
   $STD apt install --only-upgrade zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql

--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -31,9 +31,17 @@ esac
 
 msg_info "Installing Zabbix $ZABBIX_VERSION"
 cd /tmp
-ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb"
-curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/zabbix-release_latest+debian13_all.deb
-$STD dpkg -i /tmp/zabbix-release_latest+debian13_all.deb
+
+if [[ "$ZABBIX_VERSION" == "7.0" ]]; then
+  ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/debian/pool/main/z/zabbix-release/zabbix-release_latest_${ZABBIX_VERSION}+debian13_all.deb"
+  ZABBIX_DEB_FILE="zabbix-release_latest_${ZABBIX_VERSION}+debian13_all.deb"
+else
+  ZABBIX_DEB_URL="https://repo.zabbix.com/zabbix/${ZABBIX_VERSION}/release/debian/pool/main/z/zabbix-release/zabbix-release_latest+debian13_all.deb"
+  ZABBIX_DEB_FILE="zabbix-release_latest+debian13_all.deb"
+fi
+
+curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/"$ZABBIX_DEB_FILE"
+$STD dpkg -i /tmp/"$ZABBIX_DEB_FILE"
 $STD apt update
 $STD apt install -y zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql zabbix-apache-conf zabbix-sql-scripts
 zcat /usr/share/zabbix/sql-scripts/postgresql/server.sql.gz | sudo -u "$PG_DB_USER" psql "$PG_DB_NAME" &>/dev/null
@@ -104,7 +112,7 @@ fi
 
 systemctl restart zabbix-server apache2
 systemctl enable -q --now zabbix-server $AGENT_SERVICE apache2
-rm -rf /tmp/zabbix-release_latest+debian13_all.deb
+rm -rf /tmp/zabbix-release_*.deb
 msg_ok "Started Services"
 
 motd_ssh


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Zabbix 7.0 uses different repository layout without release/ directory
- Package name includes version suffix for 7.0: zabbix-release_latest_7.0+debian13_all.deb
- Zabbix 7.4+ uses release/ directory with no version suffix

shit app.

## 🔗 Related Issue

Fixes #10105

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
