### PR TITLE
Fix installer loop caused by invalid whiptail menu separator

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2027,6 +2027,10 @@ advanced_settings() {
           "${BRIDGE_MENU_OPTIONS[@]}" \
           3>&1 1>&2 2>&3); then
           local bridge_test="${result:-vmbr0}"
+          # Skip separator entries (e.g., __other__) - re-display menu
+          if [[ "$bridge_test" == "__other__" || "$bridge_test" == -* ]]; then
+            continue
+          fi
           if validate_bridge "$bridge_test"; then
             _bridge="$bridge_test"
             ((STEP++))


### PR DESCRIPTION
### Problem
When running CT installer scripts on a live Proxmox host with active LXC/VMs,
the network bridge selection menu may loop back to the previous step.

Root cause:
- misc/build.func inserts a separator line `--- Other interfaces ---`
- whiptail --menu does not support separators
- strings starting with `--` are parsed as CLI options
- whiptail returns "unknown option", resulting in an empty selection
- installer decrements STEP and loops indefinitely

This issue is reproducible on any non-clean Proxmox host with active
veth/tap/firewall interfaces.

### Fix
Replace the raw separator line with a valid whiptail menu entry that:
- does not start with `-`
- uses a proper tag/description pair
- is safely ignored if selected

This preserves the existing UI structure while preventing whiptail parse errors.

### Notes
- No behavior change on clean hosts
- No user configuration changes required
- Minimal and backward-compatible fix