### PR TITLE
fix(bazarr): update script now migrates old service files to use venv Python

### DIFF
--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -38,8 +38,13 @@ function update_script() {
     msg_info "Setup Bazarr"
     mkdir -p /var/lib/bazarr/
     chmod 775 /opt/bazarr /var/lib/bazarr/
+    # Always ensure venv exists
     if [[ ! -d /opt/bazarr/venv/ ]]; then
       $STD uv venv /opt/bazarr/venv --python 3.12
+    fi
+    
+    # Always check and fix service file if needed
+    if [[ -f /etc/systemd/system/bazarr.service ]] && grep -q "ExecStart=/usr/bin/python3" /etc/systemd/system/bazarr.service; then
       sed -i "s|ExecStart=/usr/bin/python3 /opt/bazarr/bazarr.py|ExecStart=/opt/bazarr/venv/bin/python3 /opt/bazarr/bazarr.py|g" /etc/systemd/system/bazarr.service
       systemctl daemon-reload
     fi


### PR DESCRIPTION
## ✍️ Description

- Separates venv creation from service file migration logic
- Always checks and fixes service file if it uses /usr/bin/python3
- Fixes installations created before October 28, 2025 that upgraded to Debian 13
- Ensures all users running update script get automatic migration
- Idempotent: safe to run multiple times

Resolves issue where Bazarr fails to start on Debian 13 with 'externally-managed-environment' error for installations created before the October 28, 2025 fix (commit 909dbc20c).

## 🔗 Related Issue

Fixes #10458 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.