### PR TITLE
Fix headscale Caddyfile to pass non-API URLs

### DIFF
--- a/install/headscale-install.sh
+++ b/install/headscale-install.sh
@@ -28,7 +28,7 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
 
 redir /admin /admin/
 
-handle_path /admin* {
+handle_path /admin/* {
     root * /opt/headscale-admin
     encode gzip zstd
 
@@ -36,14 +36,11 @@ handle_path /admin* {
         X-Content-Type-Options nosniff
     }
 
-    try_files {path} {path}/ /opt/headscale-admin/index.html
+    try_files {path} /opt/headscale-admin/index.html
     file_server
 }
 
-handle /api/* {
-    reverse_proxy localhost:8080
-}
-
+reverse_proxy localhost:8080
 EOF
   caddy fmt --overwrite /etc/caddy/Caddyfile
   systemctl start caddy


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Currently, headscale server is plain broken. With the latest Mac Tailscale client (1.92.3), upon clicking Settings → Accounts → Add Account Using Alternative Server, it just stalls and never connects to the server.

Similarly, from command line, it just hangs:

```
⏺ ~ % tailscale up --login-server=https://headscale.myhome.server --accept-routes --timeout 10s
2026/01/03 14:23:09 timeout waiting for Tailscale service to enter a Running state; check health with "tailscale status"
⏺ ~ % tailscale status
Logged out.
```

I traced this to `Caddyfile` only proxying `/admin` and `/api` and ignoring the rest paths. However, Headscale uses many others, e.g.:
- https://headscale.myhome.server/health
- https://headscale.myhome.server/register/REGISTER_KEY

With the fix, both the CLI and the GUI clients work fine.

## 🔗 Related Issue

There is no related issue. I am submitting the fix straight away.

Besides fixing the proxy behavior for non-admin endpoints, it slightly optimizes the admin config. The /admin123 alike URLs will no more be proxied, and I removed the unused `{path}/` (there are no legacy index listings in admin).

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
