### PR TITLE
Remove '--cpu' option from ExecStart command

### DIFF
--- a/install/comfyui-install.sh
+++ b/install/comfyui-install.sh
@@ -72,7 +72,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/opt/ComfyUI
-ExecStart=/opt/ComfyUI/venv/bin/python /opt/ComfyUI/main.py --listen --port 8188 --cpu
+ExecStart=/opt/ComfyUI/venv/bin/python /opt/ComfyUI/main.py --listen --port 8188
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
By default, the ExecStart in the system service includes the --cpu flag which forces ComfyUI to run entirely on CPU even if a GPU is present.  This commit removes that flag.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Unless there's a compelling reason for `--cpu` to be included in the ExecStart by default, this should be removed as it prevents the GPU from being utilized even if it is present. 

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
