### PR TITLE
Changed whiptail tags for update to enable first letter hot-key

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2021-2025 community-scripts ORG
 # Author: tteck (tteckster) | MickLesk | michelroegl-brunner
+# Co-Author: DerDingsCS
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/branch/main/LICENSE
 
 # ==============================================================================
@@ -2640,23 +2641,27 @@ start() {
     update_script
     cleanup_lxc
   else
+# Use proper tags in whiptail menu to enable usage of the first letter as hot-key
+# - s/S for "Silent Mode" "YES (Silent Mode)"
+# - v/V for "Verbose Mode" "YES (Verbose Mode)"
+# - c/C for Cancel update/setting
     CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
       "Support/Update functions for ${APP} LXC. Choose an option:" \
       12 60 3 \
-      "1" "YES (Silent Mode)" \
-      "2" "YES (Verbose Mode)" \
-      "3" "NO (Cancel Update)" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
+      "Silent Mode" "YES (Silent Mode)" \
+      "Verbose Mode" "YES (Verbose Mode)" \
+      "Cancel" "NO (Cancel Update)" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
 
     case "$CHOICE" in
-    1)
+    "Silent Mode")
       VERBOSE="no"
       set_std_mode
       ;;
-    2)
+  "Verbose Mode")
       VERBOSE="yes"
       set_std_mode
       ;;
-    3)
+  "Cancel")
       clear
       exit_script
       exit

--- a/misc/build.func
+++ b/misc/build.func
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Copyright (c) 2021-2025 community-scripts ORG
-# Author: tteck (tteckster) | MickLesk | michelroegl-brunner
-# Co-Author: DerDingsCS
+# Author: tteck (tteckster) | MickLesk | michelroegl-brunner | DerDingsCS
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/branch/main/LICENSE
 
 # ==============================================================================
@@ -2642,15 +2641,15 @@ start() {
     cleanup_lxc
   else
 # Use proper tags in whiptail menu to enable usage of the first letter as hot-key
-# - s/S for "Silent Mode" "YES (Silent Mode)"
-# - v/V for "Verbose Mode" "YES (Verbose Mode)"
-# - c/C for Cancel update/setting
+# - s/S for "Silent Mode"
+# - v/V for "Verbose Mode"
+# - c/C for Cancel 
     CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
       "Support/Update functions for ${APP} LXC. Choose an option:" \
       12 60 3 \
-      "Silent Mode" "YES (Silent Mode)" \
-      "Verbose Mode" "YES (Verbose Mode)" \
-      "Cancel" "NO (Cancel Update)" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
+      "Silent Mode" "Update in Silent Mode" \
+      "Verbose Mode" "Update in Verbose Mode" \
+      "Cancel" "Cancel Update" --nocancel --default-item "1" 3>&1 1>&2 2>&3)
 
     case "$CHOICE" in
     "Silent Mode")


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
According to the `whiptail` man page, menu item tags must begin with a letter in order to support hotkeys.

Therefore, the tags were changed from `"1", "2", "3"` to `"Silent Mode", "Verbose Mode", and "Cancel"`.

As a result, updates can now be automated using a simple `expect` script, for example:
```
expect <<EOF
    set timeout 5
    spawn update
    after 200
    send  "V\\r"
    expect eof
EOF
```

This is similar in spirit to [The Ultimater for Proxmox VE](https://github.com/BassT23/Proxmox) which will not work for me.


This is my first pull request.
I’m happy to address any feedback or requested changes.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [**X**] **Self-review completed** – Code follows project standards.
- [**X**] **Tested thoroughly** – Changes work as expected.
- [**X**] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
