### PR TITLE
fix(authelia): Downgrade to Debian 12

### DIFF
--- a/ct/authelia.sh
+++ b/ct/authelia.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/authelia.json
+++ b/frontend/public/json/authelia.json
@@ -23,7 +23,7 @@
         "ram": 512,
         "hdd": 2,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],


### PR DESCRIPTION
## The Pull Request

Downgrades Authelia from Debian 13 to Debian 12.

## Reason

Debian 13 LXC template has a critical bug where \/\ is owned by \
obody:nogroup\ instead of \oot:root\. This causes \systemd-tmpfiles --create\ to fail with exit code 73 (NOTRECOVERABLE) during .deb package installation with the error:

\\\
Unsafe path transition / (owned by nobody) → /run (owned by root)
\\\

This affects all scripts that install .deb packages on Debian 13 containers. Until Proxmox/upstream fixes the Debian 13 template, we need to use Debian 12.

## Changes

- \ct/authelia.sh\: Changed \ar_version\ from 13 to 12

## Related

This is a workaround until the upstream Debian 13 LXC template is fixed.