### PR TITLE
feat: Add Proxmox LXC and VM AutoScale installation scripts

### DIFF
--- a/frontend/public/json/proxmox-lxc-autoscale.json
+++ b/frontend/public/json/proxmox-lxc-autoscale.json
@@ -1,0 +1,56 @@
+{
+  "name": "Proxmox LXC AutoScale",
+  "slug": "proxmox-lxc-autoscale",
+  "categories": [
+    1
+  ],
+  "date_created": "2026-01-10",
+  "type": "pve",
+  "updateable": false,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/fabriziosalmi/proxmox-lxc-autoscale",
+  "website": "https://github.com/fabriziosalmi/proxmox-lxc-autoscale",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/proxmox.webp",
+  "config_path": "/opt/proxmox-lxc-autoscale/config.yaml",
+  "description": "LXC AutoScale is a resource management daemon specifically designed for Proxmox environments. It automatically adjusts CPU and memory allocations for LXC containers with no downtime based on real-time usage metrics and predefined thresholds. It supports horizontal scaling (cloning), container prioritization, energy efficiency mode, automatic backups, and notifications via email or Gotify.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "tools/pve/proxmox-lxc-autoscale.sh",
+      "resources": {
+        "cpu": null,
+        "ram": null,
+        "hdd": null,
+        "os": null,
+        "version": null
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Execute within the Proxmox VE shell",
+      "type": "info"
+    },
+    {
+      "text": "Requires LXCFS to be configured with the '-l' flag for proper loadavg retrieval",
+      "type": "warning"
+    },
+    {
+      "text": "Configuration file: /opt/proxmox-lxc-autoscale/config.yaml",
+      "type": "info"
+    },
+    {
+      "text": "Service commands: systemctl start/stop/status lxc_autoscale",
+      "type": "info"
+    },
+    {
+      "text": "Auto-config available: curl -sSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-lxc-autoscale/main/lxc_autoscale/lxc_autoscale_autoconf.sh | bash",
+      "type": "info"
+    }
+  ]
+}

--- a/frontend/public/json/proxmox-vm-autoscale.json
+++ b/frontend/public/json/proxmox-vm-autoscale.json
@@ -1,0 +1,60 @@
+{
+  "name": "Proxmox VM AutoScale",
+  "slug": "proxmox-vm-autoscale",
+  "categories": [
+    1
+  ],
+  "date_created": "2026-01-10",
+  "type": "pve",
+  "updateable": false,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/fabriziosalmi/proxmox-vm-autoscale",
+  "website": "https://github.com/fabriziosalmi/proxmox-vm-autoscale",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/proxmox.webp",
+  "config_path": "/opt/proxmox-vm-autoscale/config.yaml",
+  "description": "Proxmox VM AutoScale is a dynamic scaling service that automatically adjusts virtual machine (VM) resources (CPU cores and RAM) on your Proxmox Virtual Environment based on real-time metrics and user-defined thresholds. It supports multiple Proxmox hosts via SSH, auto-configures hotplug and NUMA, provides Gotify notifications, and includes billing support for web hosting providers.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "tools/pve/proxmox-vm-autoscale.sh",
+      "resources": {
+        "cpu": null,
+        "ram": null,
+        "hdd": null,
+        "os": null,
+        "version": null
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Execute within the Proxmox VE shell",
+      "type": "info"
+    },
+    {
+      "text": "Requires NUMA and Hotplug to be enabled on VMs for live scaling",
+      "type": "warning"
+    },
+    {
+      "text": "VM > Hardware > Processors > Enable NUMA, VM > Options > Hotplug > CPU & Memory",
+      "type": "info"
+    },
+    {
+      "text": "Configuration file: /opt/proxmox-vm-autoscale/config.yaml",
+      "type": "info"
+    },
+    {
+      "text": "Service commands: systemctl start/stop/status vm_autoscale",
+      "type": "info"
+    },
+    {
+      "text": "Supports SSH key and password authentication for multi-host management",
+      "type": "info"
+    }
+  ]
+}

