### PR TITLE
Pangolin: replace build:sqlite with db:generate + build

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -48,7 +48,8 @@ function update_script() {
     $STD npm run set:sqlite
     $STD npm run set:oss
     rm -rf server/private
-    $STD npm run build:sqlite
+    $STD npm run db:generate
+    $STD npm run build
     $STD npm run build:cli
     cp -R .next/standalone ./
     chmod +x ./dist/cli.mjs

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -51,6 +51,7 @@ function update_script() {
     $STD npm run db:generate
     $STD npm run build
     $STD npm run build:cli
+    $STD npm run db:sqlite:push
     cp -R .next/standalone ./
     chmod +x ./dist/cli.mjs
     cp server/db/names.json ./dist/names.json

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -36,7 +36,8 @@ $STD npm ci
 $STD npm run set:sqlite
 $STD npm run set:oss
 rm -rf server/private
-$STD npm run build:sqlite
+$STD npm run db:generate
+$STD npm run build
 $STD npm run build:cli
 cp -R .next/standalone ./
 
@@ -177,7 +178,7 @@ http:
         servers:
           - url: "http://$LOCAL_IP:3000"
 EOF
-$STD npm run db:sqlite:generate
+$STD npm run db:generate
 $STD npm run db:sqlite:push
 
 . /etc/os-release

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -178,7 +178,6 @@ http:
         servers:
           - url: "http://$LOCAL_IP:3000"
 EOF
-$STD npm run db:generate
 $STD npm run db:sqlite:push
 
 . /etc/os-release


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update build flow in pangolin to use npm run db:generate followed by npm run build instead of the old npm run build:sqlite. Also normalize a DB generation invocation by replacing `npm run db:sqlite:generate` with `npm run db:generate` in the installer. 

## 🔗 Related Issue

Fixes #11595
Fixes #11592

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
