### PR TITLE
perf(api): create MongoDB indexes at startup to imporve query performance

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -64,6 +64,23 @@ type CountResponse struct {
 	NSAPPCount   map[string]int64 `json:"nsapp_count"`
 }
 
+func ensureIndexes(ctx context.Context, coll *mongo.Collection) error {
+	indexes := []mongo.IndexModel{
+		{Keys: bson.D{{Key: "random_id", Value: 1}}},
+		{Keys: bson.D{{Key: "status", Value: 1}}},
+		{Keys: bson.D{{Key: "nsapp", Value: 1}}},
+		{Keys: bson.D{{Key: "created_at", Value: 1}}},
+		{Keys: bson.D{
+			{Key: "os_type", Value: 1},
+			{Key: "os_version", Value: 1},
+		}},
+		{Keys: bson.D{{Key: "error", Value: 1}}},
+	}
+
+	_, err := coll.Indexes().CreateMany(ctx, indexes)
+	return err
+}
+
 // ConnectDatabase initializes the MongoDB connection
 func ConnectDatabase() {
 	loadEnv()
@@ -84,6 +101,11 @@ func ConnectDatabase() {
 		log.Fatal("Failed to connect to MongoDB!", err)
 	}
 	collection = client.Database(database).Collection("data_models")
+
+	if err := ensureIndexes(ctx, collection); err != nil {
+		log.Fatal("Failed creating indexes!", err)
+	}
+	log.Println("Indexes ensured")
 	fmt.Println("Connected to MongoDB on 10.10.10.18")
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Create commonly used MongoDB indexes during API startup to avoid
collection scans on large datasets.

With the current dataset size (~216 MB), API requests take
around 5 seconds on average to respond, likely due to missing indexes
causing full collection scans.

<img width="540" height="191" alt="image" src="https://github.com/user-attachments/assets/efafdd83-bb6a-4176-b61d-0d611f72430d" />


This change ensures indexes are created automatically at startup if
they do not already exist.

Indexes could also be created manually via `mongosh`, but since I do not have access to the database servers, creating them automatically in the API simplifies deployment and avoids manual setup.

Indexed fields
- random_id
- status
- nsapp
- created_at
- os_type + os_version (compound)
- error

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
