### PR TITLE
[FIX] Tautulli: ensure virtualenv is recreated during update; backup tautulli.db

### DIFF
--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -47,7 +47,7 @@ function update_script() {
     TAUTULLI_VERSION=$(get_latest_github_release "Tautulli/Tautulli" "false")
     echo "${TAUTULLI_VERSION}" >/opt/Tautulli/version.txt
     echo "master" >/opt/Tautulli/branch.txt
-    $STD uv venv
+    $STD uv venv -c
     $STD source /opt/Tautulli/.venv/bin/activate
     $STD uv pip install -r requirements.txt
     $STD uv pip install pyopenssl

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -46,11 +46,10 @@ function update_script() {
     TAUTULLI_VERSION=$(get_latest_github_release "Tautulli/Tautulli" "false")
     echo "${TAUTULLI_VERSION}" >/opt/Tautulli/version.txt
     echo "master" >/opt/Tautulli/branch.txt
-    source /opt/Tautulli/.venv/bin/activate
-    $STD pip install --upgrade uv
-    $STD uv pip install -q -r requirements.txt
-    $STD uv pip install -q pyopenssl
-    deactivate
+    $STD uv venv
+    $STD source /opt/Tautulli/.venv/bin/activate
+    $STD uv pip install -r requirements.txt
+    $STD uv pip install pyopenssl
     msg_ok "Updated Tautulli"
 
     msg_info "Restoring config"

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -35,9 +35,10 @@ function update_script() {
     systemctl stop tautulli
     msg_ok "Stopped Service"
 
-    msg_info "Backing up config"
+    msg_info "Backing up config and database"
     cp /opt/Tautulli/config.ini /opt/tautulli_config.ini.backup
-    msg_ok "Backed up config"
+    cp /opt/Tautulli/tautulli.db /opt/tautulli.db.backup
+    msg_ok "Backed up config and database"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Tautulli" "Tautulli/Tautulli" "tarball"
 
@@ -52,10 +53,11 @@ function update_script() {
     $STD uv pip install pyopenssl
     msg_ok "Updated Tautulli"
 
-    msg_info "Restoring config"
+    msg_info "Restoring config and database"
     cp /opt/tautulli_config.ini.backup /opt/Tautulli/config.ini
-    rm -f /opt/tautulli_config.ini.backup
-    msg_ok "Restored config"
+    cp /opt/tautulli.db.backup /opt/Tautulli/tautulli.db
+    rm -f /opt/{tautulli_config.ini.backup,tautulli.db.backup}
+    msg_ok "Restored config and database"
 
     msg_info "Starting Service"
     systemctl start tautulli

--- a/install/tautulli-install.sh
+++ b/install/tautulli-install.sh
@@ -25,9 +25,10 @@ cd /opt/Tautulli
 TAUTULLI_VERSION=$(get_latest_github_release "Tautulli/Tautulli" "false")
 echo "${TAUTULLI_VERSION}" >/opt/Tautulli/version.txt
 echo "master" >/opt/Tautulli/branch.txt
-uv venv -q
-uv pip install -q -r requirements.txt
-uv pip install -q pyopenssl
+$STD uv venv
+$STD source /opt/Tautulli/.venv/bin/activate
+$STD uv pip install -r requirements.txt
+$STD uv pip install pyopenssl
 msg_ok "Installed Tautulli"
 
 msg_info "Creating Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Removes some superfluous commands
- Ensures virtualenv `/opt/Tautulli/.venv` is recreated during update
- Backup and restore of `tautulli.db`

## 🔗 Related Issue

Fixes #11173 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
