### PR TITLE
pihole/unbound: create unbound config before apt install to prevent port conflicts

### DIFF
--- a/install/pihole-install.sh
+++ b/install/pihole-install.sh
@@ -69,7 +69,7 @@ read -r -p "${TAB3}Would you like to add Unbound? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   read -r -p "${TAB3}Unbound is configured as a recursive DNS server by default, would you like it to be configured as a forwarding DNS server (using DNS-over-TLS (DoT)) instead? <y/N> " prompt
   msg_info "Installing Unbound"
-  $STD apt install -y unbound
+  mkdir -p /etc/unbound/unbound.conf.d
   cat <<EOF >/etc/unbound/unbound.conf.d/pi-hole.conf
 server:
   verbosity: 0
@@ -142,6 +142,7 @@ forward-zone:
   #forward-addr: 2620:fe::9@853#dns.quad9.net
 EOF
   fi
+  $STD apt install -y unbound
   cat <<EOF >/etc/dnsmasq.d/01-pihole.conf
 server=127.0.0.1#5335
 server=8.8.8.8
@@ -149,7 +150,7 @@ server=8.8.4.4
 EOF
 
   sed -i -E '/^\s*upstreams\s*=\s*\[/,/^\s*\]/c\  upstreams = [\n    "127.0.0.1#5335",\n    "8.8.4.4"\n  ]' /etc/pihole/pihole.toml
-  systemctl enable -q --now unbound
+  systemctl restart unbound
   systemctl restart pihole-FTL.service
   msg_ok "Installed Unbound"
 fi

--- a/install/unbound-install.sh
+++ b/install/unbound-install.sh
@@ -14,11 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Unbound"
-$STD apt install -y \
-  unbound \
-  unbound-host
-msg_info "Installed Unbound"
-
+mkdir -p /etc/unbound/unbound.conf.d
 cat <<EOF >/etc/unbound/unbound.conf.d/unbound.conf
 server:
   interface: 0.0.0.0
@@ -52,13 +48,17 @@ server:
   logfile: /var/log/unbound.log
 EOF
 
+$STD apt install -y \
+  unbound \
+  unbound-host
+
 touch /var/log/unbound.log
 chown unbound:unbound /var/log/unbound.log
 sleep 5
 systemctl restart unbound
 msg_ok "Installed Unbound"
 
-msg_ok "Configuring Logrotate"
+msg_info "Configuring Logrotate"
 cat <<EOF >/etc/logrotate.d/unbound
 /var/log/unbound.log {
   daily
@@ -74,7 +74,6 @@ cat <<EOF >/etc/logrotate.d/unbound
   endscript
 }
 EOF
-
 systemctl restart logrotate
 msg_ok "Configured Logrotate"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
create unbound config before apt install to prevent port conflicts

## 🔗 Related Issue

Fixes #10802

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
