### PR TITLE
fix(immich): improve version comparison for maintenance mode check with sort -V

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -107,7 +107,8 @@ EOF
 
   RELEASE="2.5.5"
   if check_for_gh_release "Immich" "immich-app/immich" "${RELEASE}"; then
-    if [[ $(cat ~/.immich) > "2.5.1" ]]; then
+    CURRENT_VERSION=$(cat ~/.immich)
+    if printf '%s\n%s\n' "2.5.1" "$CURRENT_VERSION" | sort -V -q -r &>/dev/null && [[ "$CURRENT_VERSION" != "2.5.1" ]]; then
       msg_info "Enabling Maintenance Mode"
       cd /opt/immich/app/bin
       $STD ./immich-admin enable-maintenance-mode


### PR DESCRIPTION
I found another way to compare the versions, namely with sort -V.

## ✍️ Description
Previously, the script was based on the “insert previous” method, e.g., manual string comparison or simple sorting, which could lead to incorrect results with multi-digit version segments (e.g., treating 1.10 as smaller than 1.2). With sort -V, the problem should be fixed.

## 🔗 Related Issue

I detected the error with an AI reviewer.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
