### PR TITLE
feat(frontend): add contribution CTA to empty search state

### DIFF
--- a/frontend/src/components/command-menu.tsx
+++ b/frontend/src/components/command-menu.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/navigation";
-import { Sparkles } from "lucide-react";
+import { ArrowRightIcon, Sparkles } from "lucide-react";
 import Image from "next/image";
 import React from "react";
 
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/t
 import { DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
+import Link from "next/link";
 
 export function formattedBadge(type: string) {
   switch (type) {
@@ -211,7 +212,27 @@ function CommandMenu() {
         <DialogTitle className="sr-only">Search scripts</DialogTitle>
         <CommandInput placeholder="Search for a script..." />
         <CommandList>
-          <CommandEmpty>{isLoading ? "Loading..." : "No scripts found."}</CommandEmpty>
+          <CommandEmpty>
+            {isLoading ? (
+              "Searching..."
+            ) : (
+              <div className="flex flex-col items-center justify-center py-6 text-center">
+                <p className="text-sm text-muted-foreground">No scripts match your search.</p>
+                <div className="mt-4">
+                  <p className="text-xs text-muted-foreground mb-2">Want to add a new script?</p>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link
+                      href={`https://github.com/community-scripts/${basePath}/tree/main/docs/contribution/GUIDE.md`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Documentation <ArrowRightIcon className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            )}
+          </CommandEmpty>
           {Object.entries(uniqueScriptsByCategory).map(([categoryName, scripts]) => (
             <CommandGroup key={`category:${categoryName}`} heading={categoryName}>
               {scripts.map(script => (


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed.-->

## ✍️ Description
When a user searches for a script that does not exist, the CommandMenu now displays a link to the contribution guide. This encourages community contributions.
<img width="528" height="258" alt="CommandMenu opened with the search query 'Search with no results' to showcase the new contribution CTA." src="https://github.com/user-attachments/assets/d3e8db85-2363-456e-b626-5e5e4cd13cd2" />


## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