--- a/tools/pve/proxmox-lxc-autoscale.sh
+++ b/tools/pve/proxmox-lxc-autoscale.sh
@@ -153,15 +153,25 @@ elif [[ -f "config.yaml" ]]; then
   CONFIG_FILE="config.yaml"
 fi
 
-# Restore backed up config if exists
-if [[ -f "/tmp/lxc_autoscale_config_backup.yaml" ]]; then
-  if [[ -n "$CONFIG_FILE" ]]; then
+# Restore backed up config if exists, and report accurate status
+if [[ -n "$CONFIG_FILE" ]]; then
+  if [[ -f "/tmp/lxc_autoscale_config_backup.yaml" ]]; then
     cp "/tmp/lxc_autoscale_config_backup.yaml" "$CONFIG_FILE"
     rm -f "/tmp/lxc_autoscale_config_backup.yaml"
     msg_ok "Previous configuration restored"
+  else
+    if [[ -f "$CONFIG_FILE" ]]; then
+      msg_ok "Default configuration created"
+    else
+      msg_error "Configuration file '$CONFIG_FILE' not found after setup"
+    fi
   fi
 else
-  msg_ok "Default configuration created"
+  if [[ -f "/tmp/lxc_autoscale_config_backup.yaml" ]]; then
+    msg_error "Found configuration backup but could not determine destination CONFIG_FILE"
+  else
+    msg_error "No configuration file could be determined"
+  fi
 fi
 
 # Determine the main Python script

