### PR TITLE
openWRT: separate disk attachment and resizing in VM setup

### DIFF
--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -552,10 +552,14 @@ fi
 
 qm set "$VMID" \
   -efidisk0 "${STORAGE}:0,efitype=4m,size=4M" \
-  -scsi0 "${DISK_REF},size=${DISK_SIZE}" \
+  -scsi0 "${DISK_REF}" \
   -boot order=scsi0 \
   -tags community-script >/dev/null
-msg_ok "Attached disk (${DISK_SIZE})"
+msg_ok "Attached disk"
+
+msg_info "Resizing disk to ${DISK_SIZE}"
+qm disk resize "$VMID" scsi0 "${DISK_SIZE}" >/dev/null
+msg_ok "Resized disk to ${DISK_SIZE}"
 
 DESCRIPTION=$(
   cat <<EOF


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The script now attaches the disk without specifying size, then resizes it in a separate step. This improves clarity and ensures disk size is set explicitly after attachment.

## 🔗 Related Issue

Fixes #10465

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
