### PR TITLE
apt-cacher-ng: add avahi-daemon for mDNS service discovery

### DIFF
--- a/install/apt-cacher-ng-install.sh
+++ b/install/apt-cacher-ng-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Apt-Cacher NG"
-DEBIAN_FRONTEND=noninteractive $STD apt -o Dpkg::Options::="--force-confold" install -y apt-cacher-ng
+DEBIAN_FRONTEND=noninteractive $STD apt -o Dpkg::Options::="--force-confold" install -y apt-cacher-ng avahi-daemon
 sed -i 's/# PassThroughPattern: .* # this would allow CONNECT to everything/PassThroughPattern: .*/' /etc/apt-cacher-ng/acng.conf
 cat <<EOF >/etc/apt/apt.conf.d/00aptproxy.conf
 Acquire::http::Proxy "http://localhost:3142";


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
apt-cacher-ng ships with Avahi service config but needs avahi-daemon to advertise itself via mDNS for auto-apt-proxy discovery.


## 🔗 Related Issue

Fixes #11101

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