--- a/tools/pve/proxmox-lxc-autoscale.sh
+++ b/tools/pve/proxmox-lxc-autoscale.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Fabrizio Salmi (fabriziosalmi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/fabriziosalmi/proxmox-lxc-autoscale
+
+function header_info() {
+  clear
+  cat <<"EOF"
+    __   _  ________   ___         __       _____            __   
+   / /  | |/ / ____/  /   | __  __/ /_____ / ___/_________ _/ /__ 
+  / /   |   / /      / /| |/ / / / __/ __ \\__ \/ ___/ __ `/ / _ \
+ / /___/   / /___   / ___ / /_/ / /_/ /_/ /__/ / /__/ /_/ / /  __/
+/_____/_/|_\____/  /_/  |_\__,_/\__/\____/____/\___/\__,_/_/\___/ 
+                                                                  
+EOF
+}
+
+set -eEuo pipefail
+
+# Color definitions
+YW=$(echo "\033[33m")
+BL=$(echo "\033[36m")
+RD=$(echo "\033[01;31m")
+GN=$(echo "\033[1;92m")
+CL=$(echo "\033[m")
+CM="${GN}✔${CL}"
+CROSS="${RD}✖${CL}"
+
+INSTALL_DIR="/opt/proxmox-lxc-autoscale"
+SERVICE_NAME="lxc_autoscale"
+REPO_URL="https://github.com/fabriziosalmi/proxmox-lxc-autoscale.git"
+
+function msg_info() {
+  local msg="$1"
+  echo -e "${BL}[INFO]${CL} ${msg}..."
+}
+
+function msg_ok() {
+  local msg="$1"
+  echo -e "${CM} ${msg}"
+}
+
+function msg_error() {
+  local msg="$1"
+  echo -e "${CROSS} ${msg}"
+}
+
+header_info
+
+# Check if running on Proxmox host
+if ! command -v pct &>/dev/null; then
+  msg_error "This script must be run on a Proxmox VE host."
+  exit 1
+fi
+
+echo -e "\n${YW}LXC AutoScale${CL} - Automatic resource scaling for LXC containers\n"
+echo -e "This script will install LXC AutoScale on your Proxmox host."
+echo -e "It automatically adjusts CPU and memory allocations based on real-time usage.\n"
+
+while true; do
+  read -p "Proceed with installation? (y/n): " yn
+  case $yn in
+    [Yy]*) break ;;
+    [Nn]*) echo "Installation cancelled."; exit 0 ;;
+    *) echo "Please answer yes or no." ;;
+  esac
+done
+
+header_info
+
+# Check for existing installation
+if [[ -d "$INSTALL_DIR" ]]; then
+  echo -e "\n${YW}Existing installation found at ${INSTALL_DIR}${CL}"
+  while true; do
+    read -p "Remove existing installation and reinstall? (y/n): " yn
+    case $yn in
+      [Yy]*) 
+        msg_info "Stopping existing service"
+        systemctl stop ${SERVICE_NAME}.service 2>/dev/null || true
+        systemctl disable ${SERVICE_NAME}.service 2>/dev/null || true
+        rm -f /etc/systemd/system/${SERVICE_NAME}.service
+        
+        # Backup existing config
+        if [[ -f "${INSTALL_DIR}/config.yaml" ]]; then
+          msg_info "Backing up existing configuration"
+          cp "${INSTALL_DIR}/config.yaml" "/tmp/lxc_autoscale_config_backup.yaml"
+          msg_ok "Configuration backed up to /tmp/lxc_autoscale_config_backup.yaml"
+        fi
+        
+        rm -rf "$INSTALL_DIR"
+        msg_ok "Existing installation removed"
+        break 
+        ;;
+      [Nn]*) echo "Installation cancelled."; exit 0 ;;
+      *) echo "Please answer yes or no." ;;
+    esac
+  done
+fi
+
+# Install dependencies
+msg_info "Installing dependencies (git, python3, python3-venv)"
+apt-get update -qq
+apt-get install -y -qq git python3 python3-pip python3-venv >/dev/null 2>&1
+msg_ok "Dependencies installed"
+
+# Clone repository
+msg_info "Cloning LXC AutoScale repository"
+git clone --depth 1 -q "$REPO_URL" "$INSTALL_DIR"
+msg_ok "Repository cloned to ${INSTALL_DIR}"
+
+# Setup Python virtual environment
+msg_info "Setting up Python virtual environment"
+cd "$INSTALL_DIR"
+python3 -m venv venv
+source venv/bin/activate
+
+# Install Python dependencies
+if [[ -f "requirements.txt" ]]; then
+  pip install --quiet --upgrade pip
+  pip install --quiet -r requirements.txt
+elif [[ -f "lxc_autoscale/requirements.txt" ]]; then
+  pip install --quiet --upgrade pip
+  pip install --quiet -r lxc_autoscale/requirements.txt
+else
+  # Install common dependencies
+  pip install --quiet --upgrade pip
+  pip install --quiet pyyaml requests
+fi
+deactivate
+msg_ok "Python environment configured"
+
+# Create configuration
+msg_info "Setting up configuration"
+cd "$INSTALL_DIR"
+
+# Find and setup config file
+CONFIG_FILE=""
+if [[ -f "lxc_autoscale/config.yaml.example" ]]; then
+  CONFIG_FILE="lxc_autoscale/config.yaml"
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    cp "lxc_autoscale/config.yaml.example" "$CONFIG_FILE"
+  fi
+elif [[ -f "config.yaml.example" ]]; then
+  CONFIG_FILE="config.yaml"
+  if [[ ! -f "$CONFIG_FILE" ]]; then
+    cp "config.yaml.example" "$CONFIG_FILE"
+  fi
+elif [[ -f "lxc_autoscale/config.yaml" ]]; then
+  CONFIG_FILE="lxc_autoscale/config.yaml"
+elif [[ -f "config.yaml" ]]; then
+  CONFIG_FILE="config.yaml"
+fi
+
+# Restore backed up config if exists
+if [[ -f "/tmp/lxc_autoscale_config_backup.yaml" ]]; then
+  if [[ -n "$CONFIG_FILE" ]]; then
+    cp "/tmp/lxc_autoscale_config_backup.yaml" "$CONFIG_FILE"
+    rm -f "/tmp/lxc_autoscale_config_backup.yaml"
+    msg_ok "Previous configuration restored"
+  fi
+else
+  msg_ok "Default configuration created"
+fi
+
+# Determine the main Python script
+MAIN_SCRIPT=""
+if [[ -f "${INSTALL_DIR}/lxc_autoscale/main.py" ]]; then
+  MAIN_SCRIPT="${INSTALL_DIR}/lxc_autoscale/main.py"
+elif [[ -f "${INSTALL_DIR}/main.py" ]]; then
+  MAIN_SCRIPT="${INSTALL_DIR}/main.py"
+elif [[ -f "${INSTALL_DIR}/lxc_autoscale/lxc_autoscale.py" ]]; then
+  MAIN_SCRIPT="${INSTALL_DIR}/lxc_autoscale/lxc_autoscale.py"
+else
+  msg_error "Could not find main Python script"
+  exit 1
+fi
+
+# Create systemd service
+msg_info "Creating systemd service"
+cat <<EOF >/etc/systemd/system/${SERVICE_NAME}.service
+[Unit]
+Description=Proxmox LXC AutoScale - Automatic resource scaling for LXC containers
+Documentation=https://github.com/fabriziosalmi/proxmox-lxc-autoscale
+After=network.target lxc.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${INSTALL_DIR}/venv/bin/python3 ${MAIN_SCRIPT}
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+NoNewPrivileges=false
+ProtectSystem=false
+ProtectHome=false
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable ${SERVICE_NAME}.service >/dev/null 2>&1
+msg_ok "Systemd service created and enabled"
+
+# Check LXCFS configuration
+header_info
+echo ""
+echo -e "${YW}╔═══════════════════════════════════════════════════════════════╗${CL}"
+echo -e "${YW}║              IMPORTANT: LXCFS CONFIGURATION                   ║${CL}"
+echo -e "${YW}╚═══════════════════════════════════════════════════════════════╝${CL}"
+echo ""
+echo -e "${RD}⚠ IMPORTANT:${CL} LXC AutoScale requires LXCFS to be properly configured."
+echo ""
+echo -e "You need to check ${BL}/lib/systemd/system/lxcfs.service${CL} for the ${GN}-l${CL} option"
+echo -e "which makes loadavg retrieval work correctly."
+echo ""
+echo -e "Required ExecStart line:"
+echo -e "  ${GN}ExecStart=/usr/bin/lxcfs /var/lib/lxcfs -l${CL}"
+echo ""
+echo -e "After modifying, run:"
+echo -e "  ${BL}systemctl daemon-reload && systemctl restart lxcfs${CL}"
+echo -e "  Then restart your LXC containers to apply the fix."
+echo ""
+
+# Check current LXCFS configuration
+LXCFS_SERVICE="/lib/systemd/system/lxcfs.service"
+if [[ -f "$LXCFS_SERVICE" ]]; then
+  if grep -q "ExecStart=/usr/bin/lxcfs /var/lib/lxcfs -l" "$LXCFS_SERVICE"; then
+    echo -e "${CM} LXCFS is already configured correctly with the -l flag."
+  elif grep -q "ExecStart=/usr/bin/lxcfs /var/lib/lxcfs$" "$LXCFS_SERVICE"; then
+    echo -e "${CROSS} LXCFS is ${RD}NOT${CL} configured with the -l flag!"
+    echo ""
+    while true; do
+      read -p "Would you like to automatically patch LXCFS? (y/n): " yn
+      case $yn in
+        [Yy]*) 
+          sed -i 's|ExecStart=/usr/bin/lxcfs /var/lib/lxcfs$|ExecStart=/usr/bin/lxcfs /var/lib/lxcfs -l|' "$LXCFS_SERVICE"
+          systemctl daemon-reload
+          systemctl restart lxcfs
+          msg_ok "LXCFS patched and restarted"
+          echo -e "${YW}Note:${CL} You should restart your LXC containers for the fix to take effect."
+          break 
+          ;;
+        [Nn]*) 
+          echo -e "${YW}Please manually configure LXCFS before using LXC AutoScale.${CL}"
+          break 
+          ;;
+        *) echo "Please answer yes or no." ;;
+      esac
+    done
+  fi
+fi
+
+echo ""
+echo -e "${YW}╔═══════════════════════════════════════════════════════════════╗${CL}"
+echo -e "${YW}║                    INSTALLATION COMPLETE                      ║${CL}"
+echo -e "${YW}╚═══════════════════════════════════════════════════════════════╝${CL}"
+echo ""
+echo -e "${GN}LXC AutoScale has been installed successfully!${CL}"
+echo ""
+echo -e "  ${BL}Installation directory:${CL} ${INSTALL_DIR}"
+if [[ -n "$CONFIG_FILE" ]]; then
+  echo -e "  ${BL}Configuration file:${CL}     ${INSTALL_DIR}/${CONFIG_FILE}"
+fi
+echo -e "  ${BL}Service name:${CL}           ${SERVICE_NAME}.service"
+echo ""
+echo -e "${YW}Commands:${CL}"
+echo -e "  Start service:   ${GN}systemctl start ${SERVICE_NAME}${CL}"
+echo -e "  Stop service:    ${GN}systemctl stop ${SERVICE_NAME}${CL}"
+echo -e "  Check status:    ${GN}systemctl status ${SERVICE_NAME}${CL}"
+echo -e "  View logs:       ${GN}journalctl -u ${SERVICE_NAME} -f${CL}"
+echo ""
+echo -e "${YW}Auto-config (optional):${CL}"
+echo -e "  Generate configuration for all LXC containers:"
+echo -e "  ${GN}curl -sSL https://raw.githubusercontent.com/fabriziosalmi/proxmox-lxc-autoscale/main/lxc_autoscale/lxc_autoscale_autoconf.sh | bash${CL}"
+echo ""
+
+# Ask to start service
+while true; do
+  read -p "Start the LXC AutoScale service now? (y/n): " yn
+  case $yn in
+    [Yy]*) 
+      systemctl start ${SERVICE_NAME}.service
+      msg_ok "Service started"
+      echo ""
+      systemctl status ${SERVICE_NAME}.service --no-pager
+      break 
+      ;;
+    [Nn]*) 
+      echo -e "\nYou can start the service later with: ${GN}systemctl start ${SERVICE_NAME}${CL}"
+      break 
+      ;;
+    *) echo "Please answer yes or no." ;;
+  esac
+done
+
+echo ""

--- a/tools/pve/proxmox-vm-autoscale.sh
+++ b/tools/pve/proxmox-vm-autoscale.sh
@@ -149,7 +149,7 @@ elif [[ ! -f "$CONFIG_FILE" ]]; then
     cp "config.yaml.example" "$CONFIG_FILE"
     msg_ok "Default configuration created from example"
   else
-    msg_ok "Using existing configuration"
+    msg_ok "No configuration file found - you'll need to create config.yaml manually"
   fi
 else
   msg_ok "Existing configuration preserved"

--- a/tools/pve/proxmox-vm-autoscale.sh
+++ b/tools/pve/proxmox-vm-autoscale.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Fabrizio Salmi (fabriziosalmi)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/fabriziosalmi/proxmox-vm-autoscale
+
+function header_info() {
+  clear
+  cat <<"EOF"
+ _    ____  ___   ___         __       _____            __   
+| |  / /  |/  /  /   | __  __/ /_____ / ___/_________ _/ /__ 
+| | / / /|_/ /  / /| |/ / / / __/ __ \\__ \/ ___/ __ `/ / _ \
+| |/ / /  / /  / ___ / /_/ / /_/ /_/ /__/ / /__/ /_/ / /  __/
+|___/_/  /_/  /_/  |_\__,_/\__/\____/____/\___/\__,_/_/\___/ 
+                                                              
+EOF
+}
+
+set -eEuo pipefail
+
+# Color definitions
+YW=$(echo "\033[33m")
+BL=$(echo "\033[36m")
+RD=$(echo "\033[01;31m")
+GN=$(echo "\033[1;92m")
+CL=$(echo "\033[m")
+CM="${GN}✔${CL}"
+CROSS="${RD}✖${CL}"
+
+INSTALL_DIR="/opt/proxmox-vm-autoscale"
+SERVICE_NAME="vm_autoscale"
+REPO_URL="https://github.com/fabriziosalmi/proxmox-vm-autoscale.git"
+
+function msg_info() {
+  local msg="$1"
+  echo -e "${BL}[INFO]${CL} ${msg}..."
+}
+
+function msg_ok() {
+  local msg="$1"
+  echo -e "${CM} ${msg}"
+}
+
+function msg_error() {
+  local msg="$1"
+  echo -e "${CROSS} ${msg}"
+}
+
+header_info
+
+# Check if running on Proxmox host
+if ! command -v qm &>/dev/null; then
+  msg_error "This script must be run on a Proxmox VE host."
+  exit 1
+fi
+
+echo -e "\n${YW}VM AutoScale${CL} - Automatic resource scaling for Virtual Machines\n"
+echo -e "This script will install VM AutoScale on your Proxmox host."
+echo -e "It automatically adjusts VM CPU and RAM based on real-time usage metrics.\n"
+echo -e "${YW}Features:${CL}"
+echo -e "  • Auto-scaling of VM CPU and RAM based on thresholds"
+echo -e "  • Multi-host support via SSH"
+echo -e "  • Auto-Hotplug & NUMA configuration"
+echo -e "  • Gotify notifications support"
+echo -e "  • Billing support for web hosters"
+echo ""
+
+while true; do
+  read -p "Proceed with installation? (y/n): " yn
+  case $yn in
+    [Yy]*) break ;;
+    [Nn]*) echo "Installation cancelled."; exit 0 ;;
+    *) echo "Please answer yes or no." ;;
+  esac
+done
+
+header_info
+
+# Check for existing installation
+if [[ -d "$INSTALL_DIR" ]]; then
+  echo -e "\n${YW}Existing installation found at ${INSTALL_DIR}${CL}"
+  while true; do
+    read -p "Remove existing installation and reinstall? (y/n): " yn
+    case $yn in
+      [Yy]*) 
+        msg_info "Stopping existing service"
+        systemctl stop ${SERVICE_NAME}.service 2>/dev/null || true
+        systemctl disable ${SERVICE_NAME}.service 2>/dev/null || true
+        rm -f /etc/systemd/system/${SERVICE_NAME}.service
+        
+        # Backup existing config
+        if [[ -f "${INSTALL_DIR}/config.yaml" ]]; then
+          msg_info "Backing up existing configuration"
+          cp "${INSTALL_DIR}/config.yaml" "/tmp/vm_autoscale_config_backup.yaml"
+          msg_ok "Configuration backed up to /tmp/vm_autoscale_config_backup.yaml"
+        fi
+        
+        rm -rf "$INSTALL_DIR"
+        msg_ok "Existing installation removed"
+        break 
+        ;;
+      [Nn]*) echo "Installation cancelled."; exit 0 ;;
+      *) echo "Please answer yes or no." ;;
+    esac
+  done
+fi
+
+# Install dependencies
+msg_info "Installing dependencies (git, python3, python3-venv)"
+apt-get update -qq
+apt-get install -y -qq git python3 python3-pip python3-venv >/dev/null 2>&1
+msg_ok "Dependencies installed"
+
+# Clone repository
+msg_info "Cloning VM AutoScale repository"
+git clone --depth 1 -q "$REPO_URL" "$INSTALL_DIR"
+msg_ok "Repository cloned to ${INSTALL_DIR}"
+
+# Setup Python virtual environment
+msg_info "Setting up Python virtual environment"
+cd "$INSTALL_DIR"
+python3 -m venv venv
+source venv/bin/activate
+
+# Install Python dependencies
+if [[ -f "requirements.txt" ]]; then
+  pip install --quiet --upgrade pip
+  pip install --quiet -r requirements.txt
+else
+  # Install known dependencies for VM autoscale
+  pip install --quiet --upgrade pip
+  pip install --quiet paramiko pyyaml requests
+fi
+deactivate
+msg_ok "Python environment configured"
+
+# Create/restore configuration
+msg_info "Setting up configuration"
+cd "$INSTALL_DIR"
+
+CONFIG_FILE="config.yaml"
+if [[ -f "/tmp/vm_autoscale_config_backup.yaml" ]]; then
+  cp "/tmp/vm_autoscale_config_backup.yaml" "$CONFIG_FILE"
+  rm -f "/tmp/vm_autoscale_config_backup.yaml"
+  msg_ok "Previous configuration restored"
+elif [[ ! -f "$CONFIG_FILE" ]]; then
+  if [[ -f "config.yaml.example" ]]; then
+    cp "config.yaml.example" "$CONFIG_FILE"
+    msg_ok "Default configuration created from example"
+  else
+    msg_ok "Using existing configuration"
+  fi
+else
+  msg_ok "Existing configuration preserved"
+fi
+
+# Determine the main Python script
+MAIN_SCRIPT=""
+if [[ -f "${INSTALL_DIR}/autoscale.py" ]]; then
+  MAIN_SCRIPT="${INSTALL_DIR}/autoscale.py"
+elif [[ -f "${INSTALL_DIR}/main.py" ]]; then
+  MAIN_SCRIPT="${INSTALL_DIR}/main.py"
+else
+  msg_error "Could not find main Python script (autoscale.py or main.py)"
+  exit 1
+fi
+
+# Create log directory
+mkdir -p /var/log/vm_autoscale
+
+# Create systemd service
+msg_info "Creating systemd service"
+cat <<EOF >/etc/systemd/system/${SERVICE_NAME}.service
+[Unit]
+Description=Proxmox VM AutoScale - Automatic resource scaling for Virtual Machines
+Documentation=https://github.com/fabriziosalmi/proxmox-vm-autoscale
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${INSTALL_DIR}/venv/bin/python3 ${MAIN_SCRIPT}
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Logging
+Environment="PYTHONUNBUFFERED=1"
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable ${SERVICE_NAME}.service >/dev/null 2>&1
+msg_ok "Systemd service created and enabled"
+
+# Display important information
+header_info
+echo ""
+echo -e "${YW}╔═══════════════════════════════════════════════════════════════╗${CL}"
+echo -e "${YW}║              IMPORTANT: VM HOTPLUG REQUIREMENTS               ║${CL}"
+echo -e "${YW}╚═══════════════════════════════════════════════════════════════╝${CL}"
+echo ""
+echo -e "${RD}⚠ IMPORTANT:${CL} For VMs to scale resources live, you must enable:"
+echo ""
+echo -e "  ${BL}1. NUMA:${CL}           VM > Hardware > Processors > Enable NUMA ☑️"
+echo -e "  ${BL}2. CPU Hotplug:${CL}    VM > Options > Hotplug > CPU ☑️"
+echo -e "  ${BL}3. Memory Hotplug:${CL} VM > Options > Hotplug > Memory ☑️"
+echo ""
+echo -e "${GN}Tip:${CL} By default, VM AutoScale will automatically enable hotplug and"
+echo -e "     NUMA on managed VMs. Set ${BL}auto_configure_hotplug: false${CL} in config"
+echo -e "     to disable this behavior."
+echo ""
+
+echo -e "${YW}╔═══════════════════════════════════════════════════════════════╗${CL}"
+echo -e "${YW}║                    INSTALLATION COMPLETE                      ║${CL}"
+echo -e "${YW}╚═══════════════════════════════════════════════════════════════╝${CL}"
+echo ""
+echo -e "${GN}VM AutoScale has been installed successfully!${CL}"
+echo ""
+echo -e "  ${BL}Installation directory:${CL} ${INSTALL_DIR}"
+echo -e "  ${BL}Configuration file:${CL}     ${INSTALL_DIR}/${CONFIG_FILE}"
+echo -e "  ${BL}Log file:${CL}               /var/log/vm_autoscale.log"
+echo -e "  ${BL}Service name:${CL}           ${SERVICE_NAME}.service"
+echo ""
+echo -e "${YW}Commands:${CL}"
+echo -e "  Start service:   ${GN}systemctl start ${SERVICE_NAME}${CL}"
+echo -e "  Stop service:    ${GN}systemctl stop ${SERVICE_NAME}${CL}"
+echo -e "  Check status:    ${GN}systemctl status ${SERVICE_NAME}${CL}"
+echo -e "  View logs:       ${GN}journalctl -u ${SERVICE_NAME} -f${CL}"
+echo -e "  View log file:   ${GN}tail -f /var/log/vm_autoscale.log${CL}"
+echo ""
+echo -e "${YW}Configuration:${CL}"
+echo -e "  Edit the configuration file to set up your Proxmox hosts and VMs:"
+echo -e "  ${GN}nano ${INSTALL_DIR}/${CONFIG_FILE}${CL}"
+echo ""
+echo -e "${YW}Required configuration:${CL}"
+echo -e "  1. Add your Proxmox host(s) with SSH credentials"
+echo -e "  2. Add the VM IDs you want to auto-scale"
+echo -e "  3. Adjust scaling thresholds as needed"
+echo ""
+
+# Ask to start service
+while true; do
+  read -p "Start the VM AutoScale service now? (y/n): " yn
+  case $yn in
+    [Yy]*) 
+      systemctl start ${SERVICE_NAME}.service
+      msg_ok "Service started"
+      echo ""
+      systemctl status ${SERVICE_NAME}.service --no-pager
+      break 
+      ;;
+    [Nn]*) 
+      echo -e "\nYou can start the service later with: ${GN}systemctl start ${SERVICE_NAME}${CL}"
+      break 
+      ;;
+    *) echo "Please answer yes or no." ;;
+  esac
+done
+
+echo ""


