### PR TITLE
[FEAT] Immich: Enable Maintenance Mode before update

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -116,8 +116,10 @@ EOF
   if check_for_gh_release "immich" "immich-app/immich" "${RELEASE}"; then
     if [[ $(cat ~/.immich) > "2.5.1" ]]; then
       msg_info "Enabling Maintenance Mode"
-      $STD bash /opt/immich/app/bin/immich-admin enable-maintenance-mode
+      cd /opt/immich/app/bin
+      $STD bash ./immich-admin enable-maintenance-mode
       export MAINT_MODE=1
+      $STD cd -
       msg_ok "Enabled Maintenance Mode"
     fi
     msg_info "Stopping Services"
@@ -250,8 +252,10 @@ EOF
     chown -R immich:immich "$INSTALL_DIR"
     if [[ "$MAINT_MODE" == 1 ]]; then
       msg_info "Disabling Maintenance Mode"
-      $STD bash /opt/immich/app/bin/immich-admin disable-maintenance-mode
+      cd /opt/immich/app/bin
+      $STD bash ./immich-admin disable-maintenance-mode
       unset MAINT_MODE
+      $STD cd -
       msg_ok "Disabled Maintenance Mode"
     fi
     systemctl restart immich-ml immich-web

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -114,6 +114,12 @@ EOF
 
   RELEASE="2.5.2"
   if check_for_gh_release "immich" "immich-app/immich" "${RELEASE}"; then
+    if [[ $(cat ~/.immich) > "2.5.1" ]]; then
+      msg_info "Enabling Maintenance Mode"
+      $STD bash /opt/immich/app/bin/immich-admin enable-maintenance-mode
+      export MAINT_MODE=1
+      msg_ok "Enabled Maintenance Mode"
+    fi
     msg_info "Stopping Services"
     systemctl stop immich-web
     systemctl stop immich-ml
@@ -242,6 +248,12 @@ EOF
     ln -s "$GEO_DIR" "$APP_DIR"
 
     chown -R immich:immich "$INSTALL_DIR"
+    if [[ "$MAINT_MODE" == 1 ]]; then
+      msg_info "Disabling Maintenance Mode"
+      $STD bash /opt/immich/app/bin/immich-admin disable-maintenance-mode
+      unset MAINT_MODE
+      msg_ok "Disabled Maintenance Mode"
+    fi
     systemctl restart immich-ml immich-web
     msg_ok "Updated successfully!"
   fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- checks that current version is 2.5.1+
- enables maintenance mode and sets flag
- checks for flag and disables maintenance mode after updating

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
