### PR TITLE
Switch Ollama install to .tar.zst and add zstd dependency

### DIFF
--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -32,17 +32,22 @@ function update_script() {
     if [[ ! -f /opt/Ollama_version.txt ]]; then
       touch /opt/Ollama_version.txt
     fi
+    if ! command -v zstd &>/dev/null; then
+      msg_info "Installing zstd"
+      $STD apt install -y zstd
+      msg_ok "Installed zstd"
+    fi
     msg_info "Stopping Services"
     systemctl stop ollama
     msg_ok "Services Stopped"
 
-    TMP_TAR=$(mktemp --suffix=.tgz)
-    curl -fL# -C - -o "${TMP_TAR}" "https://github.com/ollama/ollama/releases/download/${RELEASE}/ollama-linux-amd64.tgz"
+    TMP_TAR=$(mktemp --suffix=.tar.zst)
+    curl -fL# -C - -o "${TMP_TAR}" "https://github.com/ollama/ollama/releases/download/${RELEASE}/ollama-linux-amd64.tar.zst"
     msg_info "Updating Ollama to ${RELEASE}"
     rm -rf /usr/local/lib/ollama
     rm -rf /usr/local/bin/ollama
     mkdir -p /usr/local/lib/ollama
-    tar -xzf "${TMP_TAR}" -C /usr/local/lib/ollama
+    tar --zstd -xf "${TMP_TAR}" -C /usr/local/lib/ollama
     ln -sf /usr/local/lib/ollama/bin/ollama /usr/local/bin/ollama
     rm -f "${TMP_TAR}"
     echo "${RELEASE}" >/opt/Ollama_version.txt

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -92,12 +92,17 @@ EOF
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
+      if ! command -v zstd &>/dev/null; then
+        msg_info "Installing zstd"
+        $STD apt install -y zstd
+        msg_ok "Installed zstd"
+      fi
       msg_info "Ollama update available: v$OLLAMA_VERSION -> v$RELEASE"
       msg_info "Downloading Ollama v$RELEASE \n"
-      curl -fS#LO https://ollama.com/download/ollama-linux-amd64.tgz
+      curl -fS#LO https://github.com/ollama/ollama/releases/download/v${RELEASE}/ollama-linux-amd64.tar.zst
       msg_ok "Download Complete"
 
-      if [ -f "ollama-linux-amd64.tgz" ]; then
+      if [ -f "ollama-linux-amd64.tar.zst" ]; then
 
         msg_info "Stopping Ollama Service"
         systemctl stop ollama
@@ -106,8 +111,8 @@ EOF
         msg_info "Installing Ollama"
         rm -rf /usr/lib/ollama
         rm -rf /usr/bin/ollama
-        tar -C /usr -xzf ollama-linux-amd64.tgz
-        rm -rf ollama-linux-amd64.tgz
+        tar --zstd -C /usr -xf ollama-linux-amd64.tar.zst
+        rm -rf ollama-linux-amd64.tar.zst
         msg_ok "Installed Ollama"
 
         msg_info "Starting Ollama Service"

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -16,7 +16,8 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   build-essential \
-  pkg-config
+  pkg-config \
+  zstd
 msg_ok "Installed Dependencies"
 
 msg_info "Setting up Intel® Repositories"
@@ -67,11 +68,11 @@ RELEASE=$(curl -fsSL https://api.github.com/repos/ollama/ollama/releases/latest 
 OLLAMA_INSTALL_DIR="/usr/local/lib/ollama"
 BINDIR="/usr/local/bin"
 mkdir -p $OLLAMA_INSTALL_DIR
-OLLAMA_URL="https://github.com/ollama/ollama/releases/download/${RELEASE}/ollama-linux-amd64.tgz"
-TMP_TAR="/tmp/ollama.tgz"
+OLLAMA_URL="https://github.com/ollama/ollama/releases/download/${RELEASE}/ollama-linux-amd64.tar.zst"
+TMP_TAR="/tmp/ollama.tar.zst"
 echo -e "\n"
 if curl -fL# -C - -o "$TMP_TAR" "$OLLAMA_URL"; then
-  if tar -xzf "$TMP_TAR" -C "$OLLAMA_INSTALL_DIR"; then
+  if tar --zstd -xf "$TMP_TAR" -C "$OLLAMA_INSTALL_DIR"; then
     ln -sf "$OLLAMA_INSTALL_DIR/bin/ollama" "$BINDIR/ollama"
     echo "${RELEASE}" >/opt/Ollama_version.txt
     msg_ok "Installed Ollama ${RELEASE}"

--- a/install/openwebui-install.sh
+++ b/install/openwebui-install.sh
@@ -14,7 +14,9 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y ffmpeg
+$STD apt install -y \
+  ffmpeg \
+  zstd
 msg_ok "Installed Dependencies"
 
 setup_hwaccel
@@ -69,9 +71,10 @@ EOF
   msg_ok "Installed Intel® oneAPI Base Toolkit"
 
   msg_info "Installing Ollama"
-  curl -fsSLO -C - https://ollama.com/download/ollama-linux-amd64.tgz
-  tar -C /usr -xzf ollama-linux-amd64.tgz
-  rm -rf ollama-linux-amd64.tgz
+  OLLAMA_RELEASE=$(curl -fsSL https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk -F '"' '{print $4}')
+  curl -fsSLO -C - https://github.com/ollama/ollama/releases/download/${OLLAMA_RELEASE}/ollama-linux-amd64.tar.zst
+  tar --zstd -C /usr -xf ollama-linux-amd64.tar.zst
+  rm -rf ollama-linux-amd64.tar.zst
   cat <<EOF >/etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update all scripts to download and extract Ollama from the new .tar.zst archive format instead of .tgz. Add zstd as a required dependency where needed to support extraction. Update download URLs to use the official GitHub releases and ensure version detection and service management remain consistent.

## 🔗 Related Issue

Fixes #10813

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
