### PR TITLE
[FIX] tools.func: trim spaces in app_lc when checking for gh release

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1531,7 +1531,8 @@ check_for_gh_release() {
   local app="$1"
   local source="$2"
   local pinned_version_in="${3:-}" # optional
-  local app_lc="${app,,}"
+  local app_lc=""
+  app_lc="$(echo "${app,,}" | tr -d ' ')"
   local current_file="$HOME/.${app_lc}"
 
   msg_info "Checking for update: ${app}"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Don't know if this caused any problems for any deployments but I noticed that `fetch_and_deploy_gh_release` [trims all spaces](https://github.com/community-scripts/ProxmoxVE/blob/fb368bc2d88279c35e2864f5c32c8b3e8547ca94/misc/tools.func#L2329) before writing the .<app> file, so I figured that `check_for_gh_release` should as well.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
