### PR TITLE
various scripts: use ensure_dependencies instead of apt

### DIFF
--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -27,9 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if ! command -v memcached >/dev/null 2>&1; then
-    ensure_dependencies memcached libmemcached-tools
-  fi
+  ensure_dependencies memcached libmemcached-tools
   if check_for_gh_release "adventurelog" "seanmorley15/adventurelog"; then
     msg_info "Stopping Services"
     systemctl stop adventurelog-backend

--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -28,8 +28,7 @@ function update_script() {
     exit
   fi
   if ! command -v memcached >/dev/null 2>&1; then
-    $STD apt update
-    $STD apt install -y memcached libmemcached-tools
+    ensure_dependencies memcached libmemcached-tools
   fi
   if check_for_gh_release "adventurelog" "seanmorley15/adventurelog"; then
     msg_info "Stopping Services"

--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -33,7 +33,7 @@ function update_script() {
 
   if ! dpkg -l | grep -q "^ii  chromium "; then
     msg_info "Installing System Dependencies"
-    $STD apt-get install -y chromium
+    ensure_dependencies chromium
     msg_ok "Installed System Dependencies"
   fi
 

--- a/ct/archivebox.sh
+++ b/ct/archivebox.sh
@@ -31,11 +31,7 @@ function update_script() {
   NODE_VERSION="22" NODE_MODULE="@postlight/parser@latest,single-file-cli@latest" setup_nodejs
   PYTHON_VERSION="3.13" setup_uv
 
-  if ! dpkg -l | grep -q "^ii  chromium "; then
-    msg_info "Installing System Dependencies"
-    ensure_dependencies chromium
-    msg_ok "Installed System Dependencies"
-  fi
+  ensure_dependencies chromium
 
   msg_info "Stopping Service"
   systemctl stop archivebox

--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -29,11 +29,7 @@ function update_script() {
     exit
   fi
 
-  if ! dpkg -s libjpeg-dev >/dev/null 2>&1; then
-    msg_info "Installing Dependencies"
-    ensure_dependencies libjpeg-dev
-    msg_ok "Updated Dependencies"
-  fi
+  ensure_dependencies libjpeg-dev
 
   NODE_VERSION="24" setup_nodejs
 

--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -31,8 +31,7 @@ function update_script() {
 
   if ! dpkg -s libjpeg-dev >/dev/null 2>&1; then
     msg_info "Installing Dependencies"
-    $STD apt-get update
-    $STD apt-get install -y libjpeg-dev
+    ensure_dependencies libjpeg-dev
     msg_ok "Updated Dependencies"
   fi
 

--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -34,11 +34,7 @@ function update_script() {
     systemctl stop commafeed
     msg_ok "Stopped Service"
 
-    if ! [[ $(dpkg -s rsync 2>/dev/null) ]]; then
-      msg_info "Installing Dependencies"
-      ensure_dependencies rsync
-      msg_ok "Installed Dependencies"
-    fi
+    ensure_dependencies rsync
 
     if [ -d /opt/commafeed/data ] && [ "$(ls -A /opt/commafeed/data)" ]; then
       msg_info "Backing up existing data"

--- a/ct/commafeed.sh
+++ b/ct/commafeed.sh
@@ -36,8 +36,7 @@ function update_script() {
 
     if ! [[ $(dpkg -s rsync 2>/dev/null) ]]; then
       msg_info "Installing Dependencies"
-      $STD apt update
-      $STD apt install -y rsync
+      ensure_dependencies rsync
       msg_ok "Installed Dependencies"
     fi
 

--- a/ct/cronicle.sh
+++ b/ct/cronicle.sh
@@ -44,10 +44,7 @@ function update_script() {
     NODE_VERSION="22" setup_nodejs
     if check_for_gh_release "cronicle" "jhuckaby/Cronicle"; then
       msg_info "Installing Dependencies"
-      $STD apt install -y \
-        git \
-        build-essential \
-        ca-certificates
+      ensure_dependencies git build-essential ca-certificates
       msg_ok "Installed Dependencies"
 
       NODE_VERSION="22" setup_nodejs

--- a/ct/dispatcharr.sh
+++ b/ct/dispatcharr.sh
@@ -38,9 +38,7 @@ function update_script() {
     systemctl reload nginx
   fi
 
-  if ! dpkg -s vlc-bin vlc-plugin-base &>/dev/null; then
-    ensure_dependencies vlc-bin vlc-plugin-base
-  fi
+  ensure_dependencies vlc-bin vlc-plugin-base
 
   if check_for_gh_release "Dispatcharr" "Dispatcharr/Dispatcharr"; then
     msg_info "Stopping Services"

--- a/ct/dispatcharr.sh
+++ b/ct/dispatcharr.sh
@@ -39,7 +39,7 @@ function update_script() {
   fi
 
   if ! dpkg -s vlc-bin vlc-plugin-base &>/dev/null; then
-    $STD apt update && $STD apt install -y vlc-bin vlc-plugin-base
+    ensure_dependencies vlc-bin vlc-plugin-base
   fi
 
   if check_for_gh_release "Dispatcharr" "Dispatcharr/Dispatcharr"; then

--- a/ct/fumadocs.sh
+++ b/ct/fumadocs.sh
@@ -44,7 +44,7 @@ function update_script() {
     exit
   fi
   if ! command -v git &>/dev/null; then
-    $STD apt install -y git
+    ensure_dependencies git
   fi
 
   msg_info "Stopping service $SERVICE_NAME"

--- a/ct/fumadocs.sh
+++ b/ct/fumadocs.sh
@@ -43,9 +43,7 @@ function update_script() {
     msg_error "Project directory does not exist: $PROJECT_DIR"
     exit
   fi
-  if ! command -v git &>/dev/null; then
-    ensure_dependencies git
-  fi
+  ensure_dependencies git
 
   msg_info "Stopping service $SERVICE_NAME"
   systemctl stop "$SERVICE_NAME"

--- a/ct/graylog.sh
+++ b/ct/graylog.sh
@@ -45,7 +45,7 @@ function update_script() {
     curl -fsSL "https://packages.graylog2.org/repo/packages/graylog-7.0-repository_latest.deb" -o "graylog-7.0-repository_latest.deb"
     $STD dpkg -i graylog-7.0-repository_latest.deb
     $STD apt update
-    $STD apt install -y graylog-server graylog-datanode
+    ensure_dependencies graylog-server graylog-datanode
     rm -f graylog-7.0-repository_latest.deb
     msg_ok "Updated Graylog"
   elif dpkg --compare-versions "$CURRENT_VERSION" ge "7.0"; then

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -30,13 +30,7 @@ function update_script() {
 
   get_lxc_ip  
   NODE_VERSION="22" NODE_MODULE="pnpm@latest" setup_nodejs
-  if ! command -v jq &>/dev/null; then
-    $STD msg_info "Installing jq..."
-    ensure_dependencies jq || {
-      msg_error "Failed to install jq"
-      exit
-    }
-  fi
+  ensure_dependencies jq
 
   if check_for_gh_release "homepage" "gethomepage/homepage"; then
     msg_info "Stopping service"

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -32,8 +32,7 @@ function update_script() {
   NODE_VERSION="22" NODE_MODULE="pnpm@latest" setup_nodejs
   if ! command -v jq &>/dev/null; then
     $STD msg_info "Installing jq..."
-    $STD apt-get update -qq &>/dev/null
-    $STD apt-get install -y jq &>/dev/null || {
+    ensure_dependencies jq || {
       msg_error "Failed to install jq"
       exit
     }

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -133,9 +133,8 @@ EOF
       $STD sudo -u postgres psql -d immich -c "REINDEX INDEX face_index;"
       $STD sudo -u postgres psql -d immich -c "REINDEX INDEX clip_index;"
     fi
-    if ! dpkg -l | grep -q ccache; then
       ensure_dependencies ccache
-    fi
+
 
     INSTALL_DIR="/opt/${APP}"
     UPLOAD_DIR="$(sed -n '/^IMMICH_MEDIA_LOCATION/s/[^=]*=//p' /opt/immich/.env)"
@@ -303,10 +302,7 @@ function compile_libjxl() {
 
 function compile_libheif() {
   SOURCE=${SOURCE_DIR}/libheif
-  if ! dpkg -l | grep -q libaom; then
-    ensure_dependencies libaom-dev
-    local update="required"
-  fi
+  ensure_dependencies libaom-dev
   : "${LIBHEIF_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libheif.json)}"
   if [[ "${update:-}" ]] || [[ "$LIBHEIF_REVISION" != "$(grep 'libheif' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libheif"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -135,7 +135,7 @@ EOF
       $STD sudo -u postgres psql -d immich -c "REINDEX INDEX clip_index;"
     fi
     if ! dpkg -l | grep -q ccache; then
-      $STD apt install -yqq ccache
+      ensure_dependencies ccache
     fi
 
     INSTALL_DIR="/opt/${APP}"
@@ -305,7 +305,7 @@ function compile_libjxl() {
 function compile_libheif() {
   SOURCE=${SOURCE_DIR}/libheif
   if ! dpkg -l | grep -q libaom; then
-    $STD apt install -y libaom-dev
+    ensure_dependencies libaom-dev
     local update="required"
   fi
   : "${LIBHEIF_REVISION:=$(jq -cr '.revision' "$BASE_DIR"/server/sources/libheif.json)}"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -67,8 +67,7 @@ EOF
     msg_info "Installing Mise"
     curl -fSs https://mise.jdx.dev/gpg-key.pub | tee /etc/apt/keyrings/mise-archive-keyring.pub 1>/dev/null
     echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.pub arch=amd64] https://mise.jdx.dev/deb stable main" >/etc/apt/sources.list.d/mise.list
-    $STD apt update
-    $STD apt install -y mise
+    ensure_dependencies mise
     msg_ok "Installed Mise"
   fi
 

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -41,7 +41,7 @@ function update_script() {
 
   msg_info "Updating Jellyfin"
   if ! dpkg -s libjemalloc2 >/dev/null 2>&1; then
-    $STD apt install -y libjemalloc2
+    ensure_dependencies libjemalloc2
   fi
   if [[ ! -f /usr/lib/libjemalloc.so ]]; then
     ln -sf /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -40,9 +40,7 @@ function update_script() {
   fi
 
   msg_info "Updating Jellyfin"
-  if ! dpkg -s libjemalloc2 >/dev/null 2>&1; then
-    ensure_dependencies libjemalloc2
-  fi
+  ensure_dependencies libjemalloc2
   if [[ ! -f /usr/lib/libjemalloc.so ]]; then
     ln -sf /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so
   fi

--- a/ct/karakeep.sh
+++ b/ct/karakeep.sh
@@ -38,7 +38,7 @@ function update_script() {
     msg_ok "Updated yt-dlp"
 
     msg_info "Prepare update"
-    $STD apt install -y graphicsmagick ghostscript
+    ensure_dependencies graphicsmagick ghostscript
     if [[ -f /opt/karakeep/.env ]] && [[ ! -f /etc/karakeep/karakeep.env ]]; then
       mkdir -p /etc/karakeep
       mv /opt/karakeep/.env /etc/karakeep/karakeep.env

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -24,7 +24,7 @@ function update_script() {
   check_container_storage
   check_container_resources
   if ! command -v lsb_release; then
-    apt install -y lsb-release
+    ensure_dependencies lsb-release
   fi
   if [[ ! -d /opt/kimai ]]; then
     msg_error "No ${APP} Installation Found!"

--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -23,9 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if ! command -v lsb_release; then
-    ensure_dependencies lsb-release
-  fi
+  ensure_dependencies lsb-release
   if [[ ! -d /opt/kimai ]]; then
     msg_error "No ${APP} Installation Found!"
     exit

--- a/ct/neo4j.sh
+++ b/ct/neo4j.sh
@@ -27,9 +27,8 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if ! dpkg -l | grep -q temurin-21-jre; then
-    JAVA_VERSION="21" setup_java
-  fi
+  JAVA_VERSION="21" setup_java
+
   msg_info "Updating ${APP}"
   $STD apt update
   $STD apt -y upgrade

--- a/ct/netvisor.sh
+++ b/ct/netvisor.sh
@@ -36,12 +36,7 @@ function update_script() {
   NODE_VERSION="24" setup_nodejs
   CLEAN_INSTALL=1 fetch_and_deploy_gh_release "scanopy" "scanopy/scanopy" "tarball" "latest" "/opt/scanopy"
 
-  if ! dpkg -l | grep -q "pkg-config"; then
-    ensure_dependencies pkg-config
-  fi
-  if ! dpkg -l | grep -q "libssl-dev"; then
-    $STD apt install -y libssl-dev
-  fi
+  ensure_dependencies pkg-config libssl-dev
   TOOLCHAIN="$(grep "channel" /opt/scanopy/backend/rust-toolchain.toml | awk -F\" '{print $2}')"
   RUST_TOOLCHAIN=$TOOLCHAIN setup_rust
 

--- a/ct/netvisor.sh
+++ b/ct/netvisor.sh
@@ -37,7 +37,7 @@ function update_script() {
   CLEAN_INSTALL=1 fetch_and_deploy_gh_release "scanopy" "scanopy/scanopy" "tarball" "latest" "/opt/scanopy"
 
   if ! dpkg -l | grep -q "pkg-config"; then
-    $STD apt install -y pkg-config
+    ensure_dependencies pkg-config
   fi
   if ! dpkg -l | grep -q "libssl-dev"; then
     $STD apt install -y libssl-dev

--- a/ct/odoo.sh
+++ b/ct/odoo.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
   if ! [[ $(dpkg -s python3-lxml-html-clean 2>/dev/null) ]]; then
-    $STD apt install python3-lxml
+    ensure_dependencies python3-lxml
     curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
     $STD dpkg -i /opt/python3-lxml-html-clean.deb
     rm -f /opt/python3-lxml-html-clean.deb

--- a/ct/odoo.sh
+++ b/ct/odoo.sh
@@ -28,8 +28,8 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  ensure_dependencies python3-lxml
   if ! [[ $(dpkg -s python3-lxml-html-clean 2>/dev/null) ]]; then
-    ensure_dependencies python3-lxml
     curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
     $STD dpkg -i /opt/python3-lxml-html-clean.deb
     rm -f /opt/python3-lxml-html-clean.deb

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -34,7 +34,7 @@ function update_script() {
     fi
     if ! command -v zstd &>/dev/null; then
       msg_info "Installing zstd"
-      $STD apt install -y zstd
+      ensure_dependencies zstd
       msg_ok "Installed zstd"
     fi
     msg_info "Stopping Services"

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -32,11 +32,7 @@ function update_script() {
     if [[ ! -f /opt/Ollama_version.txt ]]; then
       touch /opt/Ollama_version.txt
     fi
-    if ! command -v zstd &>/dev/null; then
-      msg_info "Installing zstd"
-      ensure_dependencies zstd
-      msg_ok "Installed zstd"
-    fi
+    ensure_dependencies zstd
     msg_info "Stopping Services"
     systemctl stop ollama
     msg_ok "Services Stopped"

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -92,11 +92,7 @@ EOF
     OLLAMA_VERSION=$(ollama -v | awk '{print $NF}')
     RELEASE=$(curl -s https://api.github.com/repos/ollama/ollama/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}')
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
-      if ! command -v zstd &>/dev/null; then
-        msg_info "Installing zstd"
-        ensure_dependencies zstd
-        msg_ok "Installed zstd"
-      fi
+      ensure_dependencies zstd
       msg_info "Ollama update available: v$OLLAMA_VERSION -> v$RELEASE"
       msg_info "Downloading Ollama v$RELEASE \n"
       curl -fS#LO https://github.com/ollama/ollama/releases/download/v${RELEASE}/ollama-linux-amd64.tar.zst

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -94,7 +94,7 @@ EOF
     if [ "$OLLAMA_VERSION" != "$RELEASE" ]; then
       if ! command -v zstd &>/dev/null; then
         msg_info "Installing zstd"
-        $STD apt install -y zstd
+        ensure_dependencies zstd
         msg_ok "Installed zstd"
       fi
       msg_info "Ollama update available: v$OLLAMA_VERSION -> v$RELEASE"

--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -69,7 +69,7 @@ function update_script() {
       if [ "$VERSION_CODENAME" = "bookworm" ]; then
         setup_gs
       else
-        $STD apt install -y ghostscript
+        ensure_dependencies ghostscript
       fi
 
       msg_info "Updating Paperless-ngx"
@@ -145,7 +145,7 @@ function update_script() {
         setup_gs
       else
         msg_info "Installing Ghostscript"
-        $STD apt install -y ghostscript
+        ensure_dependencies ghostscript
         msg_ok "Installed Ghostscript"
       fi
 

--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -45,7 +45,7 @@ function update_script() {
     LIBHEIF_URL=$(curl -fsSL "https://dl.photoprism.app/dist/libheif/" | grep -oP "libheif-bookworm-amd64-v[0-9\.]+\.tar\.gz" | sort -V | tail -n 1)
     if [[ "${LIBHEIF_URL}" != "$(cat ~/.photoprism_libheif 2>/dev/null)" ]] || [[ ! -f ~/.photoprism_libheif ]]; then
       msg_info "Updating PhotoPrism LibHeif"
-      $STD apt install -y libvips42
+      ensure_dependencies libvips42
       curl -fsSL "https://dl.photoprism.app/dist/libheif/$LIBHEIF_URL" -o /tmp/libheif.tar.gz
       tar -xzf /tmp/libheif.tar.gz -C /usr/local
       ldconfig

--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -41,7 +41,7 @@ function update_script() {
     cp -R /opt/rdtc-backup/appsettings.json /opt/rdtc/
     if dpkg-query -W dotnet-sdk-8.0 >/dev/null 2>&1; then
       $STD apt remove --purge -y dotnet-sdk-8.0
-      $STD apt install -y aspnetcore-runtime-9.0
+      ensure_dependencies aspnetcore-runtime-9.0
     fi
     rm -rf /opt/rdtc-backup
 

--- a/ct/scanopy.sh
+++ b/ct/scanopy.sh
@@ -43,7 +43,7 @@ function update_script() {
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "scanopy" "scanopy/scanopy" "tarball" "latest" "/opt/scanopy"
 
     if ! dpkg -l | grep -q "pkg-config"; then
-      $STD apt install -y pkg-config
+      ensure_dependencies pkg-config
     fi
     if ! dpkg -l | grep -q "libssl-dev"; then
       $STD apt install -y libssl-dev

--- a/ct/scanopy.sh
+++ b/ct/scanopy.sh
@@ -42,12 +42,7 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "scanopy" "scanopy/scanopy" "tarball" "latest" "/opt/scanopy"
 
-    if ! dpkg -l | grep -q "pkg-config"; then
-      ensure_dependencies pkg-config
-    fi
-    if ! dpkg -l | grep -q "libssl-dev"; then
-      $STD apt install -y libssl-dev
-    fi
+    ensure_dependencies pkg-config libssl-dev
     TOOLCHAIN="$(grep "channel" /opt/scanopy/backend/rust-toolchain.toml | awk -F\" '{print $2}')"
     RUST_TOOLCHAIN=$TOOLCHAIN setup_rust
 

--- a/ct/twingate-connector.sh
+++ b/ct/twingate-connector.sh
@@ -30,8 +30,7 @@ function update_script() {
   fi
 
   msg_info "Updating ${APP}"
-  $STD apt update
-  $STD apt install -yq twingate-connector
+  ensure_dependencies twingate-connector
   $STD systemctl restart twingate-connector
   msg_ok "Updated successfully!"
   exit

--- a/ct/unifi.sh
+++ b/ct/unifi.sh
@@ -32,7 +32,7 @@ function update_script() {
 
   msg_info "Updating ${APP}"
   $STD apt update --allow-releaseinfo-change
-  $STD apt install -y unifi
+  ensure_dependencies unifi
   msg_ok "Updated successfully!"
   exit
 }

--- a/ct/uptimekuma.sh
+++ b/ct/uptimekuma.sh
@@ -32,8 +32,7 @@ function update_script() {
 
   if ! dpkg -s chromium >/dev/null 2>&1; then
     msg_info "Installing Chromium"
-    $STD apt update
-    $STD apt install -y chromium
+    ensure_dependencies chromium
     ln -s /usr/bin/chromium /opt/uptime-kuma/chromium
     msg_ok "Installed Chromium"
   fi

--- a/ct/uptimekuma.sh
+++ b/ct/uptimekuma.sh
@@ -30,11 +30,9 @@ function update_script() {
 
   NODE_VERSION="22" setup_nodejs
 
-  if ! dpkg -s chromium >/dev/null 2>&1; then
-    msg_info "Installing Chromium"
-    ensure_dependencies chromium
+  ensure_dependencies chromium
+  if [[ ! -L /opt/uptime-kuma/chromium ]]; then
     ln -s /usr/bin/chromium /opt/uptime-kuma/chromium
-    msg_ok "Installed Chromium"
   fi
 
   if check_for_gh_release "uptime-kuma" "louislam/uptime-kuma"; then

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -86,7 +86,7 @@ function update_script() {
   if [ "$UPD" == "3" ]; then
     if NEWTOKEN=$(whiptail --backtitle "Proxmox VE Helper Scripts" --passwordbox "Set the ADMIN_TOKEN" 10 58 3>&1 1>&2 2>&3); then
       if [[ -z "$NEWTOKEN" ]]; then exit; fi
-      if ! command -v argon2 >/dev/null 2>&1; then ensure_dependencies argon2; fi
+      ensure_dependencies argon2
       TOKEN=$(echo -n "${NEWTOKEN}" | argon2 "$(openssl rand -base64 32)" -t 2 -m 16 -p 4 -l 64 -e)
       sed -i "s|ADMIN_TOKEN=.*|ADMIN_TOKEN='${TOKEN}'|" /opt/vaultwarden/.env
       if [[ -f /opt/vaultwarden/data/config.json ]]; then

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -86,7 +86,7 @@ function update_script() {
   if [ "$UPD" == "3" ]; then
     if NEWTOKEN=$(whiptail --backtitle "Proxmox VE Helper Scripts" --passwordbox "Set the ADMIN_TOKEN" 10 58 3>&1 1>&2 2>&3); then
       if [[ -z "$NEWTOKEN" ]]; then exit; fi
-      if ! command -v argon2 >/dev/null 2>&1; then $STD apt-get install -y argon2; fi
+      if ! command -v argon2 >/dev/null 2>&1; then ensure_dependencies argon2; fi
       TOKEN=$(echo -n "${NEWTOKEN}" | argon2 "$(openssl rand -base64 32)" -t 2 -m 16 -p 4 -l 64 -e)
       sed -i "s|ADMIN_TOKEN=.*|ADMIN_TOKEN='${TOKEN}'|" /opt/vaultwarden/.env
       if [[ -f /opt/vaultwarden/data/config.json ]]; then

--- a/ct/wastebin.sh
+++ b/ct/wastebin.sh
@@ -27,9 +27,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if ! [[ $(dpkg -s zstd 2>/dev/null) ]]; then
-    ensure_dependencies zstd
-  fi
+  ensure_dependencies zstd
   RELEASE=$(curl -fsSL https://api.github.com/repos/matze/wastebin/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
   # Dirty-Fix 03/2025 for missing APP_version.txt on old installations, set to pre-latest release
   msg_info "Running Migration"

--- a/ct/wastebin.sh
+++ b/ct/wastebin.sh
@@ -28,8 +28,7 @@ function update_script() {
     exit
   fi
   if ! [[ $(dpkg -s zstd 2>/dev/null) ]]; then
-    $STD apt update
-    $STD apt install -y zstd
+    ensure_dependencies zstd
   fi
   RELEASE=$(curl -fsSL https://api.github.com/repos/matze/wastebin/releases/latest | grep "tag_name" | awk '{print substr($2, 2, length($2)-3) }')
   # Dirty-Fix 03/2025 for missing APP_version.txt on old installations, set to pre-latest release


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
use ensure_dependencies instead of several apt and dpkg script parts

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
