### PR TITLE
Fix cleanup issues in npm cache and rustup toolchain

### DIFF
--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -52,7 +52,7 @@ function update_script() {
     $STD yarn web:build
     $STD yarn prisma:deploy
     [ -d /opt/data.bak ] && mv /opt/data.bak /opt/linkwarden/data
-    rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache ~/.rustup
+    rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache
     rm -rf /root/.cache/yarn
     rm -rf /opt/linkwarden/.next/cache
     msg_ok "Updated ${APP}"

--- a/install/linkwarden-install.sh
+++ b/install/linkwarden-install.sh
@@ -62,7 +62,7 @@ EOF
 $STD yarn prisma:generate
 $STD yarn web:build
 $STD yarn prisma:deploy
-rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache ~/.rustup
+rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache
 rm -rf /root/.cache/yarn
 rm -rf /opt/linkwarden/.next/cache
 msg_ok "Installed Linkwarden"

--- a/misc/core.func
+++ b/misc/core.func
@@ -816,7 +816,10 @@ cleanup_lxc() {
   fi
 
   # Node.js npm
-  if command -v npm &>/dev/null; then $STD npm cache clean --force || true; fi
+  if command -v npm &>/dev/null; then
+    $STD npm cache verify 2>/dev/null || true
+    $STD npm cache clean --force 2>/dev/null || true
+  fi
   # Node.js yarn
   if command -v yarn &>/dev/null; then $STD yarn cache clean || true; fi
   # Node.js pnpm


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Issue 1 - BentoPDF (npm cache clean failure):
- npm cache clean --force can fail with ENOTEMPTY on corrupted caches
- Added npm cache verify before clean to detect/fix corruption
- Explicitly redirect stderr to suppress error noise

Issue 2 - Linkwarden (rustup toolchain removed too early):
- Script deleted ~/.rustup during build cleanup
- Later cleanup_lxc() tried to run 'cargo clean' without toolchain
- Now only remove cargo cache dirs, preserve ~/.rustup toolchain

## 🔗 Related Issue

Fixes #10092 #10093

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
