### PR TITLE
fix: setup_mariadb hangs on

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -176,6 +176,7 @@ prepare_repository_setup() {
 
 # ------------------------------------------------------------------------------
 # Install packages with retry logic
+# Usage: install_packages_with_retry "mysql-server" "mysql-client"
 # ------------------------------------------------------------------------------
 install_packages_with_retry() {
   local packages=("$@")
@@ -205,6 +206,7 @@ install_packages_with_retry() {
 
 # ------------------------------------------------------------------------------
 # Upgrade specific packages with retry logic
+# Usage: upgrade_packages_with_retry "mariadb-server" "mariadb-client"
 # ------------------------------------------------------------------------------
 upgrade_packages_with_retry() {
   local packages=("$@")

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -176,7 +176,6 @@ prepare_repository_setup() {
 
 # ------------------------------------------------------------------------------
 # Install packages with retry logic
-# Usage: install_packages_with_retry "mysql-server" "mysql-client"
 # ------------------------------------------------------------------------------
 install_packages_with_retry() {
   local packages=("$@")
@@ -184,7 +183,10 @@ install_packages_with_retry() {
   local retry=0
 
   while [[ $retry -le $max_retries ]]; do
-    if $STD apt install -y "${packages[@]}" 2>/dev/null; then
+    if DEBIAN_FRONTEND=noninteractive $STD apt install -y \
+      -o Dpkg::Options::="--force-confdef" \
+      -o Dpkg::Options::="--force-confold" \
+      "${packages[@]}" 2>/dev/null; then
       return 0
     fi
 
@@ -203,7 +205,6 @@ install_packages_with_retry() {
 
 # ------------------------------------------------------------------------------
 # Upgrade specific packages with retry logic
-# Usage: upgrade_packages_with_retry "mariadb-server" "mariadb-client"
 # ------------------------------------------------------------------------------
 upgrade_packages_with_retry() {
   local packages=("$@")
@@ -211,7 +212,10 @@ upgrade_packages_with_retry() {
   local retry=0
 
   while [[ $retry -le $max_retries ]]; do
-    if $STD apt install --only-upgrade -y "${packages[@]}" 2>/dev/null; then
+    if DEBIAN_FRONTEND=noninteractive $STD apt install --only-upgrade -y \
+      -o Dpkg::Options::="--force-confdef" \
+      -o Dpkg::Options::="--force-confold" \
+      "${packages[@]}" 2>/dev/null; then
       return 0
     fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Fix an issue, where the config already exists and no dialogue is shown to the user, this tries to follow the default option rather than to wait inifinitely for user input

## 🔗 Related Issue

Fixes https://discord.com/channels/1302816934508630047/1421202270846189608/1457406503043469384

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
