### PR TITLE
feat(gns3): add GNS3 server install script

### DIFF
--- a/ct/gns3.sh
+++ b/ct/gns3.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Yumgi
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/GNS3/gns3-server
+
+# App Default Values
+APP="GNS3"
+var_tags="${var_tags:-network;simulation}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-ubuntu}"
+var_version="${var_version:-22.04}"
+var_unprivileged="${var_unprivileged:-0}"  # Privileged required for nesting/Docker
+
+# GNS3 Version Configuration
+GNS3_VERSION="${GNS3_VERSION:-latest}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+header_info
+check_container_storage
+check_container_resources
+
+# Check if installation exists
+if [[ ! -f /etc/systemd/system/gns3.service ]]; then
+msg_error "No ${APP} Installation Found!"
+exit
+fi
+
+msg_info "Updating ${APP}"
+systemctl stop gns3.service
+
+# Check current version
+CURRENT_VERSION=$(gns3server --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1)
+msg_info "Current version: ${CURRENT_VERSION}"
+
+# Update repository
+$STD apt-get update
+
+# Unhold package for update
+apt-mark unhold gns3-server &>/dev/null
+
+if [[ "$GNS3_VERSION" == "latest" ]]; then
+  msg_info "Installing latest GNS3 version"
+  $STD apt-get install -y --only-upgrade gns3-server
+else
+  PACKAGE_VERSION=$(apt-cache madison gns3-server | grep "$GNS3_VERSION" | head -1 | awk '{print $3}')
+  if [[ -n "$PACKAGE_VERSION" ]]; then
+    msg_info "Installing GNS3 version ${GNS3_VERSION}"
+    $STD apt-get install -y gns3-server=${PACKAGE_VERSION}
+    $STD apt-mark hold gns3-server
+  else
+    msg_error "Version ${GNS3_VERSION} not found"
+    exit 1
+  fi
+fi
+
+# Update Docker images
+msg_info "Updating Docker images"
+docker images --format "{{.Repository}}:{{.Tag}}" | grep gns3 | xargs -r -n 1 docker pull &>/dev/null
+
+systemctl start gns3.service
+
+NEW_VERSION=$(gns3server --version 2>/dev/null | grep -oP '\d+\.\d+\.\d+' | head -1)
+msg_ok "Updated successfully to version ${NEW_VERSION}!"
+exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:3080${CL}"
+echo -e "${INFO}${YW} Connect your GNS3 GUI client to this server${CL}"

--- a/frontend/public/json/gns3.json
+++ b/frontend/public/json/gns3.json
@@ -1,0 +1,39 @@
+{
+  "name": "GNS3",
+  "slug": "gns3",
+  "categories": [
+    10
+  ],
+  "date_created": "2026-01-29",
+  "type": "ct",
+  "updateable": true,
+  "privileged": true,
+  "interface_port": 3080,
+  "documentation": "https://docs.gns3.com/",
+  "website": "https://www.gns3.com/",
+  "logo": "https://raw.githubusercontent.com/GNS3/gns3-gui/master/resources/images/logo_icon_256x256.png",
+  "description": "GNS3 is a network software emulator that allows you to design and test complex network topologies using Cisco, Juniper, and other vendor equipment.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/gns3.sh",
+      "resources": {
+        "cpu": 2,
+        "ram": 4096,
+        "hdd": 8,
+        "os": "ubuntu",
+        "version": "22.04"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    "Container must be privileged for Docker and nested virtualization support",
+    "Default server listens on port 3080",
+    "To install specific version: GNS3_VERSION=2.2.51 bash -c '$(wget -qLO - https://...)'",
+    "Connect your GNS3 GUI client to the server IP on port 3080"
+  ]
+}

