### PR TITLE
phpipam: use PHP 8.4 with correct mysql module for PDO support

### DIFF
--- a/ct/phpipam.sh
+++ b/ct/phpipam.sh
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop apache2
     msg_ok "Stopped Service"
 
-    PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
+    PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
 
     msg_info "Installing PHP-PEAR"
     $STD apt install -y \

--- a/install/phpipam-install.sh
+++ b/install/phpipam-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y fping
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="pdo,pdo-mysql,gmp,snmp,ldap,apcu" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql,gmp,snmp,ldap,apcu" setup_php
 
 msg_info "Installing PHP-PEAR"
 $STD apt install -y \
@@ -39,7 +39,7 @@ sed -i -e "s/\(\$disable_installer = \).*/\1true;/" \
   -e "s/\(\$db\['pass'\] = \).*/\1'$MARIADB_DB_PASS';/" \
   -e "s/\(\$db\['name'\] = \).*/\1'$MARIADB_DB_NAME';/" \
   /opt/phpipam/config.php
-sed -i '/max_execution_time/s/= .*/= 600/' /etc/php/8.3/apache2/php.ini
+sed -i '/max_execution_time/s/= .*/= 600/' /etc/php/8.4/apache2/php.ini
 msg_ok "Installed phpIPAM"
 
 msg_info "Creating Service"


### PR DESCRIPTION



<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Changed PHP_VERSION from 8.3 to 8.4
- Replaced 'pdo,pdo-mysql' with 'mysql' (php8.4-mysql includes pdo_mysql)
- Updated php.ini path reference to 8.4
- Updated update script in ct/phpipam.sh accordingly


## 🔗 Related Issue

Fixes #9132

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
