### PR TITLE
Zabbix: Add version-specific SQL script path for 7.0 LTS

### DIFF
--- a/install/zabbix-install.sh
+++ b/install/zabbix-install.sh
@@ -44,7 +44,14 @@ curl -fsSL "$ZABBIX_DEB_URL" -o /tmp/"$ZABBIX_DEB_FILE"
 $STD dpkg -i /tmp/"$ZABBIX_DEB_FILE"
 $STD apt update
 $STD apt install -y zabbix-server-pgsql zabbix-frontend-php php8.4-pgsql zabbix-apache-conf zabbix-sql-scripts
-zcat /usr/share/zabbix/sql-scripts/postgresql/server.sql.gz | sudo -u "$PG_DB_USER" psql "$PG_DB_NAME" &>/dev/null
+
+if [[ "$ZABBIX_VERSION" == "7.0" ]]; then
+  ZABBIX_SQL="/usr/share/zabbix-sql-scripts/postgresql/server.sql.gz"
+else
+  ZABBIX_SQL="/usr/share/zabbix/sql-scripts/postgresql/server.sql.gz"
+fi
+
+zcat "$ZABBIX_SQL" | sudo -u "$PG_DB_USER" psql "$PG_DB_NAME" &>/dev/null
 sed -i "s/^DBName=.*/DBName=$PG_DB_NAME/" /etc/zabbix/zabbix_server.conf
 sed -i "s/^DBUser=.*/DBUser=$PG_DB_USER/" /etc/zabbix/zabbix_server.conf
 sed -i "s/^# DBPassword=.*/DBPassword=$PG_DB_PASS/" /etc/zabbix/zabbix_server.conf


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Fixes installation failure for Zabbix 7.0 LTS caused by incorrect SQL script path.

Zabbix 7.0 LTS uses a different directory structure than 7.4 and 8.0:
- Zabbix 7.0 LTS: /usr/share/zabbix-sql-scripts/postgresql/server.sql.gz
- Zabbix 7.4+:    /usr/share/zabbix/sql-scripts/postgresql/server.sql.gz

## 🔗 Related Issue

Fixes #10109

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
