### PR TITLE
Apache Cassandra: bump to debian 13 and add update support

### DIFF
--- a/ct/apache-cassandra.sh
+++ b/ct/apache-cassandra.sh
@@ -31,6 +31,7 @@ function update_script() {
   $STD apt update
   $STD apt install -y --only-upgrade cassandra cassandra-tools
   msg_ok "Updated Apache Cassandra"
+  msg_ok "Updated successfully!"
   exit
 }
 

--- a/ct/apache-cassandra.sh
+++ b/ct/apache-cassandra.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -20,15 +20,18 @@ color
 catch_errors
 
 function update_script() {
-    header_info
-    check_container_storage
-    check_container_resources
-    if [[ ! -f /etc/systemd/system/cassandra.service ]]; then
-        msg_error "No ${APP} Installation Found!"
-        exit
-    fi
-    msg_error "Currently we don't provide an update function for this ${APP}."
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -f /etc/init.d/cassandra ]]; then
+    msg_error "No ${APP} Installation Found!"
     exit
+  fi
+  msg_info "Updating Apache Cassandra"
+  $STD apt update
+  $STD apt install -y --only-upgrade cassandra cassandra-tools
+  msg_ok "Updated Apache Cassandra"
+  exit
 }
 
 start

--- a/frontend/public/json/apache-cassandra.json
+++ b/frontend/public/json/apache-cassandra.json
@@ -6,7 +6,7 @@
   ],
   "date_created": "2024-05-02",
   "type": "ct",
-  "updateable": false,
+  "updateable": true,
   "privileged": false,
   "interface_port": null,
   "documentation": "https://cassandra.apache.org/doc/latest/",
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 4,
         "os": "debian",
-        "version": "12"
+        "version": "13"
       }
     }
   ],

--- a/install/apache-cassandra-install.sh
+++ b/install/apache-cassandra-install.sh
@@ -13,22 +13,16 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt-get install -y apt-transport-https
-msg_ok "Installed Dependencies"
-
-msg_info "Installing Eclipse Temurin (Patience)"
-curl -fsSL "https://packages.adoptium.net/artifactory/api/gpg/key/public" | gpg --dearmor >/etc/apt/trusted.gpg.d/adoptium.gpg
-echo 'deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb bookworm main' >/etc/apt/sources.list.d/adoptium.list
-$STD apt-get update
-$STD apt-get install -y temurin-11-jdk
-msg_ok "Installed Eclipse Temurin"
+JAVA_VERSION="11" setup_java
 
 msg_info "Installing Apache Cassandra"
-curl -fsSL "https://downloads.apache.org/cassandra/KEYS" | gpg --dearmor >/etc/apt/trusted.gpg.d/cassandra.gpg
-echo "deb https://debian.cassandra.apache.org 41x main" >/etc/apt/sources.list.d/cassandra.sources.list
-$STD apt-get update
-$STD apt-get install -y cassandra cassandra-tools
+setup_deb822_repo \
+  "cassandra" \
+  "https://downloads.apache.org/cassandra/KEYS" \
+  "https://debian.cassandra.apache.org" \
+  "41x" \
+  "main"
+$STD apt install -y cassandra cassandra-tools
 sed -i -e 's/^rpc_address: localhost/#rpc_address: localhost/g' -e 's/^# rpc_interface: eth1/rpc_interface: eth0/g' /etc/cassandra/cassandra.yaml
 msg_ok "Installed Apache Cassandra"
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Bump default Cassandra version from 12 to 13. Refactor install script to use helper functions for Java and repository setup. Implement update functionality in ct  and mark Cassandra as updateable in the json

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
