### PR TITLE
Jotty: increase RAM; cap heap size at 3GB during build

### DIFF
--- a/ct/jotty.sh
+++ b/ct/jotty.sh
@@ -8,7 +8,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="jotty"
 var_tags="${var_tags:-tasks;notes}"
 var_cpu="${var_cpu:-2}"
-var_ram="${var_ram:-3072}"
+var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-6}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
@@ -45,6 +45,8 @@ function update_script() {
 
     msg_info "Updating jotty"
     cd /opt/jotty
+    unset NODE_OPTIONS
+    export NODE_OPTIONS="--max-old-space-size=3072"
     $STD yarn --frozen-lockfile
     $STD yarn next telemetry disable
     $STD yarn build
@@ -55,7 +57,7 @@ function update_script() {
     cp -r .next/static .next/standalone/.next/
 
     mv .next/standalone /tmp/jotty_standalone
-    rm -rf * .next .git .gitignore .yarn
+    rm -rf ./* .next .git .gitignore .yarn
     mv /tmp/jotty_standalone/* .
     mv /tmp/jotty_standalone/.[!.]* . 2>/dev/null || true
     rm -rf /tmp/jotty_standalone

--- a/frontend/public/json/jotty.json
+++ b/frontend/public/json/jotty.json
@@ -20,7 +20,7 @@
       "script": "ct/jotty.sh",
       "resources": {
         "cpu": 2,
-        "ram": 3072,
+        "ram": 4096,
         "hdd": 6,
         "os": "debian",
         "version": "13"

--- a/install/jotty-install.sh
+++ b/install/jotty-install.sh
@@ -18,6 +18,8 @@ fetch_and_deploy_gh_release "jotty" "fccview/jotty" "tarball" "latest" "/opt/jot
 
 msg_info "Installing ${APPLICATION}"
 cd /opt/jotty
+unset NODE_OPTIONS
+export NODE_OPTIONS="--max-old-space-size=3072"
 $STD yarn --frozen-lockfile
 $STD yarn next telemetry disable
 $STD yarn build
@@ -28,7 +30,7 @@ mkdir -p .next/standalone/.next
 cp -r .next/static .next/standalone/.next/
 
 mv .next/standalone /tmp/jotty_standalone
-rm -rf * .next .git .gitignore .yarn
+rm -rf ./* .next .git .gitignore .yarn
 mv /tmp/jotty_standalone/* .
 mv /tmp/jotty_standalone/.[!.]* . 2>/dev/null || true
 rm -rf /tmp/jotty_standalone


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Jotty was crashing when trying to update/install the latest few versions. RAM usage is pretty damn high, the only thing that works is increasing RAM to 4GB in conjunction with capping the max heap size (`export NODE_OPTIONS="--max-old-space-size=3072"`). I tried capping the heap size at 2GB and leaving RAM at 3GB but it still crashes.
- Tested this on my install, and a fresh install from scratch.
- Small formatting fix when removing files/dirs.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
