### PR TITLE
feat(healthchecks): add sendalerts service

### DIFF
--- a/install/healthchecks-install.sh
+++ b/install/healthchecks-install.sh
@@ -108,7 +108,7 @@ ${LOCAL_IP} {
 EOF
 msg_ok "Configured Caddy"
 
-msg_info "Creating systemd service"
+msg_info "Creating systemd services"
 cat <<EOF >/etc/systemd/system/healthchecks.service
 [Unit]
 Description=Healthchecks Service
@@ -123,9 +123,23 @@ Restart=always
 WantedBy=multi-user.target
 EOF
 
-systemctl enable -q --now healthchecks caddy
+cat <<EOF >/etc/systemd/system/healthchecks-sendalerts.service
+[Unit]
+Description=Healthchecks Sendalerts Service
+After=network.target postgresql.service healthchecks.service
+
+[Service]
+WorkingDirectory=/opt/healthchecks/
+ExecStart=/opt/healthchecks/venv/bin/python manage.py sendalerts
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable -q --now healthchecks healthchecks-sendalerts caddy
 systemctl reload caddy
-msg_ok "Created Service"
+msg_ok "Created Services"
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Healthcheck needs to be running its `sendalerts` command, otherwise notifications are not sent ( https://github.com/healthchecks/healthchecks?tab=readme-ov-file#sending-alerts-and-reports )

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
