### PR TITLE
Fix typo in the New Script request template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/request-script.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-script.yml
@@ -30,7 +30,7 @@ body:
         required: true
       - label: "I have searched existing [discussions](https://github.com/community-scripts/ProxmoxVE/discussions?discussions_q=) and found no duplicate requests."
         required: true
-      - label: "The application requested has 200+ stars on Github (if applicable), is older than 6 months, actively maintained and has release tarballs published."
+      - label: "The application requested has 500+ stars on Github (if applicable), is older than 6 months, actively maintained and has release tarballs published."
         required: true
 - type: markdown
   attributes:

--- a/.github/DISCUSSION_TEMPLATE/request-script.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-script.yml
@@ -30,7 +30,7 @@ body:
         required: true
       - label: "I have searched existing [discussions](https://github.com/community-scripts/ProxmoxVE/discussions?discussions_q=) and found no duplicate requests."
         required: true
-      - label: "The application requested has 500+ stars on Github (if applicable), is older than 6 months, actively maintained and has release tarballs published."
+      - label: "The application requested has 600+ stars on Github (if applicable), is older than 6 months, actively maintained and has release tarballs published."
         required: true
 - type: markdown
   attributes:


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- The template wrongly states that application requested should have 200 stars on GitHub. The correct number is 600

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
