### PR TITLE
Joplin-Server: use yarn workspaces focus for faster builds

### DIFF
--- a/ct/joplin-server.sh
+++ b/ct/joplin-server.sh
@@ -44,7 +44,9 @@ function update_script() {
     sed -i "/onenote-converter/d" packages/lib/package.json
     $STD yarn config set --home enableTelemetry 0
     export BUILD_SEQUENCIAL=1
-    $STD yarn install --inline-builds
+    $STD yarn workspaces focus @joplin/server
+    cd packages/server
+    $STD yarn run build
     msg_ok "Updated Joplin-Server"
 
     msg_info "Starting Services"

--- a/frontend/public/json/joplin-server.json
+++ b/frontend/public/json/joplin-server.json
@@ -14,7 +14,6 @@
   "website": "https://joplinapp.org/",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/joplin.webp",
   "description": "Joplin - the privacy-focused note taking app with sync capabilities for Windows, macOS, Linux, Android and iOS.",
-  "disable": true,
   "install_methods": [
     {
       "type": "default",

--- a/install/joplin-server-install.sh
+++ b/install/joplin-server-install.sh
@@ -36,7 +36,9 @@ cd /opt/joplin-server
 sed -i "/onenote-converter/d" packages/lib/package.json
 $STD yarn config set --home enableTelemetry 0
 export BUILD_SEQUENCIAL=1
-$STD yarn install --inline-builds
+$STD yarn workspaces focus @joplin/server
+cd packages/server
+$STD yarn run build
 
 cat <<EOF >/opt/joplin-server/.env
 PM2_HOME=/opt/pm2


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
@tremor021 build now in 20-30 sec instead of 12min. 
Replace `yarn install --inline-builds` with `yarn workspaces focus @joplin/server` to build only server dependencies instead of entire monorepo. Reduces build time from ~13 minutes to ~30 seconds and fixes build failures.

<img width="1088" height="349" alt="image" src="https://github.com/user-attachments/assets/b23b94dc-ace7-4bda-bfab-4646dbd1a9bf" />

<img width="1488" height="736" alt="image" src="https://github.com/user-attachments/assets/f514a133-95d6-4c45-b9c6-021e18364647" />


## 🔗 Related Issue

Fixes #10806

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
