### PR TITLE
feat(ct): add Clawdbot AI assistant

### DIFF
--- a/ct/clawdbot.sh
+++ b/ct/clawdbot.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: JD (pentafive)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/clawdbot/clawdbot
+
+APP="Clawdbot"
+var_tags="${var_tags:-ai;automation;assistant}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -f /etc/systemd/system/clawdbot.service ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  RELEASE=$(npm show clawdbot version 2>/dev/null)
+  CURRENT=$(clawdbot --version 2>/dev/null | head -1 | grep -oP '[\d.]+' || echo "0.0.0")
+
+  if [[ "${RELEASE}" != "${CURRENT}" ]]; then
+    msg_info "Updating ${APP} to v${RELEASE}"
+    $STD npm update -g clawdbot
+    systemctl restart clawdbot
+    msg_ok "Updated ${APP} to v${RELEASE}"
+  else
+    msg_ok "No update required. ${APP} is already at v${CURRENT}"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access the web interface at:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3003${CL}"
+echo -e "${INFO}${YW} Configuration file:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}/opt/clawdbot/config.yaml${CL}"
+echo -e "${INFO}${YW} To configure, edit the config and add your API keys.${CL}"

--- a/frontend/public/json/clawdbot.json
+++ b/frontend/public/json/clawdbot.json
@@ -1,0 +1,48 @@
+{
+  "name": "Clawdbot",
+  "slug": "clawdbot",
+  "categories": [
+    16
+  ],
+  "date_created": "2026-01-27",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 3003,
+  "documentation": "https://docs.clawd.bot",
+  "website": "https://github.com/clawdbot/clawdbot",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/clawdbot.webp",
+  "config_path": "/opt/clawdbot/config.yaml",
+  "description": "Clawdbot is an AI-powered personal assistant that runs as a background daemon, bridging Claude and other LLMs to messaging platforms (Signal, Telegram, Discord, Slack, iMessage), smart home systems, and developer tools. It features multi-channel support, cron scheduling, browser automation, MCP integration, and a built-in web interface. Designed for homelabbers and power users who want an always-on AI assistant with full system access.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/clawdbot.sh",
+      "resources": {
+        "cpu": 2,
+        "ram": 2048,
+        "hdd": 8,
+        "os": "debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "After installation, edit `/opt/clawdbot/config.yaml` to add your Anthropic API key and configure messaging channels.",
+      "type": "warning"
+    },
+    {
+      "text": "View logs with: `journalctl -u clawdbot -f`",
+      "type": "info"
+    },
+    {
+      "text": "CLI commands: `clawdbot gateway status`, `clawdbot gateway restart`",
+      "type": "info"
+    }
+  ]
+}

--- a/install/clawdbot-install.sh
+++ b/install/clawdbot-install.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: JD (pentafive)
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/clawdbot/clawdbot
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  ca-certificates \
+  curl \
+  gnupg \
+  build-essential \
+  git
+msg_ok "Installed Dependencies"
+
+NODE_VERSION="22" setup_nodejs
+
+msg_info "Installing Clawdbot"
+$STD npm install -g clawdbot
+msg_ok "Installed Clawdbot"
+
+msg_info "Creating Configuration"
+mkdir -p /opt/clawdbot
+cat <<EOF >/opt/clawdbot/config.yaml
+# Clawdbot Configuration
+# Documentation: https://docs.clawd.bot
+
+# LLM Provider Configuration
+# Uncomment and configure your preferred provider(s)
+
+# anthropic:
+#   apiKey: "your-anthropic-api-key"
+
+# openai:
+#   apiKey: "your-openai-api-key"
+
+# Gateway Settings
+gateway:
+  port: 3003
+  host: "0.0.0.0"
+
+# Webchat (built-in web interface)
+webchat:
+  enabled: true
+
+# Workspace directory for agent files
+workspace: /opt/clawdbot/workspace
+
+# Logging
+logging:
+  level: info
+EOF
+
+mkdir -p /opt/clawdbot/workspace
+msg_ok "Created Configuration"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/clawdbot.service
+[Unit]
+Description=Clawdbot AI Assistant Gateway
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/clawdbot
+ExecStart=/usr/bin/clawdbot gateway start --config /opt/clawdbot/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now clawdbot
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## Description

Adds installation scripts for **Clawdbot**, an AI-powered personal assistant that runs as a background daemon.

### What is Clawdbot?

Clawdbot bridges Claude and other LLMs to:
- **Messaging platforms**: Signal, Telegram, Discord, Slack, iMessage
- **Smart home systems**: Home Assistant integration
- **Developer tools**: Browser automation, shell access, MCP servers

It's designed for homelabbers and power users who want an always-on AI assistant with full system access.

### Key Features
- Multi-channel messaging support
- Cron scheduling and reminders
- Browser automation (Playwright)
- MCP (Model Context Protocol) integration
- Built-in web interface
- Persistent memory across sessions

### Container Defaults
| Resource | Value |
|----------|-------|
| CPU | 2 cores |
| RAM | 2048 MB |
| Disk | 8 GB |
| OS | Debian 13 |
| Port | 3003 |

### Links
- **Source**: https://github.com/clawdbot/clawdbot
- **Documentation**: https://docs.clawd.bot
- **Discord**: https://discord.com/invite/clawd

### Files Added
- `ct/clawdbot.sh` - Container creation script
- `install/clawdbot-install.sh` - Installation script
- `frontend/public/json/clawdbot.json` - Web interface metadata

### Post-Installation
Users need to edit `/opt/clawdbot/config.yaml` to add their Anthropic API key and configure messaging channels.

---

Tested on Proxmox VE 8.x with Debian 13 LXC.