### PR TITLE
Netbird (addon): add systemd ordering to start after Docker

### DIFF
--- a/tools/addon/add-netbird-lxc.sh
+++ b/tools/addon/add-netbird-lxc.sh
@@ -84,6 +84,15 @@ curl -fsSL "https://pkgs.netbird.io/debian/public.key" | gpg --dearmor >/usr/sha
 echo "deb [signed-by=/usr/share/keyrings/netbird-archive-keyring.gpg] https://pkgs.netbird.io/debian stable main" >/etc/apt/sources.list.d/netbird.list
 apt-get update &>/dev/null
 apt-get install -y netbird-ui &>/dev/null
+if systemctl list-unit-files docker.service &>/dev/null; then
+  mkdir -p /etc/systemd/system/netbird.service.d
+  cat <<OVERRIDE >/etc/systemd/system/netbird.service.d/after-docker.conf
+[Unit]
+After=docker.service
+Wants=docker.service
+OVERRIDE
+  systemctl daemon-reload
+fi
 '
 msg "\e[1;32m ✔ Installed NetBird.\e[0m"
 sleep 2


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When Docker is installed in the same LXC, Docker sets the FORWARD chain policy to DROP on startup. If Netbird starts before Docker finishes initializing its iptables rules, Docker overrides the Netbird routing rules, causing traffic routing to fail despite the tunnel being up.

## 🔗 Related Issue

Fixes #11354

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
