### PR TITLE
fix(swizzin): Use HTTPS and add curl error handling

### DIFF
--- a/install/swizzin-install.sh
+++ b/install/swizzin-install.sh
@@ -23,7 +23,7 @@ if [[ ! "$CONFIRM" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   msg_error "Aborted by user. No changes have been made."
   exit 10
 fi
-bash <(curl -sL s5n.sh)
+bash <(curl -fsSL https://s5n.sh)
 
 motd_ssh
 customize


### PR DESCRIPTION
Add https:// to s5n.sh URL to ensure secure connection

## ✍️ Description
- Add https:// to s5n.sh URL to ensure https is used
- Add -f flag to fail on HTTP errors instead of piping error pages to bash
- Add -S flag to show errors even in silent mode

Without -f, if the server returns an error page (4xx/5xx), curl would pipe that HTML content to bash, causing unexpected behavior.

## 🔗 Related Issue

N/A identified during security audit

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
