### PR TITLE
Optimize Jotty installation with standalone mode

### DIFF
--- a/ct/jotty.sh
+++ b/ct/jotty.sh
@@ -48,6 +48,17 @@ function update_script() {
     $STD yarn --frozen-lockfile
     $STD yarn next telemetry disable
     $STD yarn build
+
+    [ -d "public" ] && cp -r public .next/standalone/
+    [ -d "howto" ] && cp -r howto .next/standalone/
+    mkdir -p .next/standalone/.next
+    cp -r .next/static .next/standalone/.next/
+
+    mv .next/standalone /tmp/jotty_standalone
+    rm -rf * .next .git .gitignore .yarn
+    mv /tmp/jotty_standalone/* .
+    mv /tmp/jotty_standalone/.[!.]* . 2>/dev/null || true
+    rm -rf /tmp/jotty_standalone
     msg_ok "Updated jotty"
 
     msg_info "Restoring configuration & data"

--- a/ct/jotty.sh
+++ b/ct/jotty.sh
@@ -66,6 +66,24 @@ function update_script() {
     $STD tar -xf /opt/data_config.tar
     msg_ok "Restored configuration & data"
 
+    msg_info "Updating Service"
+    cat <<EOF >/etc/systemd/system/jotty.service
+[Unit]
+Description=jotty server
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/jotty
+EnvironmentFile=/opt/jotty/.env
+ExecStart=/usr/bin/node server.js
+Restart=on-abnormal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    msg_ok "Updated Service"
+
     msg_info "Starting Service"
     systemctl start jotty
     msg_ok "Started Service"

--- a/install/jotty-install.sh
+++ b/install/jotty-install.sh
@@ -21,6 +21,18 @@ cd /opt/jotty
 $STD yarn --frozen-lockfile
 $STD yarn next telemetry disable
 $STD yarn build
+
+[ -d "public" ] && cp -r public .next/standalone/
+[ -d "howto" ] && cp -r howto .next/standalone/
+mkdir -p .next/standalone/.next
+cp -r .next/static .next/standalone/.next/
+
+mv .next/standalone /tmp/jotty_standalone
+rm -rf * .next .git .gitignore .yarn
+mv /tmp/jotty_standalone/* .
+mv /tmp/jotty_standalone/.[!.]* . 2>/dev/null || true
+rm -rf /tmp/jotty_standalone
+
 mkdir -p data/{users,checklists,notes}
 
 cat <<EOF >/opt/jotty/.env
@@ -55,7 +67,7 @@ After=network.target
 [Service]
 WorkingDirectory=/opt/jotty
 EnvironmentFile=/opt/jotty/.env
-ExecStart=yarn start
+ExecStart=/usr/bin/node server.js
 Restart=on-abnormal
 
 [Install]


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Use Next.js standalone mode to reduce folder size from ~2.4GB to ~80MB
- Copy public, howto, and static folders to standalone output
- Remove node_modules and build artifacts after creating standalone version
- Update systemd service to use node directly instead of yarn start
- Improves build efficiency and reduces disk usage

Implements #10178

## 🔗 Related Issue

Fixes #10178

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
