### PR TITLE
reitti: add postgis extension to PostgreSQL DB setup

### DIFF
--- a/ct/reitti.sh
+++ b/ct/reitti.sh
@@ -28,6 +28,15 @@ function update_script() {
     exit
   fi
 
+  # Enable PostGIS extension if not already enabled
+  if systemctl is-active --quiet postgresql; then
+    if ! sudo -u postgres psql -d reitti -tAc "SELECT 1 FROM pg_extension WHERE extname='postgis'" 2>/dev/null | grep -q 1; then
+      msg_info "Enabling PostGIS extension"
+      sudo -u postgres psql -d reitti -c "CREATE EXTENSION IF NOT EXISTS postgis;" &>/dev/null
+      msg_ok "Enabled PostGIS extension"
+    fi
+  fi
+
   if [ ! -d /var/cache/nginx/tiles ]; then
     msg_info "Installing Nginx Tile Cache"
     mkdir -p /var/cache/nginx/tiles

--- a/ct/reitti.sh
+++ b/ct/reitti.sh
@@ -30,9 +30,9 @@ function update_script() {
 
   # Enable PostGIS extension if not already enabled
   if systemctl is-active --quiet postgresql; then
-    if ! sudo -u postgres psql -d reitti -tAc "SELECT 1 FROM pg_extension WHERE extname='postgis'" 2>/dev/null | grep -q 1; then
+    if ! sudo -u postgres psql -d reitti_db -tAc "SELECT 1 FROM pg_extension WHERE extname='postgis'" 2>/dev/null | grep -q 1; then
       msg_info "Enabling PostGIS extension"
-      sudo -u postgres psql -d reitti -c "CREATE EXTENSION IF NOT EXISTS postgis;" &>/dev/null
+      sudo -u postgres psql -d reitti_db -c "CREATE EXTENSION IF NOT EXISTS postgis;" &>/dev/null
       msg_ok "Enabled PostGIS extension"
     fi
   fi

--- a/install/reitti-install.sh
+++ b/install/reitti-install.sh
@@ -24,7 +24,7 @@ msg_ok "Installed Dependencies"
 
 JAVA_VERSION="25" setup_java
 PG_VERSION="17" PG_MODULES="postgis" setup_postgresql
-PG_DB_NAME="reitti_db" PG_DB_USER="reitti" setup_postgresql_db
+PG_DB_NAME="reitti_db" PG_DB_USER="reitti" PG_DB_EXTENSIONS="postgis" setup_postgresql_db
 
 msg_info "Configuring RabbitMQ"
 RABBIT_USER="reitti"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Sets the PG_DB_EXTENSIONS variable postgis when calling setup_postgresql_db, ensuring the PostGIS extension is enabled for the reitti_db database.


## 🔗 Related Issue

Fixes #10554 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
