### PR TITLE
hwaccel: add libmfx-gen1.2 to Intel Arc setup for QSV support

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -3595,6 +3595,7 @@ _setup_intel_arc() {
     $STD apt -y install \
       intel-media-va-driver-non-free \
       intel-opencl-icd \
+      libmfx-gen1.2 \
       vainfo \
       intel-gpu-tools 2>/dev/null || msg_warn "Some Intel Arc packages failed"
 
@@ -3621,6 +3622,7 @@ _setup_intel_arc() {
       intel-media-va-driver-non-free \
       ocl-icd-libopencl1 \
       libvpl2 \
+      libmfx-gen1.2 \
       vainfo \
       intel-gpu-tools 2>/dev/null || msg_warn "Some Intel Arc packages failed"
   fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add missing libmfx-gen1.2 package to _setup_intel_arc() for both Ubuntu and Debian. Without this package, QSV hardware acceleration fails with 'Error creating a MFX session: -9'.

The package was already present in _setup_intel_modern() (Gen9+) but missing from the Arc

## 🔗 Related Issue

Fixes #11701

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
