### PR TITLE
Shelfmark: remove Chromedriver dep, add URL_BASE env

### DIFF
--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -42,16 +42,19 @@ function update_script() {
       msg_info "Stopping FlareSolverr service"
       systemctl stop flaresolverr
       msg_ok "Stopped FlareSolverr service"
-      
+
       CLEAN_INSTALL=1 fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"
-      
+
       msg_info "Starting FlareSolverr Service"
       systemctl start flaresolverr
       msg_ok "Started FlareSolverr Service"
       msg_ok "Updated FlareSolverr"
     fi
-    
+
     cp /opt/shelfmark/start.sh /opt/start.sh.bak
+    if command -v chromedriver &>/dev/null; then
+      $STD apt remove -y chromium-driver
+    fi
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"
     RELEASE_VERSION=$(cat "$HOME/.shelfmark")
 

--- a/frontend/public/json/shelfmark.json
+++ b/frontend/public/json/shelfmark.json
@@ -35,6 +35,10 @@
     {
       "text": "The configuration at `/etc/shelfmark/.env` is for bootstrapping the initial install. Customize the configuration via the Shelfmark UI.",
       "type": "info"
+    },
+    {
+      "text": "This version of the application does not support routing through Tor (the `USING_TOR` env var).",
+      "type": "info"
     }
   ]
 }

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -14,14 +14,14 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y \
-  unrar-free
+$STD apt install -y unrar-free
 ln -sf /usr/bin/unrar-free /usr/bin/unrar
 msg_ok "Installed Dependencies"
 
 mkdir -p /etc/shelfmark
 cat <<EOF >/etc/shelfmark/.env
 DOCKERMODE=false
+URL_BASE=""
 CONFIG_DIR=/etc/shelfmark
 TMP_DIR=/tmp/shelfmark
 ENABLE_LOGGING=true
@@ -111,7 +111,6 @@ else
     ffmpeg \
     chromium-common \
     chromium \
-    chromium-driver \
     python3-tk
   msg_ok "Installed internal bypasser dependencies"
 fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Internal bypasser is migrated to using pure CDP
- Configuring `URL_BASE` allows the use of subpaths with reverse proxies

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
