### PR TITLE
[duplicati] Add 'DAEMON_OPTS' variable to allow passing arguments to the server

### DIFF
--- a/install/duplicati-install.sh
+++ b/install/duplicati-install.sh
@@ -38,7 +38,7 @@ Description=Duplicati Service
 After=network.target
 
 [Service]
-EnvironmentFile=-/etc/default/duplicati
+EnvironmentFile=/etc/default/duplicati
 ExecStart=/usr/bin/duplicati-server --webservice-interface=any --webservice-password=$ADMINPASS --settings-encryption-key=$DECRYPTKEY $DAEMON_OPTS
 Restart=always
 

--- a/install/duplicati-install.sh
+++ b/install/duplicati-install.sh
@@ -38,7 +38,8 @@ Description=Duplicati Service
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/duplicati-server --webservice-interface=any --webservice-password=$ADMINPASS --settings-encryption-key=$DECRYPTKEY
+EnvironmentFile=-/etc/default/duplicati
+ExecStart=/usr/bin/duplicati-server --webservice-interface=any --webservice-password=$ADMINPASS --settings-encryption-key=$DECRYPTKEY $DAEMON_OPTS
 Restart=always
 
 [Install]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Updated `/etc/systemd/system/duplicati.service` by adding `$DAEMON_OPTS` variable
According to the official documentation of [duplicati](https://docs.duplicati.com/community-docs/community-docs-installation#installing-duplicati-on-linux) 

The variable `DAEMON_OPTS=` is the commandline arguments passed to the server. The meaning of the options that are passed are described in [Other Command Line Utilities](https://docs.duplicati.com/en/latest/07-other-command-line-utilities/#duplicatiserverexe) 

Typical usecase:
Using duplicati behind a reverse proxy (nginx), the arguments `--webservice-allowed-hostnames=` and `--webservice-url-prefix=/duplicati` must be added

## 🔗 Related Issue
N/A - Identified during the configuration of duplicati with nginxproxymanager

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
