### PR TITLE
[Fix]Jotty: run cleanup after update

### DIFF
--- a/ct/jotty.sh
+++ b/ct/jotty.sh
@@ -59,6 +59,7 @@ function update_script() {
     systemctl start jotty
     msg_ok "Started Service"
     rm /opt/data_config.tar
+    cleanup_lxc
     msg_ok "Updated successfully!"
   fi
   exit


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- fixes #10117
- but end users may need to manually run `yarn cache clean` themselves once before updating

## 🔗 Related Issue

Fixes #10117 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
