### PR TITLE
tools.func - hwaccel: skip setup without GPU passthrough and fix Ubuntu AMD firmware

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2571,6 +2571,15 @@ function setup_gs() {
 #   - Some things are fetched from intel repositories due to not being in debian repositories.
 # ------------------------------------------------------------------------------
 function setup_hwaccel() {
+  # Check if GPU passthrough is enabled (device nodes must exist)
+  # /dev/dri = Intel iGPU, AMD GPU (open-source drivers)
+  # /dev/nvidia* = NVIDIA proprietary drivers
+  # /dev/kfd = AMD ROCm compute
+  if [[ ! -d /dev/dri && ! -e /dev/nvidia0 && ! -e /dev/kfd ]]; then
+    msg_warn "No GPU passthrough detected (/dev/dri, /dev/nvidia*, /dev/kfd not found) - skipping hardware acceleration setup"
+    return 0
+  fi
+
   msg_info "Setup Hardware Acceleration"
 
   if ! command -v lspci &>/dev/null; then
@@ -2771,15 +2780,11 @@ EOF
         msg_warn "Failed to install AMD firmware - may need manual installation"
       }
     elif [[ "$os_id" == "ubuntu" ]]; then
-      # For Ubuntu, ensure multiverse is enabled (firmware-amd-graphics is in multiverse)
-      if ! grep -qE '^deb.*multiverse' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null; then
-        $STD add-apt-repository -y multiverse
-        $STD apt update
-      fi
-      
-      # Install AMD firmware and libdrm
-      $STD apt -y install libdrm-amdgpu1 firmware-amd-graphics 2>/dev/null || {
-        msg_warn "Failed to install AMD firmware - may need manual installation"
+      # For Ubuntu, firmware-amd-graphics does not exist (it's Debian-specific from non-free-firmware)
+      # Ubuntu includes AMD firmware in linux-firmware package which is installed by default
+      # Only install libdrm-amdgpu1 for userspace driver support
+      $STD apt -y install libdrm-amdgpu1 2>/dev/null || {
+        msg_warn "Failed to install libdrm-amdgpu1 - may need manual installation"
       }
     else
       # For other distributions, try without adding repositories


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add /dev/dri check at start of setup_hwaccel() to skip when no GPU is passed through
- Remove firmware-amd-graphics installation on Ubuntu as it doesn't exist (Ubuntu includes AMD firmware in linux-firmware package by default)
- Only install libdrm-amdgpu1 on Ubuntu for userspace driver support

## 🔗 Related Issue

Fixes #10216

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
