### PR TITLE
Refactor: remove redundant PHP_MODULE entries in several scripts

### DIFF
--- a/ct/2fauth.sh
+++ b/ct/2fauth.sh
@@ -41,7 +41,7 @@ function update_script() {
     msg_ok "Backup Created"
 
     if ! dpkg -l | grep -q 'php8.4'; then
-      PHP_VERSION="8.4" PHP_MODULE="common,ctype,fileinfo,mysql,cli,tokenizer,dom,redis,session,openssl" PHP_FPM="YES" setup_php
+      PHP_VERSION="8.4" PHP_FPM="YES" setup_php
       sed -i 's/php8\.[0-9]/php8.4/g' /etc/nginx/conf.d/2fauth.conf
     fi
     fetch_and_deploy_gh_release "2fauth" "Bubka/2FAuth" "tarball"

--- a/ct/baikal.sh
+++ b/ct/baikal.sh
@@ -37,7 +37,7 @@ function update_script() {
     mv /opt/baikal /opt/baikal-backup
     msg_ok "Backed up data"
 
-    PHP_APACHE="YES" PHP_MODULE="pgsql,curl" PHP_VERSION="8.3" setup_php
+    PHP_APACHE="YES" PHP_VERSION="8.3" setup_php
     setup_composer
     fetch_and_deploy_gh_release "baikal" "sabre-io/Baikal" "tarball"
 

--- a/ct/bar-assistant.sh
+++ b/ct/bar-assistant.sh
@@ -34,7 +34,7 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped nginx"
 
-    PHP_VERSION="8.4" PHP_FPM=YES PHP_MODULE="ffi,redis,pdo-sqlite" setup_php
+    PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="pdo-sqlite" setup_php
 
     msg_info "Backing up Bar Assistant"
     mv /opt/bar-assistant /opt/bar-assistant-backup

--- a/ct/bookstack.sh
+++ b/ct/bookstack.sh
@@ -39,7 +39,7 @@ function update_script() {
     msg_ok "Backup finished"
 
     fetch_and_deploy_gh_release "bookstack" "BookStackApp/BookStack" "tarball"
-    PHP_MODULE="ldap,tidy,bz2,mysqli" PHP_FPM="YES" PHP_APACHE="YES" PHP_VERSION="8.3" setup_php
+    PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="ldap,tidy,mysqli" setup_php
     setup_composer
 
     msg_info "Restoring backup"

--- a/ct/grocy.sh
+++ b/ct/grocy.sh
@@ -29,7 +29,7 @@ function update_script() {
   fi
   php_ver=$(php -v | head -n 1 | awk '{print $2}')
   if [[ ! $php_ver == "8.3"* ]]; then
-    PHP_VERSION="8.3" PHP_MODULE="sqlite3,bz2" PHP_APACHE="yes" setup_php
+    PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
   fi
   if check_for_gh_release "grocy" "grocy/grocy"; then
     msg_info "Updating grocy"

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -32,7 +32,7 @@ function update_script() {
   fi
   setup_mariadb
 
-  PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" setup_php
+  PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
   setup_composer
 
   if check_for_gh_release "kimai" "kimai/kimai"; then

--- a/ct/linkstack.sh
+++ b/ct/linkstack.sh
@@ -28,7 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  PHP_VERSION="8.3" PHP_MODULE="sqlite3" PHP_APACHE="YES" setup_php
+  PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
   msg_warn "LinkStack should be updated via the user interface."
   exit
 }

--- a/ct/paymenter.sh
+++ b/ct/paymenter.sh
@@ -31,7 +31,7 @@ function update_script() {
 
   CURRENT_PHP=$(php -v 2>/dev/null | awk '/^PHP/{print $2}' | cut -d. -f1,2)
   if [[ "$CURRENT_PHP" != "8.3" ]]; then
-    PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="mysql,redis" setup_php
+    PHP_VERSION="8.3" PHP_FPM="YES" setup_php
     setup_composer
     sed -i 's|php8\.2-fpm\.sock|php8.3-fpm.sock|g' /etc/nginx/sites-available/paymenter.conf
     $STD systemctl reload nginx

--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -35,7 +35,7 @@ function update_script() {
   if [[ "$CURRENT_PHP" != "8.4" ]]; then
     msg_info "Migrating PHP $CURRENT_PHP to 8.4"
     $STD apt remove -y php"${CURRENT_PHP//./}"*
-    PHP_VERSION="8.4" PHP_MODULE="mysql,sqlite3" PHP_APACHE="YES" PHP_FPM="YES" setup_php
+    PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" setup_php
     msg_ok "Migrated PHP $CURRENT_PHP to 8.4"
   fi
 

--- a/ct/projectsend.sh
+++ b/ct/projectsend.sh
@@ -36,7 +36,7 @@ function update_script() {
 
     php_ver=$(php -v | head -n 1 | awk '{print $2}')
     if [[ ! $php_ver == "8.4"* ]]; then
-      PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="pdo,mysql,gettext,fileinfo" setup_php
+      PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
     fi
 
     mv /opt/projectsend/includes/sys.config.php /opt/sys.config.php

--- a/ct/snipeit.sh
+++ b/ct/snipeit.sh
@@ -42,7 +42,7 @@ function update_script() {
     msg_ok "Created Backup"
 
     fetch_and_deploy_gh_release "snipe-it" "grokability/snipe-it" "tarball"
-    [[ "$(php -v 2>/dev/null)" == PHP\ 8.2* ]] && PHP_VERSION="8.3" PHP_MODULE="common,ctype,ldap,fileinfo,iconv,mysql,soap,xsl" PHP_FPM="YES" setup_php
+    [[ "$(php -v 2>/dev/null)" == PHP\ 8.2* ]] && PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="ldap,soap,xsl" setup_php
     sed -i 's/php8.2/php8.3/g' /etc/nginx/conf.d/snipeit.conf
     setup_composer
 

--- a/ct/speedtest-tracker.sh
+++ b/ct/speedtest-tracker.sh
@@ -30,7 +30,7 @@ function update_script() {
   fi
 
   if check_for_gh_release "speedtest-tracker" "alexjustesen/speedtest-tracker"; then
-    PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="common,sqlite3,redis" setup_php
+    PHP_VERSION="8.4" PHP_FPM="YES" setup_php
     setup_composer
     NODE_VERSION="22" setup_nodejs
     setcap cap_net_raw+ep /bin/ping

--- a/install/2fauth-install.sh
+++ b/install/2fauth-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y nginx
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.4" PHP_MODULE="common,ctype,fileinfo,mysql,tokenizer,dom,redis" PHP_FPM="YES" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="2fauth_db" MARIADB_DB_USER="2fauth" setup_mariadb_db

--- a/install/baikal-install.sh
+++ b/install/baikal-install.sh
@@ -18,7 +18,7 @@ $STD apt install -y git
 msg_ok "Installed Dependencies"
 
 PG_VERSION="16" setup_postgresql
-PHP_APACHE="YES" PHP_MODULE="pgsql,curl" PHP_VERSION="8.3" setup_php
+PHP_APACHE="YES" PHP_VERSION="8.3" setup_php
 setup_composer
 fetch_and_deploy_gh_release "baikal" "sabre-io/Baikal" "tarball"
 PG_DB_NAME="baikal_db" PG_DB_USER="baikal_user" PG_DB_PASS="$(openssl rand -base64 12)" setup_postgresql_db

--- a/install/bar-assistant-install.sh
+++ b/install/bar-assistant-install.sh
@@ -23,7 +23,7 @@ $STD apt install -y \
   libvips
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.4" PHP_FPM=YES PHP_MODULE="ffi,redis,pdo-sqlite" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="pdo-sqlite" setup_php
 setup_composer
 NODE_VERSION="22" setup_nodejs
 setup_meilisearch

--- a/install/bookstack-install.sh
+++ b/install/bookstack-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y make
 msg_ok "Installed Dependencies"
 
-PHP_MODULE="ldap,tidy,bz2,mysqli" PHP_FPM="YES" PHP_APACHE="YES" PHP_VERSION="8.3" setup_php
+PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="ldap,tidy,mysqli" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="bookstack_db" MARIADB_DB_USER="bookstack_user" setup_mariadb_db

--- a/install/domain-monitor-install.sh
+++ b/install/domain-monitor-install.sh
@@ -26,7 +26,7 @@ $STD apt install -y --no-install-recommends \
   pkg-config
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="mysql" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="domain_monitor" MARIADB_DB_USER="domainmonitor" setup_mariadb_db

--- a/install/firefly-install.sh
+++ b/install/firefly-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="mysql" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="firefly" MARIADB_DB_USER="firefly" setup_mariadb_db

--- a/install/freshrss-install.sh
+++ b/install/freshrss-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_MODULE="curl,common,xml,mbstring,intl,zip,pgsql,gmp" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="freshrss" PG_DB_USER="freshrss_usr" setup_postgresql_db
 

--- a/install/grocy-install.sh
+++ b/install/grocy-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y apt-transport-https
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.3" PHP_MODULE="sqlite3,bz2" PHP_APACHE="yes" setup_php
+PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
 fetch_and_deploy_gh_release "grocy" "grocy/grocy" "prebuild" "latest" "/var/www/html" "grocy*.zip"
 
 msg_info "Configuring grocy"

--- a/install/heimdall-dashboard-install.sh
+++ b/install/heimdall-dashboard-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y apt-transport-https
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.4" PHP_MODULE="bz2,sqlite3" PHP_FPM="YES" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" setup_php
 setup_composer
 fetch_and_deploy_gh_release "Heimdall" "linuxserver/Heimdall" "tarball"
 

--- a/install/hortusfox-install.sh
+++ b/install/hortusfox-install.sh
@@ -15,7 +15,7 @@ update_os
 
 setup_mariadb
 MARIADB_DB_NAME="hortusfox" MARIADB_DB_USER="hortusfox" setup_mariadb_db
-PHP_MODULE="exif,mysql" PHP_APACHE="YES" PHP_FPM="NO" PHP_VERSION="8.3" setup_php
+PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
 setup_composer
 fetch_and_deploy_gh_release "hortusfox" "danielbrendel/hortusfox-web" "tarball"
 

--- a/install/investbrain-install.sh
+++ b/install/investbrain-install.sh
@@ -28,7 +28,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 export PHP_VERSION="8.4"
-PHP_FPM=YES PHP_MODULE="gd,zip,intl,pdo,pgsql,pdo-pgsql,bcmath,opcache,mbstring,redis" setup_php
+PHP_FPM="YES" PHP_MODULE="pdo-pgsql" setup_php
 setup_composer
 NODE_VERSION="22" setup_nodejs
 PG_VERSION="17" setup_postgresql

--- a/install/invoiceninja-install.sh
+++ b/install/invoiceninja-install.sh
@@ -35,7 +35,7 @@ msg_ok "Installed Dependencies"
 
 setup_mariadb
 MARIADB_DB_NAME="invoiceninja" MARIADB_DB_USER="invoiceninja" setup_mariadb_db
-PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="bcmath,curl,gd,gmp,imagick,intl,mbstring,mysql,soap,xml,zip" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="soap" setup_php
 
 fetch_and_deploy_gh_release "invoiceninja" "invoiceninja/invoiceninja" "prebuild" "latest" "/opt/invoiceninja" "invoiceninja.tar.gz"
 

--- a/install/kimai-install.sh
+++ b/install/kimai-install.sh
@@ -22,7 +22,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 setup_mariadb
-PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
 setup_composer
 
 msg_info "Setting up database"

--- a/install/koel-install.sh
+++ b/install/koel-install.sh
@@ -23,7 +23,7 @@ msg_ok "Installed Dependencies"
 
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="koel" PG_DB_USER="koel" setup_postgresql_db
-PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="bz2,exif,imagick,pgsql,sqlite3" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" setup_php
 NODE_VERSION="22" NODE_MODULE="pnpm" setup_nodejs
 setup_composer
 

--- a/install/leantime-install.sh
+++ b/install/leantime-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" PHP_FPM="YES" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" setup_php
 setup_mariadb
 MARIADB_DB_NAME="leantime" MARIADB_DB_USER="leantime" setup_mariadb_db
 fetch_and_deploy_gh_release "leantime" "Leantime/leantime" "prebuild" "latest" "/opt/leantime" Leantime*.tar.gz

--- a/install/librenms-install.sh
+++ b/install/librenms-install.sh
@@ -38,7 +38,7 @@ $STD apt install -y \
   python3-pip
 msg_ok "Installed Python Dependencies"
 
-PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="gmp,mysql,snmp" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="snmp" setup_php
 setup_mariadb
 setup_composer
 PYTHON_VERSION="3.13" setup_uv

--- a/install/limesurvey-install.sh
+++ b/install/limesurvey-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="imap,ldap,mysql" setup_php
+PHP_VERSION="8.3" PHP_APACHE="YES" PHP_FPM="YES" PHP_MODULE="imap,ldap" setup_php
 setup_mariadb
 
 msg_info "Configuring MariaDB Database"

--- a/install/linkstack-install.sh
+++ b/install/linkstack-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.3" PHP_MODULE="sqlite3" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
 fetch_and_deploy_gh_release "linkstack" "linkstackorg/linkstack" "prebuild" "latest" "/var/www/html/" "linkstack.zip"
 
 msg_info "Configuring LinkStack"

--- a/install/monica-install.sh
+++ b/install/monica-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.2" PHP_APACHE="YES" PHP_MODULE="dom,gmp,iconv,mysqli,pdo-mysql,redis,tokenizer" setup_php
+PHP_VERSION="8.2" PHP_APACHE="YES" PHP_MODULE="mysqli,pdo-mysql" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="monica" MARIADB_DB_USER="monica" setup_mariadb_db

--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -16,7 +16,7 @@ update_os
 NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="partdb" PG_DB_USER="partdb" setup_postgresql_db
-PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="xsl,pgsql" PHP_POST_MAX_SIZE="100M" PHP_UPLOAD_MAX_FILESIZE="100M" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="xsl" PHP_POST_MAX_SIZE="100M" PHP_UPLOAD_MAX_FILESIZE="100M" setup_php
 setup_composer
 
 msg_info "Installing Part-DB (Patience)"

--- a/install/paymenter-install.sh
+++ b/install/paymenter-install.sh
@@ -21,7 +21,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 setup_mariadb
-PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="common,mysql,redis" setup_php
+PHP_VERSION="8.3" PHP_FPM="YES" setup_php
 setup_composer
 fetch_and_deploy_gh_release "paymenter" "paymenter/paymenter" "prebuild" "latest" "/opt/paymenter" "paymenter.tar.gz"
 chmod -R 755 /opt/paymenter/storage/* /opt/paymenter/bootstrap/cache/

--- a/install/pelican-panel-install.sh
+++ b/install/pelican-panel-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_MODULE="mysql,sqlite3" PHP_APACHE="YES" PHP_FPM="YES" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" setup_php
 setup_composer
 setup_mariadb
 MARIADB_DB_NAME="panel" MARIADB_DB_USER="pelican" setup_mariadb_db

--- a/install/projectsend-install.sh
+++ b/install/projectsend-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="pdo,mysql,gettext,fileinfo" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
 setup_mariadb
 MARIADB_DB_NAME="projectsend" MARIADB_DB_USER="projectsend" setup_mariadb_db
 fetch_and_deploy_gh_release "projectsend" "projectsend/projectsend" "prebuild" "latest" "/opt/projectsend" "projectsend-r*.zip"

--- a/install/snipeit-install.sh
+++ b/install/snipeit-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   nginx
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.3" PHP_MODULE="common,ctype,ldap,fileinfo,iconv,mysql,soap,xsl" PHP_FPM="YES" setup_php
+PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="ldap,soap,xsl" setup_php
 setup_composer
 fetch_and_deploy_gh_release "snipe-it" "grokability/snipe-it" "tarball"
 setup_mariadb

--- a/install/speedtest-tracker-install.sh
+++ b/install/speedtest-tracker-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
 setcap cap_net_raw+ep /bin/ping
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="common,sqlite3,redis" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" setup_php
 setup_composer
 NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "speedtest-tracker" "alexjustesen/speedtest-tracker" "tarball"

--- a/install/wallabag-install.sh
+++ b/install/wallabag-install.sh
@@ -22,7 +22,7 @@ msg_ok "Installed Dependencies"
 
 setup_mariadb
 MARIADB_DB_NAME="wallabag" MARIADB_DB_USER="wallabag" setup_mariadb_db
-PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="bcmath,bz2,curl,gd,imagick,intl,mbstring,mysql,redis,tidy,xml,zip" setup_php
+PHP_VERSION="8.3" PHP_FPM="YES" PHP_MODULE="tidy" setup_php
 setup_composer
 NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "wallabag" "wallabag/wallabag" "prebuild" "latest" "/opt/wallabag" "wallabag-*.tar.gz"

--- a/install/wallos-install.sh
+++ b/install/wallos-install.sh
@@ -14,7 +14,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="imagick,bz2,sqlite3" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
 fetch_and_deploy_gh_release "wallos" "ellite/Wallos" "tarball"
 
 msg_info "Installing Wallos (Patience)"

--- a/install/wavelog-install.sh
+++ b/install/wavelog-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_MODULE="mysql" PHP_APACHE="YES" PHP_MAX_EXECUTION_TIME="600" setup_php
+PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MAX_EXECUTION_TIME="600" setup_php
 setup_mariadb
 MARIADB_DB_NAME="wavelog" MARIADB_DB_USER="waveloguser" setup_mariadb_db
 fetch_and_deploy_gh_release "wavelog" "wavelog/wavelog" "tarball"

--- a/install/wordpress-install.sh
+++ b/install/wordpress-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-PHP_VERSION="8.4" PHP_FPM="YES" PHP_MODULE="common,snmp,imap,mysql" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.4" PHP_FPM="YES" PHP_APACHE="YES" PHP_MODULE="snmp,imap" setup_php
 setup_mariadb
 MARIADB_DB_NAME="wordpress_db" MARIADB_DB_USER="wordpress" setup_mariadb_db
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4512,7 +4512,7 @@ function setup_php() {
 
   # Base modules - essential for most PHP applications
   # Note: 'common' provides many built-in extensions
-  local BASE_MODULES="cli,common,bcmath,curl,gd,intl,mbstring,readline,xml,zip"
+  local BASE_MODULES="cli,common,bcmath,curl,dom,gd,gmp,intl,mbstring,readline,xml,zip"
 
   # Add opcache only for PHP < 8.5 (it's built-in starting from 8.5)
   if [[ "$PHP_MAJOR" -lt 8 ]] || [[ "$PHP_MAJOR" -eq 8 && "$PHP_MINOR" -lt 5 ]]; then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add dom and gmp to BASE_MODULES in setup_php()
- Remove modules already covered by BASE_MODULES (cli,common,bcmath,curl,dom,gd,gmp,intl,mbstring,readline,xml,zip)
- Remove modules already covered by EXTENDED_MODULES (mysql,sqlite3,pgsql,redis,imagick,bz2,apcu)
- Remove modules already covered by BUILTIN (ctype,exif,ffi,fileinfo,gettext,iconv,pdo,tokenizer)


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
