### PR TITLE
[FIX] Homepage: preserve public/images & public/icons if they exist

### DIFF
--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -28,7 +28,7 @@ function update_script() {
     exit
   fi
 
-  get_lxc_ip  
+  get_lxc_ip
   NODE_VERSION="22" NODE_MODULE="pnpm@latest" setup_nodejs
   ensure_dependencies jq
 
@@ -39,6 +39,8 @@ function update_script() {
 
     cp /opt/homepage/.env /opt/homepage.env
     cp -r /opt/homepage/config /opt/homepage_config_backup
+    [[ -d /opt/homepage/public/images ]] && cp -r /opt/homepage/public/images /opt/homepage_images_backup
+    [[ -d /opt/homepage/public/icons ]] && cp -r /opt/homepage/public/icons /opt/homepage_icons_backup
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homepage" "gethomepage/homepage" "tarball"
     mv /opt/homepage.env /opt/homepage
     rm -rf /opt/homepage/config
@@ -54,6 +56,8 @@ function update_script() {
     export NEXT_PUBLIC_BUILDTIME=$(curl -fsSL https://api.github.com/repos/gethomepage/homepage/releases/latest | jq -r '.published_at')
     export NEXT_TELEMETRY_DISABLED=1
     $STD pnpm build
+    [[ -d /opt/homepage_images_backup ]] && mv /opt/homepage_images_backup /opt/homepage/public/images
+    [[ -d /opt/homepage_icons_backup ]] && mv /opt/homepage_icons_backup /opt/homepage/public/icons
     msg_ok "Updated Homepage"
 
     msg_info "Starting service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Some folks have custom backgrounds/icons in the `/opt/homepage/public` folder. This PR will back them up during update if they exist and restore them afterwards.

## 🔗 Related Issue

Fixes #11591 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
