### PR TITLE
iptag: fix syntax error in VM config file parsing

### DIFF
--- a/tools/pve/add-iptag.sh
+++ b/tools/pve/add-iptag.sh
@@ -842,13 +842,11 @@ update_all_tags() {
     else
         # More efficient: direct file listing instead of ls+sed
         vmids=()
-        shopt -s nullglob
         for conf in /etc/pve/qemu-server/*.conf; do
             [[ -f "$conf" ]] || continue
-            local filename="${conf##*/}"
-            vmids+=("${filename%.conf}")
+            local basename="${conf##*/}"
+            vmids+=("${basename%.conf}")
         done
-        shopt -u nullglob
     fi
     
     count=${#vmids[@]}

--- a/tools/pve/add-iptag.sh
+++ b/tools/pve/add-iptag.sh
@@ -842,9 +842,13 @@ update_all_tags() {
     else
         # More efficient: direct file listing instead of ls+sed
         vmids=()
-        for conf in /etc/pve/qemu-server/*.conf 2>/dev/null; do
-            [[ -f "$conf" ]] && vmids+=("${conf##*/}" | sed 's/\.conf$//')
+        shopt -s nullglob
+        for conf in /etc/pve/qemu-server/*.conf; do
+            [[ -f "$conf" ]] || continue
+            local filename="${conf##*/}"
+            vmids+=("${filename%.conf}")
         done
+        shopt -u nullglob
     fi
     
     count=${#vmids[@]}


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Parameter expansion ${filename%.conf} instead of sed pipe - syntax error fixed

## 🔗 Related Issue

Fixes #10595

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
