### PR TITLE
[FEAT] Scanopy: automatically update integrated daemon

### DIFF
--- a/ct/scanopy.sh
+++ b/ct/scanopy.sh
@@ -67,11 +67,18 @@ function update_script() {
     mv ./target/release/server /usr/bin/scanopy-server
     msg_ok "Built scanopy-server"
 
+    [[ -f /etc/systemd/system/scanopy-daemon.service ]] &&
+      fetch_and_deploy_gh_release "scanopy" "scanopy/scanopy" "singlefile" "latest" "/usr/local/bin" "scanopy-daemon-linux-amd64" &&
+      rm -f /usr/bin/scanopy-daemon ~/configure_daemon.sh &&
+      sed -i -e 's|usr/bin|usr/local/bin|' \
+        -e 's/push/daemon_poll/' \
+        -e 's/pull/server_poll/' /etc/systemd/system/scanopy-daemon.service &&
+      systemctl daemon-reload
+
     msg_info "Starting services"
     systemctl start scanopy-server
     [[ -f /etc/systemd/system/scanopy-daemon.service ]] && systemctl start scanopy-daemon
     msg_ok "Updated successfully!"
-    msg_warn "Update your integrated daemon via the UI"
   fi
   exit
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Although we cannot configure the daemon for the user, once it's installed we can at least update it to the latest version whenever there is an update to the Scanopy server.
- Also edits the daemon service file (if it exists) to use the new 'daemon_poll/server_poll' for the daemon mode.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
