### PR TITLE
core: implement ensure_profile_loaded function

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2843,6 +2843,7 @@ start() {
   elif [ ! -z ${PHS_SILENT+x} ] && [[ "${PHS_SILENT}" == "1" ]]; then
     VERBOSE="no"
     set_std_mode
+    ensure_profile_loaded
     update_script
     cleanup_lxc
   else
@@ -2868,6 +2869,7 @@ start() {
       exit
       ;;
     esac
+    ensure_profile_loaded
     update_script
     cleanup_lxc
   fi

--- a/misc/core.func
+++ b/misc/core.func
@@ -38,6 +38,7 @@ load_functions() {
   icons
   default_vars
   set_std_mode
+  ensure_profile_loaded  # Fix PATH for pct enter/exec users
   # Note: get_lxc_ip() is NOT called here automatically
   # Call it explicitly when you need LOCAL_IP variable
 }
@@ -127,6 +128,34 @@ icons() {
   FUSE="${TAB}🗂️${TAB}${CL}"
   GPU="${TAB}🎮${TAB}${CL}"
   HOURGLASS="${TAB}⏳${TAB}"
+}
+
+# ------------------------------------------------------------------------------
+# ensure_profile_loaded()
+#
+# - Sources /etc/profile.d/*.sh scripts if not already loaded
+# - Fixes PATH issues when running via pct enter/exec (non-login shells)
+# - Safe to call multiple times (uses guard variable)
+# - Should be called in update_script() or any script running inside LXC
+# ------------------------------------------------------------------------------
+ensure_profile_loaded() {
+  # Skip if already loaded or running on Proxmox host
+  [[ -n "${_PROFILE_LOADED:-}" ]] && return
+  command -v pveversion &>/dev/null && return
+
+  # Source all profile.d scripts to ensure PATH is complete
+  if [[ -d /etc/profile.d ]]; then
+    for script in /etc/profile.d/*.sh; do
+      [[ -r "$script" ]] && source "$script"
+    done
+  fi
+
+  # Also ensure /usr/local/bin is in PATH (common install location)
+  if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
+    export PATH="/usr/local/bin:$PATH"
+  fi
+
+  export _PROFILE_LOADED=1
 }
 
 # ------------------------------------------------------------------------------

--- a/misc/core.func
+++ b/misc/core.func
@@ -38,9 +38,6 @@ load_functions() {
   icons
   default_vars
   set_std_mode
-  ensure_profile_loaded  # Fix PATH for pct enter/exec users
-  # Note: get_lxc_ip() is NOT called here automatically
-  # Call it explicitly when you need LOCAL_IP variable
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Adds ensure_profile_loaded function to source profile scripts and fix PATH issues for pct enter/exec users.

That mean: 
- Automatically loads all /etc/profile.d/*.sh scripts - this adds tools such as go, cargo, etc. to the PATH.
- Explicitly adds /usr/local/bin to the PATH - if it is missing.
- Uses guard variable - can be called multiple times without any problems.
- Skips Proxmox host - only runs within containers.

## 🔗 Related Issue

Fixes #10998

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
