### PR TITLE
fix(frontend): implement weighted search scoring for command menu

### DIFF
--- a/frontend/src/components/command-menu.tsx
+++ b/frontend/src/components/command-menu.tsx
@@ -23,6 +23,33 @@ import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
 import Link from "next/link";
 
+function search(scripts: Script[], query: string): Script[] {
+  const queryLower = query.toLowerCase().trim();
+  const searchWords = queryLower.split(/\s+/).filter(Boolean);
+
+  return scripts
+    .map(script => {
+      const nameLower = script.name.toLowerCase();
+      const descriptionLower = (script.description || "").toLowerCase();
+
+      let score = 0;
+
+      for (const word of searchWords) {
+        if (nameLower.includes(word)) {
+          score += 10;
+        }
+        if (descriptionLower.includes(word)) {
+          score += 5;
+        }
+      }
+
+      return { script, score };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map(({ script }) => script);
+}
+
 export function formattedBadge(type: string) {
   switch (type) {
     case "vm":
@@ -51,9 +78,11 @@ function getRandomScript(categories: Category[], previouslySelected: Set<string>
 }
 
 function CommandMenu() {
+  const [query, setQuery] = React.useState("");
   const [open, setOpen] = React.useState(false);
   const [links, setLinks] = React.useState<Category[]>([]);
   const [isLoading, setIsLoading] = React.useState(false);
+  const [results, setResults] = React.useState<Script[]>([]);
   const [selectedScripts, setSelectedScripts] = React.useState<Set<string>>(new Set());
   const router = useRouter();
 
@@ -69,6 +98,27 @@ function CommandMenu() {
         console.error(error);
       });
   };
+
+  React.useEffect(() => {
+    if (query.trim() === "") {
+      fetchSortedCategories();
+    }
+    else {
+      const scriptMap = new Map<string, Script>();
+
+      for (const category of links) {
+        for (const script of category.scripts || []) {
+          if (!scriptMap.has(script.slug)) {
+            scriptMap.set(script.slug, script);
+          }
+        }
+      }
+
+      const uniqueScripts = Array.from(scriptMap.values());
+      const filteredResults = search(uniqueScripts, query);
+      setResults(filteredResults);
+    }
+  }, [query]);
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -197,20 +247,20 @@ function CommandMenu() {
 
       <CommandDialog
         open={open}
-        onOpenChange={setOpen}
-        filter={(value: string, search: string) => {
-          const searchLower = search.toLowerCase().trim();
-          if (!searchLower)
-            return 1;
-          const valueLower = value.toLowerCase();
-          const searchWords = searchLower.split(/\s+/).filter(Boolean);
-          // All search words must appear somewhere in the value (name + description)
-          const allWordsMatch = searchWords.every((word: string) => valueLower.includes(word));
-          return allWordsMatch ? 1 : 0;
+        onOpenChange={(open) => {
+          setOpen(open);
+          if (open) {
+            setQuery("");
+            setResults([]);
+          }
         }}
       >
         <DialogTitle className="sr-only">Search scripts</DialogTitle>
-        <CommandInput placeholder="Search for a script..." />
+        <CommandInput
+          placeholder="Search for a script..."
+          onValueChange={setQuery}
+          value={query}
+        />
         <CommandList>
           <CommandEmpty>
             {isLoading ? (
@@ -233,9 +283,10 @@ function CommandMenu() {
               </div>
             )}
           </CommandEmpty>
-          {Object.entries(uniqueScriptsByCategory).map(([categoryName, scripts]) => (
-            <CommandGroup key={`category:${categoryName}`} heading={categoryName}>
-              {scripts.map(script => (
+
+          {results.length > 0 ? (
+            <CommandGroup heading="Search Results">
+              {results.map(script => (
                 <CommandItem
                   key={`script:${script.slug}`}
                   value={`${script.name} ${script.type} ${script.description || ""}`}
@@ -268,7 +319,44 @@ function CommandMenu() {
                 </CommandItem>
               ))}
             </CommandGroup>
-          ))}
+          ) : ( // When no search results, show all scripts grouped by category
+            Object.entries(uniqueScriptsByCategory).map(([categoryName, scripts]) => (
+              <CommandGroup key={`category:${categoryName}`} heading={categoryName}>
+                {scripts.map(script => (
+                  <CommandItem
+                    key={`script:${script.slug}`}
+                    value={`${script.name} ${script.type} ${script.description || ""}`}
+                    onSelect={() => {
+                      setOpen(false);
+                      router.push(`/scripts?id=${script.slug}`);
+                    }}
+                    tabIndex={0}
+                    aria-label={`Open script ${script.name}`}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        setOpen(false);
+                        router.push(`/scripts?id=${script.slug}`);
+                      }
+                    }}
+                  >
+                    <div className="flex gap-2" onClick={() => setOpen(false)}>
+                      <Image
+                        src={script.logo || `/${basePath}/logo.png`}
+                        onError={e => ((e.currentTarget as HTMLImageElement).src = `/${basePath}/logo.png`)}
+                        unoptimized
+                        width={16}
+                        height={16}
+                        alt=""
+                        className="h-5 w-5"
+                      />
+                      <span>{script.name}</span>
+                      <span>{formattedBadge(script.type)}</span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ))
+          )}
         </CommandList>
       </CommandDialog>
     </>

--- a/frontend/src/components/command-menu.tsx
+++ b/frontend/src/components/command-menu.tsx
@@ -47,6 +47,7 @@ function search(scripts: Script[], query: string): Script[] {
     })
     .filter(({ score }) => score > 0)
     .sort((a, b) => b.score - a.score)
+    .slice(0, 20)
     .map(({ script }) => script);
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The previous `cmdk` search was filtered correctly but then sorted by category order rather than match strength. This caused "Dokpoly" to appear above "Traefik", if you searched for Traefik, simply because its category (Containers) comes before Traefik's category alphabetically.

- Flatten search results into a single "Search Results" group.
- Implement scoring to prioritize name matches over descriptions.
- Revert to category grouping only when the search query is empty.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
