### PR TITLE
immich: use dpkg-query to get intel-opencl-icd version

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -96,7 +96,7 @@ EOF
       $STD apt install -y ./*.deb
       rm ./*.deb
       $STD apt-mark hold libigdgmm12
-      dpkg -l | grep -m1 "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
+      dpkg-query -W -f='${Version}\n' intel-opencl-icd >~/.intel_version
       msg_ok "Intel iGPU dependencies updated"
     fi
     rm ./Dockerfile

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -112,7 +112,7 @@ if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   $STD apt-mark hold libigdgmm12
   $STD popd
   rm -rf "$tmp_dir"
-  dpkg -l | grep -m1 "intel-opencl-icd" | awk '{print $3}' >~/.intel_version
+  dpkg-query -W -f='${Version}\n' intel-opencl-icd >~/.intel_version
   msg_ok "Installed OpenVINO dependencies"
 fi
 


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replaces parsing dpkg output with dpkg-query to reliably obtain the intel-opencl-icd package version in both immich.sh and immich-install.sh scripts.


## 🔗 Related Issue

Fixes #10838

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
