### PR TITLE
Immich: Fix Intel version check; install legacy Intel packages during new install

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -93,6 +93,7 @@ EOF
       $STD apt install -y ./*.deb
       rm ./*.deb
       $STD apt-mark hold libigdgmm12
+      dpkg -l | grep -m1 "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
       msg_ok "Intel iGPU dependencies updated"
     fi
     rm ./Dockerfile

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -99,20 +99,21 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   $STD apt install -y --no-install-recommends patchelf
   tmp_dir=$(mktemp -d)
   $STD pushd "$tmp_dir"
-  curl -fsSLZ -O "https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.24/intel-igc-core_1.0.17537.24_amd64.deb" \
-    -O "https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.24/intel-igc-opencl_1.0.17537.24_amd64.deb" \
-    -O "https://github.com/intel/compute-runtime/releases/download/24.35.30872.36/intel-opencl-icd-legacy1_24.35.30872.36_amd64.deb" \
-    -O "https://github.com/intel/intel-graphics-compiler/releases/download/v2.22.2/intel-igc-core-2_2.22.2+20121_amd64.deb" \
-    -O "https://github.com/intel/intel-graphics-compiler/releases/download/v2.22.2/intel-igc-opencl-2_2.22.2+20121_amd64.deb" \
-    -O "https://github.com/intel/compute-runtime/releases/download/25.44.36015.5/intel-opencl-icd_25.44.36015.5-0_amd64.deb" \
-    -O "https://github.com/intel/compute-runtime/releases/download/25.44.36015.5/libigdgmm12_22.8.2_amd64.deb"
+  curl -fsSLO https://raw.githubusercontent.com/immich-app/base-images/refs/heads/main/server/Dockerfile
+  readarray -t INTEL_URLS < <(
+    sed -n "/intel-[igc|opencl]/p" ./Dockerfile | awk '{print $2}'
+    sed -n "/libigdgmm12/p" ./Dockerfile | awk '{print $3}'
+  )
+  for url in "${INTEL_URLS[@]}"; do
+    curl -fsSLO "$url"
+  done
   $STD apt install -y ./libigdgmm12*.deb
   rm ./libigdgmm12*.deb
   $STD apt install -y ./*.deb
   $STD apt-mark hold libigdgmm12
   $STD popd
   rm -rf "$tmp_dir"
-  dpkg -l | grep "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
+  dpkg -l | grep -m1 "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
   msg_ok "Installed OpenVINO dependencies"
 fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Fixed issue with the update function downloading the Intel packages even if they are already up-to-date
- Change install script to install both versions (current and legacy) of Intel packages when opting into OpenVino

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
