### PR TITLE
grist: enable optional enterprise features toggle

### DIFF
--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -49,6 +49,7 @@ function update_script() {
     cp /opt/grist_bak/landing.db /opt/grist/landing.db
     cd /opt/grist
     $STD yarn install
+    $STD yarn run install:ee
     $STD yarn run build:prod
     $STD yarn run install:python
     msg_ok "Updated Grist"

--- a/install/grist-install.sh
+++ b/install/grist-install.sh
@@ -27,6 +27,7 @@ export CYPRESS_INSTALL_BINARY=0
 export NODE_OPTIONS="--max-old-space-size=2048"
 cd /opt/grist
 $STD yarn install
+$STD yarn run install:ee
 $STD yarn run build:prod
 $STD yarn run install:python
 cat <<EOF >/opt/grist/.env


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add 'yarn run install:ee' before build:prod
- Allows users to enable optional Enterprise features via admin panel
- Most self-hosters qualify for free EE license

Requested by Grist developer @paulfitz

## 🔗 Related Issue

Fixes #11203

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
