### PR TITLE
Outline: prevent corepack interactive prompt blocking installation

### DIFF
--- a/ct/outline.sh
+++ b/ct/outline.sh
@@ -41,16 +41,17 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "outline" "outline/outline" "tarball"
 
-    msg_info "Updating ${APP}"
+    msg_info "Updating Outline"
     cd /opt/outline
     mv /opt/.env /opt/outline
     export NODE_ENV=development
     export NODE_OPTIONS="--max-old-space-size=3584"
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     $STD corepack enable
     $STD yarn install --immutable
     export NODE_ENV=production
     $STD yarn build
-    msg_ok "Updated ${APP}"
+    msg_ok "Updated Outline"
 
     msg_info "Starting Services"
     systemctl start outline

--- a/install/outline-install.sh
+++ b/install/outline-install.sh
@@ -38,6 +38,7 @@ sed -i 's/redis:6379/localhost:6379/g' /opt/outline/.env
 sed -i "5s#URL=#URL=http://${LOCAL_IP}#g" /opt/outline/.env
 sed -i 's/FORCE_HTTPS=true/FORCE_HTTPS=false/g' /opt/outline/.env
 export NODE_OPTIONS="--max-old-space-size=3584"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 $STD corepack enable
 $STD yarn install --immutable
 export NODE_ENV=production


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add COREPACK_ENABLE_DOWNLOAD_PROMPT=0 to skip yarn download confirmation
- Fixes installation hanging on 'Configuring Outline (Patience)'

## 🔗 Related Issue

Fixes #10943

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