### PR DESCRIPTION
## Description
Adds installation scripts for two Proxmox resource auto-scaling tools:
- **LXC AutoScale**: Automatically adjusts CPU/RAM for LXC containers based on real-time usage
- **VM AutoScale**: Automatically adjusts CPU/RAM for Virtual Machines based on thresholds

## Changes
- `tools/pve/proxmox-lxc-autoscale.sh` - LXC AutoScale installer
- `tools/pve/proxmox-vm-autoscale.sh` - VM AutoScale installer
- `frontend/public/json/proxmox-lxc-autoscale.json` - Frontend metadata
- `frontend/public/json/proxmox-vm-autoscale.json` - Frontend metadata

## Features
- Python venv for Debian 12/Proxmox 8 compatibility (avoids pip system-wide issues)
- Config backup/restore during updates
- LXCFS auto-patch option (LXC) - adds `-l` flag for proper loadavg
- NUMA/Hotplug requirements documentation (VM)
- Systemd service integration
- Installation to `/opt/` for clean multi-file project structure

## Source Projects
- https://github.com/fabriziosalmi/proxmox-lxc-autoscale (225 stars)
- https://github.com/fabriziosalmi/proxmox-vm-autoscale (284 stars)

## Testing
Tested on Proxmox VE 8.3.3
