### PR TITLE
feat(frontend): preview tab

### DIFF
--- a/frontend/src/app/json-editor/_components/note.tsx
+++ b/frontend/src/app/json-editor/_components/note.tsx
@@ -105,7 +105,7 @@ function Note({
   const addNote = useCallback(() => {
     setScript({
       ...script,
-      notes: [...script.notes, { text: "", type: "" }],
+      notes: [...script.notes, { text: "", type: "info" }],
     });
   }, [script, setScript]);
 

--- a/frontend/src/app/json-editor/_schemas/schemas.ts
+++ b/frontend/src/app/json-editor/_schemas/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AlertColors } from "@/config/site-config";
 
 export const InstallMethodSchema = z.object({
   type: z.enum(["default", "alpine"], {
@@ -16,7 +17,9 @@ export const InstallMethodSchema = z.object({
 
 const NoteSchema = z.object({
   text: z.string().min(1, "Note text cannot be empty"),
-  type: z.string().min(1, "Note type cannot be empty"),
+  type: z.enum(Object.keys(AlertColors) as [keyof typeof AlertColors, ...(keyof typeof AlertColors)[]], {
+    message: `Type must be one of: ${Object.keys(AlertColors).join(", ")}`,
+  }),
 });
 
 export const ScriptSchema = z.object({
@@ -42,7 +45,7 @@ export const ScriptSchema = z.object({
     username: z.string().nullable(),
     password: z.string().nullable(),
   }),
-  notes: z.array(NoteSchema),
+  notes: z.array(NoteSchema).optional().default([]),
 }).refine((data) => {
   if (data.disable === true && !data.disable_description) {
     return false;

--- a/frontend/src/app/scripts/_components/script-item.tsx
+++ b/frontend/src/app/scripts/_components/script-item.tsx
@@ -4,7 +4,8 @@ import { X, HelpCircle } from "lucide-react";
 import { Suspense } from "react";
 import Image from "next/image";
 
-import type { AppVersion, Script } from "@/lib/types";
+import type { AppVersion } from "@/lib/types";
+import type { Script } from "@/app/json-editor/_schemas/schemas";
 
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -26,7 +27,6 @@ import Alerts from "./script-items/alerts";
 
 type ScriptItemProps = {
   item: Script;
-  setSelectedScript: (script: string | null) => void;
 };
 
 function ScriptHeader({ item }: { item: Script }) {
@@ -135,25 +135,10 @@ function VersionInfo({ item }: { item: Script }) {
   );
 }
 
-export function ScriptItem({ item, setSelectedScript }: ScriptItemProps) {
-  const closeScript = () => {
-    window.history.pushState({}, document.title, window.location.pathname);
-    setSelectedScript(null);
-  };
-
+export function ScriptItem({ item }: ScriptItemProps) {
   return (
     <div className="w-full mx-auto">
       <div className="flex w-full flex-col">
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-2xl font-semibold tracking-tight text-foreground/90">Selected Script</h2>
-          <button
-            onClick={closeScript}
-            className="rounded-full p-2 text-muted-foreground hover:bg-card/50 transition-colors"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
         <div className="rounded-xl border border-border bg-accent/30 backdrop-blur-sm shadow-sm">
           <div className="p-6 space-y-6">
             <Suspense fallback={<div className="animate-pulse h-32 bg-accent/20 rounded-xl" />}>
@@ -162,7 +147,7 @@ export function ScriptItem({ item, setSelectedScript }: ScriptItemProps) {
 
             {item.disable && item.disable_description && (
               <DisableDescription item={item} />
-            ) }
+            )}
 
             {!item.disable && (
               <>

--- a/frontend/src/app/scripts/page.tsx
+++ b/frontend/src/app/scripts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { Suspense, useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { useQueryState } from "nuqs";
 
 import type { Category, Script } from "@/lib/types";
@@ -19,6 +19,11 @@ function ScriptContent() {
   const [links, setLinks] = useState<Category[]>([]);
   const [item, setItem] = useState<Script>();
   const [latestPage, setLatestPage] = useState(1);
+
+  const closeScript = () => {
+    window.history.pushState({}, document.title, window.location.pathname);
+    setSelectedScript(null);
+  };
 
   useEffect(() => {
     if (selectedScript && links.length > 0) {
@@ -53,7 +58,18 @@ function ScriptContent() {
         <div className="px-4 w-full sm:max-w-[calc(100%-350px-16px)]">
           {selectedScript && item
             ? (
-                <ScriptItem item={item} setSelectedScript={setSelectedScript} />
+                <div className="flex w-full flex-col">
+                  <div className="mb-3 flex items-center justify-between">
+                    <h2 className="text-2xl font-semibold tracking-tight text-foreground/90">Selected Script</h2>
+                    <button
+                      onClick={closeScript}
+                      className="rounded-full p-2 text-muted-foreground hover:bg-card/50 transition-colors"
+                    >
+                      <X className="h-5 w-5" />
+                    </button>
+                  </div>
+                  <ScriptItem item={item} />
+                </div>
               )
             : (
                 <div className="flex w-full flex-col gap-5">

--- a/frontend/src/components/navigation/mobile-sidebar.tsx
+++ b/frontend/src/components/navigation/mobile-sidebar.tsx
@@ -119,7 +119,6 @@ function MobileSidebar() {
                   <p className="text-sm font-medium">Last Viewed</p>
                   <ScriptItem
                     item={lastViewedScript}
-                    setSelectedScript={isOnScriptsPage ? setSelectedScript : setTempSelectedScript}
                   />
                 </div>
               )
@@ -131,3 +130,4 @@ function MobileSidebar() {
 }
 
 export default MobileSidebar;
+

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -5,7 +5,7 @@ export type Script = {
   slug: string;
   categories: number[];
   date_created: string;
-  type: "vm" | "ct" | "pve" | "addon";
+  type: "vm" | "ct" | "pve" | "addon" | "turnkey";
   updateable: boolean;
   privileged: boolean;
   interface_port: number | null;
@@ -31,12 +31,10 @@ export type Script = {
     username: string | null;
     password: string | null;
   };
-  notes: [
-    {
-      text: string;
-      type: keyof typeof AlertColors;
-    },
-  ];
+  notes: {
+    text: string;
+    type: keyof typeof AlertColors;
+  }[];
 };
 
 export type Category = {


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
New tabbed interface in the JSON editor to allow switching between raw JSON and a rendered component preview.

Changes:
- auto-revert to 'JSON' tab if schema validation fails while in preview mode.
- Decoupled 'Selected Script' header and close logic from ScriptItem to allow for reusable rendering in the preview pane.
- Enhanced Zod schema for notes by enforcing enums based on AlertColors
- Defaulting new notes to 'info'.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9f6d9b01-9e30-4495-b81b-53e3971d17f5" />

_Preview tab_
## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
