### PR TITLE
Downgrade: OpenProject | NginxProxyManager | Semaphore to Debian 12 due to persistent SHA1 issues 

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/openproject.sh
+++ b/ct/openproject.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/semaphore.sh
+++ b/ct/semaphore.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-13}"
+var_version="${var_version:-12}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/frontend/public/json/nginxproxymanager.json
+++ b/frontend/public/json/nginxproxymanager.json
@@ -25,7 +25,7 @@
         "ram": 2048,
         "hdd": 8,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/frontend/public/json/openproject.json
+++ b/frontend/public/json/openproject.json
@@ -23,7 +23,7 @@
         "ram": 4096,
         "hdd": 8,
         "os": "Debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],

--- a/frontend/public/json/semaphore.json
+++ b/frontend/public/json/semaphore.json
@@ -23,7 +23,7 @@
         "ram": 2048,
         "hdd": 4,
         "os": "debian",
-        "version": "13"
+        "version": "12"
       }
     }
   ],


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Downgrade 3 Scripts to debian 12, because SHA1 since weeks not refreshed
- NPM -> OpenResty
- Semaphore -> Own Repository isnt updated
- OpenProject -> packager.io sha1 issues


Semaphore little bugfix for Deb12 too (need jammy instead of noble)

## 🔗 Related Issue

Fixes #11622
Fixes #11496
Fixes #11406

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
