### PR TITLE
authelia: use POSIX-safe arithmetic to avoid exit code 1 with set -e in subshells

### DIFF
--- a/install/authelia-install.sh
+++ b/install/authelia-install.sh
@@ -15,11 +15,10 @@ update_os
 
 fetch_and_deploy_gh_release "authelia" "authelia/authelia" "binary"
 
-get_lxc_ip
 MAX_ATTEMPTS=3
 attempt=0
 while true; do
-  ((attempt++))
+  attempt=$((attempt + 1))
   read -rp "${TAB3}Enter your domain or IP (ex. example.com or 192.168.1.100): " DOMAIN
   if [[ -z "$DOMAIN" ]]; then
     if ((attempt >= MAX_ATTEMPTS)); then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description


## 🔗 Related Issue

Fixes #11117

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
