### PR TITLE
palmr: update for v3 with MinIO S3 storage

### DIFF
--- a/ct/palmr.sh
+++ b/ct/palmr.sh
@@ -29,7 +29,7 @@ function update_script() {
   fi
   if check_for_gh_release "palmr" "kyantech/Palmr"; then
     msg_info "Stopping Services"
-    systemctl stop palmr-frontend palmr-backend
+    systemctl stop palmr-frontend palmr-backend palmr-minio
     msg_ok "Stopped Services"
 
     cp /opt/palmr/apps/server/.env /opt/palmr.env
@@ -49,16 +49,19 @@ function update_script() {
     $STD pnpm build
 
     cd /opt/palmr/apps/web
+    cat <<EOF >./.env
+API_BASE_URL=http://127.0.0.1:3333
+NEXT_PUBLIC_DEFAULT_LANGUAGE=en-US
+EOF
     export NODE_ENV=production
     export NEXT_TELEMETRY_DISABLED=1
-    mv ./.env.example ./.env
     $STD pnpm install
     $STD pnpm build
     chown -R palmr:palmr /opt/palmr_data /opt/palmr
     msg_ok "Updated ${APP}"
 
     msg_info "Starting Services"
-    systemctl start palmr-backend palmr-frontend
+    systemctl start palmr-minio palmr-backend palmr-frontend
     msg_ok "Started Services"
     msg_ok "Updated successfully!"
   fi
@@ -72,4 +75,4 @@ description
 msg_ok "Completed successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3000${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:5487${CL}"

--- a/install/palmr-install.sh
+++ b/install/palmr-install.sh
@@ -13,56 +13,96 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "Palmr" "kyantech/Palmr" "tarball" "latest" "/opt/palmr"
-PNPM="$(jq -r '.packageManager' /opt/palmr/package.json)"
-NODE_VERSION="24" NODE_MODULE="$PNPM" setup_nodejs
+msg_info "Setting up MinIO"
+curl -fsSL "https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2024-10-13T13-34-11Z" -o /usr/local/bin/minio
+chmod +x /usr/local/bin/minio
+curl -fsSL "https://dl.min.io/client/mc/release/linux-amd64/mc" -o /usr/local/bin/mc
+chmod +x /usr/local/bin/mc
+msg_ok "Set up MinIO"
 
-msg_info "Configuring palmr backend"
-PALMR_DIR="/opt/palmr_data"
-mkdir -p "$PALMR_DIR"
-PALMR_DB="${PALMR_DIR}/palmr.db"
-PALMR_KEY="$(openssl rand -hex 32)"
+fetch_and_deploy_gh_release "Palmr" "kyantech/Palmr" "tarball" "latest" "/opt/palmr"
+NODE_VERSION="24" NODE_MODULE="$(jq -r '.packageManager' /opt/palmr/package.json)" setup_nodejs
+
+msg_info "Configuring Palmr"
+mkdir -p /opt/palmr_data/{minio-data,prisma,uploads,temp-uploads}
+MINIO_PASSWORD="$(openssl rand -hex 16)"
+
+cat <<EOF >/opt/palmr_data/.minio-credentials
+S3_ENDPOINT=127.0.0.1
+S3_PORT=9379
+S3_ACCESS_KEY=palmr-admin
+S3_SECRET_KEY=${MINIO_PASSWORD}
+S3_BUCKET_NAME=palmr-files
+S3_REGION=us-east-1
+S3_USE_SSL=false
+S3_FORCE_PATH_STYLE=true
+EOF
+
 cd /opt/palmr/apps/server
-sed -e 's/_ENCRYPTION=true/_ENCRYPTION=false/' \
-  -e '/^# ENC/s/# //' \
-  -e "s/ENCRYPTION_KEY=.*$/ENCRYPTION_KEY=$PALMR_KEY/" \
-  -e "s|file:.*$|file:$PALMR_DB\"|" \
-  -e "\|db\"$|a\\# Uncomment below when using a reverse proxy\\
-# SECURE_SITE=true\\
-# Uncomment and add your path if using symlinks for data storage\\
-# CUSTOM_PATH=<path-to-your-bind-mount>" \
-  .env.example >./.env
+cat <<EOF >.env
+ENABLE_S3=false
+STORAGE_URL=http://$(hostname -I | awk '{print $1}'):9379
+DATABASE_URL=file:/opt/palmr_data/prisma/palmr.db
+DISABLE_FILESYSTEM_ENCRYPTION=true
+ENCRYPTION_KEY=$(openssl rand -hex 32)
+EOF
 $STD pnpm install
 $STD npx prisma generate
 $STD npx prisma migrate deploy
 $STD npx prisma db push
 $STD pnpm db:seed
 $STD pnpm build
-msg_ok "Configured palmr backend"
 
-msg_info "Configuring palmr frontend"
 cd /opt/palmr/apps/web
-mv ./.env.example ./.env
+echo "API_BASE_URL=http://127.0.0.1:3333" >.env
 export NODE_ENV=production
 export NEXT_TELEMETRY_DISABLED=1
 $STD pnpm install
 $STD pnpm build
-msg_ok "Configured palmr frontend"
 
-msg_info "Creating service"
-useradd -d "$PALMR_DIR" -M -s /usr/sbin/nologin -U palmr
-chown -R palmr:palmr "$PALMR_DIR" /opt/palmr
-cat <<EOF >/etc/systemd/system/palmr-backend.service
+{
+  echo "Palmr Credentials"
+  echo "MinIO User: palmr-admin"
+  echo "MinIO Password: $MINIO_PASSWORD"
+} >>~/palmr.creds
+msg_ok "Configured Palmr"
+
+msg_info "Creating Services"
+useradd -d /opt/palmr_data -M -s /usr/sbin/nologin -U palmr
+chown -R palmr:palmr /opt/palmr_data /opt/palmr
+
+cat <<EOF >/etc/systemd/system/palmr-minio.service
 [Unit]
-Description=palmr Backend Service
+Description=Palmr MinIO Service
 After=network.target
 
 [Service]
 Type=simple
 User=palmr
 Group=palmr
-WorkingDirectory=/opt/palmr_data
+Environment="MINIO_ROOT_USER=palmr-admin"
+Environment="MINIO_ROOT_PASSWORD=${MINIO_PASSWORD}"
+ExecStart=/usr/local/bin/minio server /opt/palmr_data/minio-data --address 0.0.0.0:9379 --console-address 0.0.0.0:9378
+Restart=always
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat <<EOF >/etc/systemd/system/palmr-backend.service
+[Unit]
+Description=Palmr Backend Service
+After=network.target palmr-minio.service
+Requires=palmr-minio.service
+
+[Service]
+Type=simple
+User=palmr
+Group=palmr
+WorkingDirectory=/opt/palmr/apps/server
 ExecStart=/usr/bin/node /opt/palmr/apps/server/dist/server.js
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
@@ -70,21 +110,29 @@ EOF
 
 cat <<EOF >/etc/systemd/system/palmr-frontend.service
 [Unit]
-Description=palmr Frontend Service
+Description=Palmr Frontend Service
 After=network.target palmr-backend.service
+Requires=palmr-backend.service
 
 [Service]
 Type=simple
 User=palmr
 Group=palmr
 WorkingDirectory=/opt/palmr/apps/web
+Environment="NODE_ENV=production"
 ExecStart=/usr/bin/pnpm start
+Restart=always
 
 [Install]
 WantedBy=multi-user.target
 EOF
+
+systemctl enable -q --now palmr-minio
+sleep 3
+$STD mc alias set palmr http://127.0.0.1:9379 palmr-admin "$MINIO_PASSWORD"
+$STD mc mb palmr/palmr-files --ignore-existing
 systemctl enable -q --now palmr-backend palmr-frontend
-msg_ok "Created service"
+msg_ok "Created Services"
 
 motd_ssh
 customize


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add MinIO for internal S3-compatible storage (port 9379)
- Update web UI port from 3000 to 5487
- Add palmr-minio systemd service
- Update environment configuration for new architecture
- Fix update script to handle all three services

## 🔗 Related Issue

Fixes #9779

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
