### PR TITLE
fix(phpipam): use PHP 8.4 with correct mysql module for PDO support

### DIFF
--- a/ct/phpipam.sh
+++ b/ct/phpipam.sh
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop apache2
     msg_ok "Stopped Service"
 
-    PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
+    PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
 
     msg_info "Installing PHP-PEAR"
     $STD apt install -y \

--- a/install/phpipam-install.sh
+++ b/install/phpipam-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y fping
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="pdo,pdo-mysql,gmp,snmp,ldap,apcu" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
 
 msg_info "Installing PHP-PEAR"
 $STD apt install -y \
@@ -39,7 +39,7 @@ sed -i -e "s/\(\$disable_installer = \).*/\1true;/" \
   -e "s/\(\$db\['pass'\] = \).*/\1'$MARIADB_DB_PASS';/" \
   -e "s/\(\$db\['name'\] = \).*/\1'$MARIADB_DB_NAME';/" \
   /opt/phpipam/config.php
-sed -i '/max_execution_time/s/= .*/= 600/' /etc/php/8.3/apache2/php.ini
+sed -i '/max_execution_time/s/= .*/= 600/' /etc/php/8.4/apache2/php.ini
 msg_ok "Installed phpIPAM"
 
 msg_info "Creating Service"


### PR DESCRIPTION
Fixes #9132

## Problem
The phpIPAM ping/discovery scan fails with:
```
Could not connect to database! could not find driver
```

## Root Cause
1. The install script used `pdo,pdo-mysql` as PHP modules, but:
   - `pdo` is not a separate package (included in php-common)
   - `pdo-mysql` is not a valid package name
2. The correct package is `php8.x-mysql` which includes both `mysqli` and `pdo_mysql` extensions

## Fix
- Changed PHP_VERSION from 8.3 to 8.4
- Replaced `pdo,pdo-mysql` with `mysql` (the correct module name)
- Updated php.ini path reference to 8.4
- Updated update script in ct/phpipam.sh accordingly

## Testing
Users in the issue confirmed that `apt install php8.4-mysql php8.4-gmp` resolves the problem.