### PR TITLE
Linkwarden: enable Corepack and prepare Yarn v4 before running yarn

### DIFF
--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -42,9 +42,8 @@ function update_script() {
 
     fetch_and_deploy_gh_release "linkwarden" "linkwarden/linkwarden"
 
-    msg_info "Updating ${APP}"
+    msg_info "Updating Linkwarden"
     cd /opt/linkwarden
-    # Determine pinned Yarn version from package.json (e.g. "yarn@4.12.0+sha512...")
     yarn_ver="4.12.0"
     if [[ -f package.json ]]; then
       pkg_manager=$(jq -r '.packageManager // empty' package.json 2>/dev/null || true)
@@ -68,7 +67,7 @@ function update_script() {
     rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache
     rm -rf /root/.cache/yarn
     rm -rf /opt/linkwarden/.next/cache
-    msg_ok "Updated ${APP}"
+    msg_ok "Updated Linkwarden"
 
     msg_info "Starting Service"
     systemctl start linkwarden

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -44,12 +44,10 @@ function update_script() {
 
     msg_info "Updating ${APP}"
     cd /opt/linkwarden
-    msg_info "Enabling Corepack and preparing Yarn v4"
     if command -v corepack >/dev/null 2>&1; then
       $STD corepack enable
       $STD corepack prepare yarn@4.12.0 --activate || true
     fi
-    msg_ok "Corepack enabled"
     $STD yarn
     $STD npx playwright install-deps
     $STD yarn playwright install

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -44,9 +44,18 @@ function update_script() {
 
     msg_info "Updating ${APP}"
     cd /opt/linkwarden
+    # Determine pinned Yarn version from package.json (e.g. "yarn@4.12.0+sha512...")
+    yarn_ver="4.12.0"
+    if [[ -f package.json ]]; then
+      pkg_manager=$(jq -r '.packageManager // empty' package.json 2>/dev/null || true)
+      if [[ -n "$pkg_manager" && "$pkg_manager" == yarn@* ]]; then
+        yarn_spec="${pkg_manager#yarn@}"
+        yarn_ver="${yarn_spec%%+*}"
+      fi
+    fi
     if command -v corepack >/dev/null 2>&1; then
       $STD corepack enable
-      $STD corepack prepare yarn@4.12.0 --activate || true
+      $STD corepack prepare "yarn@${yarn_ver}" --activate || true
     fi
     $STD yarn
     $STD npx playwright install-deps

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -44,6 +44,12 @@ function update_script() {
 
     msg_info "Updating ${APP}"
     cd /opt/linkwarden
+    msg_info "Enabling Corepack and preparing Yarn v4"
+    if command -v corepack >/dev/null 2>&1; then
+      $STD corepack enable
+      $STD corepack prepare yarn@4.12.0 --activate || true
+    fi
+    msg_ok "Corepack enabled"
     $STD yarn
     $STD npx playwright install-deps
     $STD yarn playwright install

--- a/install/linkwarden-install.sh
+++ b/install/linkwarden-install.sh
@@ -54,7 +54,7 @@ IP=$(hostname -I | awk '{print $1}')
 cat <<EOF >/opt/linkwarden/.env
 NEXTAUTH_SECRET=${SECRET_KEY}
 NEXTAUTH_URL=http://${IP}:3000
-DATABASE_URL=postgresql://${DB_USER}:${DB_PASS}@localhost:5432/${DB_NAME}
+DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}
 EOF
 $STD yarn prisma:generate
 $STD yarn web:build

--- a/install/linkwarden-install.sh
+++ b/install/linkwarden-install.sh
@@ -50,6 +50,12 @@ fi
 msg_info "Installing Linkwarden (Patience)"
 fetch_and_deploy_gh_release "linkwarden" "linkwarden/linkwarden"
 cd /opt/linkwarden
+msg_info "Enabling Corepack and preparing Yarn v4"
+if command -v corepack >/dev/null 2>&1; then
+  $STD corepack enable
+  $STD corepack prepare yarn@4.12.0 --activate || true
+fi
+msg_ok "Corepack enabled"
 $STD yarn
 $STD npx playwright install-deps
 $STD yarn playwright install


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Enable Corepack and prepare Yarn v4 before running yarn to address Linkwarden v2.13.3 install issues (corepack required for Yarn v4).
Use Local packagemanager for dynamic yarn version
refactored to setup_postgres_db


## 🔗 Related Issue

Fixes #10243

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
