### PR TITLE
recyclarr: add default daily cron job for recyclarr sync

### DIFF
--- a/frontend/public/json/recyclarr.json
+++ b/frontend/public/json/recyclarr.json
@@ -31,5 +31,14 @@
     "username": null,
     "password": null
   },
-  "notes": []
+  "notes": [
+    {
+      "type": "warning",
+      "content": "Configure your Radarr/Sonarr instances in `/root/.config/recyclarr/recyclarr.yml` before the first sync."
+    },
+    {
+      "type": "info",
+      "content": "Automatic daily sync is configured via `/etc/cron.d/recyclarr`. Sync logs are saved to `/root/.config/recyclarr/sync.log`."
+    }
+  ]
 }

--- a/install/recyclarr-install.sh
+++ b/install/recyclarr-install.sh
@@ -24,6 +24,14 @@ mkdir -p /root/.config/recyclarr
 $STD recyclarr config create
 msg_ok "Configured Recyclarr"
 
+msg_info "Setting up Daily Sync Cron"
+cat <<EOF >/etc/cron.d/recyclarr
+# Run recyclarr sync daily
+@daily root recyclarr sync >> /root/.config/recyclarr/sync.log 2>&1
+EOF
+chmod 644 /etc/cron.d/recyclarr
+msg_ok "Setup Daily Sync Cron"
+
 motd_ssh
 customize
 cleanup_lxc


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add daily cron entry to automatically sync recyclarr
Log output: /root/.config/recyclarr/sync.log


## 🔗 Related Issue

Fixes #10182

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
