### PR TITLE
Karakeep: Add the FFmpeg option to the installation script

### DIFF
--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -22,6 +22,14 @@ $STD apt install -y \
   ghostscript
 msg_ok "Installed Dependencies"
 
+msg_info "Optional Dependency"
+read -r -p "Would you like to add FFmpeg (Recommended for high-quality yt-dlp)? <y/N> " prompt
+if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
+    msg_info "Installing FFmpeg"
+    $STD apt-get install -y ffmpeg
+    msg_ok "Installed FFmpeg"
+fi
+
 fetch_and_deploy_gh_release "monolith" "Y2Z/monolith" "singlefile" "latest" "/usr/bin" "monolith-gnu-linux-x86_64"
 fetch_and_deploy_gh_release "yt-dlp" "yt-dlp/yt-dlp-nightly-builds" "singlefile" "latest" "/usr/bin" "yt-dlp_linux"
 fetch_and_deploy_gh_release "meilisearch" "meilisearch/meilisearch" "binary"

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -19,7 +19,8 @@ $STD apt install -y \
   ca-certificates \
   chromium \
   graphicsmagick \
-  ghostscript
+  ghostscript \
+  ffmpeg
 msg_ok "Installed Dependencies"
 
 msg_info "Optional Dependency"

--- a/install/karakeep-install.sh
+++ b/install/karakeep-install.sh
@@ -23,14 +23,6 @@ $STD apt install -y \
   ffmpeg
 msg_ok "Installed Dependencies"
 
-msg_info "Optional Dependency"
-read -r -p "Would you like to add FFmpeg (Recommended for high-quality yt-dlp)? <y/N> " prompt
-if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
-    msg_info "Installing FFmpeg"
-    $STD apt-get install -y ffmpeg
-    msg_ok "Installed FFmpeg"
-fi
-
 fetch_and_deploy_gh_release "monolith" "Y2Z/monolith" "singlefile" "latest" "/usr/bin" "monolith-gnu-linux-x86_64"
 fetch_and_deploy_gh_release "yt-dlp" "yt-dlp/yt-dlp-nightly-builds" "singlefile" "latest" "/usr/bin" "yt-dlp_linux"
 fetch_and_deploy_gh_release "meilisearch" "meilisearch/meilisearch" "binary"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Add an "installing ffmpeg" option to `install/karakeep-install.sh` script. 

## 🔗 Related Issue

Fixes #11155

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
