### PR TITLE
add libmfx-gen1.2 for intel gpu hwaccel

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2639,6 +2639,7 @@ function setup_hwaccel() {
         ocl-icd-libopencl1 \
         intel-opencl-icd \
         vainfo \
+        libmfx-gen1.2 \
         intel-gpu-tools || {
         msg_error "Failed to install Intel GPU dependencies"
         return 1
@@ -2666,6 +2667,7 @@ EOF
             ocl-icd-libopencl1 \
             intel-opencl-icd \
             vainfo \
+            libmfx-gen1.2 \
             intel-gpu-tools || {
             msg_warn "Non-free driver install failed, falling back to open drivers"
             needs_nonfree=false
@@ -2694,6 +2696,7 @@ EOF
             mesa-va-drivers \
             libvpl2 \
             vainfo \
+            libmfx-gen1.2 \
             intel-gpu-tools 2>/dev/null || {
             msg_warn "Non-free driver install failed, falling back to open drivers"
             needs_nonfree=false


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Found this issue with Tdarr where hardware acceleration did not work on my Intel Arc A380.
Link to necessary package: https://packages.debian.org/trixie/libmfx-gen1.2
Log from Tdarr:
```
2025-12-28T10:35:53.905Z qTnz-i_01:Node[bulky-bass]:Worker[moral-mule]:Running /opt/tdarr/Tdarr_Node/assets/app/ffmpeg/linux_x64/ffmpeg -y -hwaccel qsv -i /mnt/input.mkv -map 0:0 -c:0 hevc_qsv -global_quality 20 -preset medium -map 0:1 -c:1 copy -look_ahead 1 /mnt/output/transcode/tdarr-workDir2-qTnz-i_01/1766939751641/input.mkv
...
2025-12-28T10:35:53.905Z [AVHWDeviceContext @ 0x5d507a8fa480] Error creating a MFX session: -9.
2025-12-28T10:35:53.905Z [AVHWDeviceContext @ 0x5d507a8fa480] Error initializing an MFX session: -3.
2025-12-28T10:35:53.905Z Device creation failed: -1313558101.
2025-12-28T10:35:53.905Z [vist#0:0/av1 @ 0x5d507a8faec0] [dec:av1_qsv @ 0x5d507a8fdac0] No device available for decoder: device type qsv needed for codec av1_qsv.
2025-12-28T10:35:53.905Z [vist#0:0/av1 @ 0x5d507a8faec0] [dec:av1_qsv @ 0x5d507a8fdac0] Hardware device setup failed for decoder: Unknown error occurred
```

The above errors out on decoding, so if I remove hardware decoding in favor of software decoding this is the error for hardware encoding
```
root@tdarr:/opt/tdarr/Tdarr_Node/assets/app/ffmpeg/linux_x64# ./ffmpeg -y -i /mnt/input.mkv -map 0:0 -c:0 hevc_qsv -global_quality 20 -preset medium -map 0:1 -c:1 copy -look_ahead 1 /mnt/test.mkv
...
[hevc_qsv @ 0x573c60e9f200] Error creating a MFX session: -9.
[hevc_qsv @ 0x573c60e9f200] Error initializing a MFX session: unsupported (-3)
[vost#0:0/hevc_qsv @ 0x573c60ecf0c0] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
[vf#0:0 @ 0x573c60ed0080] Error sending frames to consumers: Unknown error occurred
[vf#0:0 @ 0x573c60ed0080] Task finished with error code: -1313558101 (Unknown error occurred)
[vf#0:0 @ 0x573c60ed0080] Terminating thread with return code -1313558101 (Unknown error occurred)
[vost#0:0/hevc_qsv @ 0x573c60ecf0c0] Could not open encoder before EOF
[vost#0:0/hevc_qsv @ 0x573c60ecf0c0] Task finished with error code: -22 (Invalid argument)
[vost#0:0/hevc_qsv @ 0x573c60ecf0c0] Terminating thread with return code -22 (Invalid argument)
[out#0/matroska @ 0x573c60ea2340] Nothing was written into output file, because at least one of its streams received no packets.
frame=    0 fps=0.0 q=0.0 Lsize=       0KiB time=N/A bitrate=N/A speed=N/A    
Conversion failed!
```

Installing the above `libmfx-gen1.2` resolves this for me. I don't believe this library is needed for older generation Intel graphics, but I don't have the hardware to test with.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
