### PR TITLE
tools.func: hwaccel - make beignet-opencl-icd optional for legacy Intel GPUs

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2926,8 +2926,15 @@ _setup_intel_legacy() {
     vainfo \
     intel-gpu-tools 2>/dev/null || msg_warn "Some Intel legacy packages failed"
 
-  # beignet provides OpenCL for older Intel GPUs (if available)
-  $STD apt -y install beignet-opencl-icd 2>/dev/null || true
+  # beignet provides OpenCL for older Intel GPUs (Sandy Bridge to Broadwell)
+  # Note: beignet-opencl-icd was removed in Debian 12+ and Ubuntu 22.04+
+  # Check if package is available before attempting installation
+  if apt-cache show beignet-opencl-icd &>/dev/null; then
+    $STD apt -y install beignet-opencl-icd 2>/dev/null || msg_warn "beignet-opencl-icd installation failed (optional)"
+  else
+    msg_warn "beignet-opencl-icd not available - OpenCL support for legacy Intel GPU limited"
+    msg_warn "Note: Hardware video encoding/decoding (VA-API) still works without OpenCL"
+  fi
 
   msg_ok "Intel Legacy GPU configured"
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Check if beignet-opencl-icd package is available before installation
- Package was removed in Debian 12+ and Ubuntu 22.04+
- VA-API hardware acceleration still works without OpenCL
- Prevents installation failure on systems with Intel HD 2000-5999 GPUs

## 🔗 Related Issue

Fixes #10676

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
