### PR TITLE
fix(wazuh): add LXC rootcheck exclusion to prevent false positives

### DIFF
--- a/install/wazuh-install.sh
+++ b/install/wazuh-install.sh
@@ -39,6 +39,14 @@ rm -f wazuh-*.sh
 rm -f ~/wazuh-install.output
 msg_ok "Setup Wazuh"
 
+# Fix LXC container false positives in rootcheck
+# When running Wazuh in an LXC container, /dev/.lxc/* paths trigger false alerts
+if [ -d /dev/.lxc ]; then
+  msg_info "Adding LXC rootcheck exclusion"
+  sed -i '/<\/rootcheck>/i \    <ignore>/dev/.lxc</ignore>' /var/ossec/etc/ossec.conf
+  msg_ok "Added LXC rootcheck exclusion"
+fi
+
 motd_ssh
 customize
 cleanup_lxc


### PR DESCRIPTION
## Summary

When Wazuh runs inside an LXC container (which is the default for this script), the `/dev/.lxc/*` bind mounts trigger false positive alerts from rootcheck (Rule 510) claiming 'possible hidden file' on /dev.

## Problem

After installing Wazuh via this script, the dashboard immediately shows multiple medium-severity alerts like:

```
Rule: 510 (level 7) -> 'Host-based anomaly detection event (rootcheck).'
File '/dev/.lxc/proc/vmallocinfo' present on /dev. Possible hidden file.
```

These are false positives - the `/dev/.lxc/` directory contains normal LXC container bind mounts for `/proc` entries.

## Solution

This PR adds an automatic check after Wazuh installation:
- If `/dev/.lxc` exists (indicating an LXC container), add an ignore rule to `/var/ossec/etc/ossec.conf`
- This prevents the spurious rootcheck alerts while maintaining security monitoring for actual concerns

## Testing

- Installed Wazuh via this script in a Proxmox LXC container
- Verified `/dev/.lxc` false positives no longer appear
- Confirmed other rootcheck functionality remains intact