### PR TITLE
Openwrt: Remove default VLAN for LAN

### DIFF
--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -277,7 +277,7 @@ function default_settings() {
   MAC=$GEN_MAC
   LAN_MAC=$GEN_MAC_LAN
   VLAN=""
-  LAN_VLAN=",tag=999"
+  LAN_VLAN=""
   LAN_IP_ADDR="192.168.1.1"
   LAN_NETMASK="255.255.255.0"
   MTU=""
@@ -427,8 +427,8 @@ function advanced_settings() {
 
   if VLAN2=$(whiptail --backtitle "Proxmox VE Helper Scripts" --inputbox "Set a LAN Vlan" 8 58 999 --title "LAN VLAN" --cancel-button Exit-Script 3>&1 1>&2 2>&3); then
     if [ -z $VLAN2 ]; then
-      VLAN2="999"
-      LAN_VLAN=",tag=$VLAN2"
+      VLAN2="Default"
+      LAN_VLAN=""
     else
       LAN_VLAN=",tag=$VLAN2"
     fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Removes the default VLAN for LAN interface on openwrt.

## 🔗 Related Issue

Fixes #10704

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
