### PR TITLE
Fix AMD GPU firmware installation by adding non-free repositories

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2734,11 +2734,57 @@ EOF
       return 1
     }
 
-    # AMD firmware for better GPU support
+    # For AMD GPUs, firmware-amd-graphics requires non-free repositories
     if [[ "$os_id" == "debian" ]]; then
-      $STD apt -y install firmware-amd-graphics 2>/dev/null || true
+      # Add non-free-firmware repository if not already present
+      if [[ ! -f /etc/apt/sources.list.d/non-free-firmware.sources ]]; then
+        if [[ "$os_codename" == "bookworm" ]]; then
+          cat <<EOF >/etc/apt/sources.list.d/non-free-firmware.sources
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: bookworm bookworm-updates
+Components: non-free-firmware
+
+Types: deb
+URIs: http://deb.debian.org/debian-security
+Suites: bookworm-security
+Components: non-free-firmware
+EOF
+        elif [[ "$os_codename" == "trixie" || "$os_codename" == "sid" ]]; then
+          cat <<EOF >/etc/apt/sources.list.d/non-free-firmware.sources
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: trixie trixie-updates
+Components: non-free-firmware
+
+Types: deb
+URIs: http://deb.debian.org/debian-security
+Suites: trixie-security
+Components: non-free-firmware
+EOF
+        fi
+        $STD apt update
+      fi
+
+      # Install AMD firmware and libdrm
+      $STD apt -y install libdrm-amdgpu1 firmware-amd-graphics 2>/dev/null || {
+        msg_warn "Failed to install AMD firmware - may need manual installation"
+      }
+    elif [[ "$os_id" == "ubuntu" ]]; then
+      # For Ubuntu, ensure multiverse is enabled (firmware-amd-graphics is in multiverse)
+      if ! grep -qE '^deb.*multiverse' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null; then
+        $STD add-apt-repository -y multiverse
+        $STD apt update
+      fi
+      
+      # Install AMD firmware and libdrm
+      $STD apt -y install libdrm-amdgpu1 firmware-amd-graphics 2>/dev/null || {
+        msg_warn "Failed to install AMD firmware - may need manual installation"
+      }
+    else
+      # For other distributions, try without adding repositories
+      $STD apt -y install libdrm-amdgpu1 2>/dev/null || true
     fi
-    $STD apt -y install libdrm-amdgpu1 2>/dev/null || true
     ;;
 
   NVIDIA)


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add non-free-firmware repository for Debian before attempting to install firmware-amd-graphics
- Support both Debian Bookworm (12) and Trixie (13)/Sid
- Install firmware-amd-graphics for all AMD GPUs detected, not just APUs
- Improve error handling with warning message if firmware installation fails


## 🔗 Related Issue

Fixes #10177

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