--- a/install/gns3-install.sh
+++ b/install/gns3-install.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: Yumgi
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/GNS3/gns3-server
+
+# Import Functions and Setup
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+# =============================================================================
+# DEPENDENCIES
+# =============================================================================
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  software-properties-common \
+  gnupg \
+  apt-transport-https \
+  ca-certificates
+msg_ok "Installed Dependencies"
+
+# =============================================================================
+# GNS3 SERVER INSTALLATION
+# =============================================================================
+msg_info "Adding GNS3 PPA Repository"
+$STD add-apt-repository -y ppa:gns3/ppa
+$STD apt-get update
+msg_ok "Added GNS3 Repository"
+
+msg_info "Installing GNS3 Server"
+# Determine version to install
+GNS3_VERSION="${GNS3_VERSION:-latest}"
+
+if [[ "$GNS3_VERSION" == "latest" ]]; then
+  msg_info "Installing latest GNS3 Server version"
+  $STD apt-get install -y gns3-server
+else
+  msg_info "Installing GNS3 Server version ${GNS3_VERSION}"
+  # Find exact package version
+  PACKAGE_VERSION=$(apt-cache madison gns3-server | grep "$GNS3_VERSION" | head -1 | awk '{print $3}')
+
+  if [[ -z "$PACKAGE_VERSION" ]]; then
+    msg_error "Version ${GNS3_VERSION} not found in repository"
+    msg_info "Available versions:"
+    apt-cache madison gns3-server | awk '{print $3}' | head -5
+    exit 1
+  fi
+
+  $STD apt-get install -y gns3-server=${PACKAGE_VERSION}
+  $STD apt-mark hold gns3-server
+  msg_ok "Installed GNS3 Server ${GNS3_VERSION} (package held)"
+fi
+
+# Install QEMU/KVM for emulation
+$STD apt-get install -y \
+  qemu-kvm \
+  qemu-utils \
+  libvirt-daemon-system \
+  virtinst \
+  bridge-utils \
+  uml-utilities
+msg_ok "Installed GNS3 Server and QEMU"
+
+# =============================================================================
+# DOCKER INSTALLATION (for Docker appliances)
+# =============================================================================
+msg_info "Installing Docker"
+setup_docker
+msg_ok "Installed Docker"
+
+# =============================================================================
+# GNS3 CONFIGURATION
+# =============================================================================
+get_lxc_ip
+
+msg_info "Configuring GNS3 Server"
+# Create GNS3 directories
+mkdir -p /opt/gns3/{images,projects,appliances,configs}
+mkdir -p /etc/gns3
+
+# Configure GNS3 to listen on all interfaces
+cat >/etc/gns3/gns3_server.conf <<EOF
+[Server]
+host = 0.0.0.0
+port = 3080
+path = /opt/gns3
+images_path = /opt/gns3/images
+projects_path = /opt/gns3/projects
+appliances_path = /opt/gns3/appliances
+configs_path = /opt/gns3/configs
+report_errors = True
+
+[Qemu]
+enable_hardware_acceleration = True
+require_hardware_acceleration = True
+EOF
+
+# Set proper permissions
+chown -R root:root /opt/gns3
+chmod -R 755 /opt/gns3
+msg_ok "Configured GNS3 Server"
+
+# =============================================================================
+# SERVICE CREATION
+# =============================================================================
+msg_info "Creating GNS3 Service"
+cat >/etc/systemd/system/gns3.service <<EOF
+[Unit]
+Description=GNS3 Server
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/gns3server --local
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable -q --now gns3.service
+msg_ok "Created GNS3 Service"
+
+# =============================================================================
+# CLEANUP & FINALIZATION
+# =============================================================================
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

This PR adds a complete installation script for GNS3 Server, a network software emulator that allows users to design and test complex network topologies using Cisco, Juniper, and other vendor equipment.

**Key features:**
- Configurable GNS3 version installation (default: latest, or specify version via `GNS3_VERSION` environment variable)
- Full Docker integration for Docker-based network appliances
- QEMU/KVM support for virtual device emulation
- Privileged LXC container with nesting enabled (required for Docker and nested virtualization)
- Systemd service with automatic restart on failure
- Update script included for seamless version upgrades
- Default configuration listening on port 3080

**Usage examples:**
```bash
# Standard installation (latest version)
bash -c "$(wget -qLO - https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/gns3.sh)"

# Specific version installation
GNS3_VERSION=2.2.51 bash -c "$(wget -qLO - https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/gns3.sh)"
