### PR TITLE
paperless-ai: Set TMPDIR for pip to use disk during install

### DIFF
--- a/install/paperless-ai-install.sh
+++ b/install/paperless-ai-install.sh
@@ -37,8 +37,12 @@ msg_info "Setup Paperless-AI"
 cd /opt/paperless-ai
 $STD python3 -m venv /opt/paperless-ai/venv
 source /opt/paperless-ai/venv/bin/activate
+# TMPDIR to use container disk instead of tmpfs for large pip downloads (https://github.com/community-scripts/ProxmoxVE/issues/10338)
+export TMPDIR=/opt/paperless-ai/tmp
+mkdir -p "$TMPDIR"
 $STD pip install --upgrade pip
 $STD pip install --no-cache-dir -r requirements.txt
+rm -rf "$TMPDIR"
 mkdir -p data/chromadb
 $STD npm ci --only=production
 mkdir -p /opt/paperless-ai/data


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Configures TMPDIR to use the container disk instead of tmpfs for large pip downloads, addressing issues with limited tmpfs space. The temporary directory is created before pip install and removed afterward.


## 🔗 Related Issue

Fixes #10338

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
