### PR TITLE
Apache-Guacamole: move jdbc cleanup after schema upgrade

### DIFF
--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -92,7 +92,6 @@ function update_script() {
     curl -fsSL "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-auth-jdbc-${LATEST_SERVER}.tar.gz" -o "/tmp/guacamole-auth-jdbc.tar.gz"
     $STD tar -xf /tmp/guacamole-auth-jdbc.tar.gz -C /tmp
     mv /tmp/guacamole-auth-jdbc-"${LATEST_SERVER}"/mysql/guacamole-auth-jdbc-mysql-"${LATEST_SERVER}".jar /etc/guacamole/extensions/
-    rm -rf /tmp/guacamole-auth-jdbc*
     echo "${LATEST_SERVER}" >~/.guacamole_auth_jdbc
     msg_ok "Updated Guacamole Auth JDBC"
   else
@@ -140,6 +139,7 @@ function update_script() {
         fi
       done
     fi
+    rm -rf /tmp/guacamole-auth-jdbc*
     msg_ok "MySQL Schema updated"
   fi
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Temp files were deleted before schema upgrade could access them so i Fixed update script failing on MySQL schema upgrade step

## 🔗 Related Issue

Fixes #10942

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
