### PR TITLE
Install curl if required

### DIFF
--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -89,6 +89,11 @@ if ! dig +short pkgs.tailscale.com | grep -qvE "^127\.|^0\.0\.0\.0$"; then
   echo "nameserver 1.1.1.1" >"$ORIG_RESOLV"
 fi
 
+if ! which curl &>/dev/null; then
+  echo "Curl needs to be installed in container before running this script."
+  apt-get install -y curl >/dev/null
+fi
+
 curl -fsSL https://pkgs.tailscale.com/stable/${ID}/${VER}.noarmor.gpg \
   | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
 


### PR DESCRIPTION
## ✍️ Description
I kept running this script before installing curl. This results in a broken apt configuration which you have to fix before installing curl and rerunning the script.

This addition checks for the existence of curl (using the `which` command) then installs it if not found. I've been using a local version of the script with this modification for several months.

## 🔗 Related Issue

None

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
