### PR TITLE
postgresql: name of sources file fixed (update check)

### DIFF
--- a/ct/postgresql.sh
+++ b/ct/postgresql.sh
@@ -23,7 +23,7 @@ function update_script() {
     header_info
     check_container_storage
     check_container_resources
-    if [[ ! -f /etc/apt/sources.list.d/pgdg.list ]]; then
+    if [[ ! -f /etc/apt/sources.list.d/pgdg.sources ]]; then
         msg_error "No ${APP} Installation Found!"
         exit
     fi

--- a/ct/postgresql.sh
+++ b/ct/postgresql.sh
@@ -23,7 +23,7 @@ function update_script() {
     header_info
     check_container_storage
     check_container_resources
-    if [[ ! -f /etc/apt/sources.list.d/pgdg.sources ]]; then
+    if [[ ! command -v psql >/dev/null 2>&1 ]]; then
         msg_error "No ${APP} Installation Found!"
         exit
     fi

--- a/ct/postgresql.sh
+++ b/ct/postgresql.sh
@@ -23,7 +23,7 @@ function update_script() {
     header_info
     check_container_storage
     check_container_resources
-    if [[ ! command -v psql >/dev/null 2>&1 ]]; then
+    if ! command -v psql >/dev/null 2>&1; then
         msg_error "No ${APP} Installation Found!"
         exit
     fi


### PR DESCRIPTION
## ✍️ Description

The wrong name of the sources file in the script leads to the situation that updates being not possible as "No PostgreSQL Installation Found!" will be displayed.

## 🔗 Related Issue

No issue recorded for this small typo, I hope that users with that issue find this pull request when they search for the error message.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected. I tested with my fork.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
