### PR TITLE
cloudflare: Remove deprecated DNS-over-HTTPS proxy option

### DIFF
--- a/frontend/public/json/cloudflared.json
+++ b/frontend/public/json/cloudflared.json
@@ -33,7 +33,11 @@
   },
   "notes": [
     {
-      "text": "With an option to configure cloudflared as a DNS-over-HTTPS (DoH) proxy",
+      "text": "After install, run: cloudflared tunnel login && cloudflared tunnel create <NAME>",
+      "type": "info"
+    },
+    {
+      "text": "Or create tunnel via Cloudflare Zero Trust Dashboard",
       "type": "info"
     }
   ]

--- a/install/cloudflared-install.sh
+++ b/install/cloudflared-install.sh
@@ -23,41 +23,6 @@ setup_deb822_repo \
 $STD apt install -y cloudflared
 msg_ok "Installed Cloudflared"
 
-read -r -p "${TAB3}Would you like to configure cloudflared as a DNS-over-HTTPS (DoH) proxy? <y/N> " prompt
-if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
-  msg_info "Creating Service"
-  cat <<EOF >/usr/local/etc/cloudflared/config.yml
-proxy-dns: true
-proxy-dns-address: 0.0.0.0
-proxy-dns-port: 53
-proxy-dns-max-upstream-conns: 5
-proxy-dns-upstream:
-  - https://1.1.1.1/dns-query
-  - https://1.0.0.1/dns-query
-  #- https://8.8.8.8/dns-query
-  #- https://8.8.4.4/dns-query
-  #- https://9.9.9.9/dns-query
-  #- https://149.112.112.112/dns-query
-EOF
-  cat <<EOF >/etc/systemd/system/cloudflared.service
-[Unit]
-Description=cloudflared DNS-over-HTTPS (DoH) proxy
-After=syslog.target network-online.target
-
-[Service]
-Type=simple
-ExecStart=/usr/local/bin/cloudflared --config /usr/local/etc/cloudflared/config.yml
-Restart=on-failure
-RestartSec=10
-KillMode=process
-
-[Install]
-WantedBy=multi-user.target
-EOF
-  systemctl enable -q --now cloudflared
-  msg_ok "Created Service"
-fi
-
 motd_ssh
 customize
 cleanup_lxc


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Remove deprecated DNS-over-HTTPS proxy option from cloudflared installer

## 🔗 Related Issue

Fixes #11038

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
