### PR TITLE
fix: removed verbose option to avoid unnecessary output

### DIFF
--- a/tools/pve/execute.sh
+++ b/tools/pve/execute.sh
@@ -50,7 +50,7 @@ function execute_in() {
   container=$1
   name=$(pct exec "$container" hostname)
   echo -e "${BL}[Info]${GN} Execute inside${BL} ${name}${GN} with output: ${CL}"
-    if !   pct exec "$container" -- bash -c "command -v ${custom_command} >/dev/null 2>&1"
+    if !   pct exec "$container" -- bash -c "command ${custom_command} >/dev/null 2>&1"
       then
         echo -e "${BL}[Info]${GN} Skipping ${name} ${RD}$container has no command: ${custom_command}"
       else


### PR DESCRIPTION
The "command" command had a verbose option that produced additional but unnecessary output (The path where the command is located.).  The function is not affected.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
