### PR TITLE
Immich: Install libde265-dev from Debian Testing

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -57,9 +57,12 @@ EOF
     fi
     $STD apt update
     msg_ok "Added Debian Testing repo"
-    msg_info "Installing libmimalloc3"
-    $STD apt install -t testing --no-install-recommends libmimalloc3
-    msg_ok "Installed libmimalloc3"
+  fi
+
+  if ! dpkg -l "libmimalloc3" | grep -q '3.1' || ! dpkg -l "libde265-dev" | grep -q '1.0.16'; then
+    msg_info "Installing/upgrading Testing repo packages"
+    $STD apt install -t testing libmimalloc3 libde265-dev -y
+    msg_ok "Installed/upgraded Testing repo packages"
   fi
 
   if [[ ! -f /etc/apt/sources.list.d/mise.list ]]; then

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -29,7 +29,6 @@ $STD apt install --no-install-recommends -y \
   libltdl-dev \
   libgdk-pixbuf-2.0-dev \
   libbrotli-dev \
-  libde265-dev \
   libexif-dev \
   libexpat1-dev \
   libglib2.0-dev \
@@ -130,9 +129,9 @@ Pin-Priority: 450
 EOF
 $STD apt update
 msg_ok "Configured Debian Testing repo"
-msg_info "Installing libmimalloc3"
-$STD apt install -t testing --no-install-recommends -yqq libmimalloc3
-msg_ok "Installed libmimalloc3"
+msg_info "Installing packages from Debian Testing repo"
+$STD apt install -t testing --no-install-recommends -yqq libmimalloc3 libde265-dev
+msg_ok "Installed packages from Debian Testing repo"
 
 PNPM_VERSION="$(curl -fsSL "https://raw.githubusercontent.com/immich-app/immich/refs/heads/main/package.json" | jq -r '.packageManager | split("@")[1]')"
 NODE_VERSION="24" NODE_MODULE="pnpm@${PNPM_VERSION}" setup_nodejs


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- libde265-dev v1.0.16 from Debian Testing has fixes for HDR screenshots on iOS
- Change testing package update/install check to it's own if statement

## 🔗 Related Issue

Fixes https://github.com/immich-app/immich/issues/21261

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
