### PR TITLE
core: add nesting warning for systemd-based distributions

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1134,6 +1134,10 @@ load_vars_file() {
               msg_warn "Invalid nesting value '$var_val' in $file (must be 0 or 1), ignoring"
               continue
             fi
+            # Warn about potential issues with systemd-based OS when nesting is disabled via vars file
+            if [[ "$var_val" == "0" && "${var_os:-debian}" != "alpine" ]]; then
+              msg_warn "Nesting disabled in $file - modern systemd-based distributions may require nesting for proper operation"
+            fi
             ;;
           var_keyctl)
             if [[ "$var_val" != "0" && "$var_val" != "1" ]]; then
@@ -2394,6 +2398,12 @@ advanced_settings() {
       else
         if [ $? -eq 1 ]; then
           _enable_nesting="0"
+          # Warn about potential issues with systemd-based OS when nesting is disabled
+          if [[ "$var_os" != "alpine" ]]; then
+            whiptail --backtitle "Proxmox VE Helper Scripts" \
+              --title "⚠️ NESTING WARNING" \
+              --msgbox "Modern systemd-based distributions (Debian 13+, Ubuntu 24.04+, etc.) may require nesting to be enabled for proper operation.\n\nWithout nesting, the container may start in a degraded state with failing services (error 243/CREDENTIALS).\n\nIf you experience issues, enable nesting in the container options." 14 68
+          fi
         else
           ((STEP--))
           continue


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Show whiptail warning in advanced settings when nesting is disabled
- Show msg_warn when var_nesting=0 is set via default.vars or app.vars
- Warning explains that modern systemd distros (Debian 12.11/13+, Ubuntu 24.04+) may require nesting for proper operation (error 243/CREDENTIALS)
- Only applies to non-alpine systems (alpine uses OpenRC, not systemd)

## 🔗 Related Issue

Fixes #11204

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
