### PR TITLE
Umlautadaptarr: use release appsettings.json instead of hardcoded copy

### DIFF
--- a/ct/umlautadaptarr.sh
+++ b/ct/umlautadaptarr.sh
@@ -33,7 +33,9 @@ function update_script() {
     systemctl stop umlautadaptarr
     msg_ok "Stopped Service"
 
+    cp /opt/UmlautAdaptarr/appsettings.json /opt/UmlautAdaptarr/appsettings.json.bak
     fetch_and_deploy_gh_release "UmlautAdaptarr" "PCJones/Umlautadaptarr" "prebuild" "latest" "/opt/UmlautAdaptarr" "linux-x64.zip"
+    cp /opt/UmlautAdaptarr/appsettings.json.bak /opt/UmlautAdaptarr/appsettings.json
 
     msg_info "Starting Service"
     systemctl start umlautadaptarr

--- a/install/umlautadaptarr-install.sh
+++ b/install/umlautadaptarr-install.sh
@@ -27,68 +27,6 @@ msg_ok "Installed Dependencies"
 
 fetch_and_deploy_gh_release "UmlautAdaptarr" "PCJones/Umlautadaptarr" "prebuild" "latest" "/opt/UmlautAdaptarr" "linux-x64.zip"
 
-msg_info "Setting up UmlautAdaptarr"
-cat <<EOF >/opt/UmlautAdaptarr/appsettings.json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    },
-    "Console": {
-      "TimestampFormat": "yyyy-MM-dd HH:mm:ss::"
-    }
-  },
-  "AllowedHosts": "*",
-  "Kestrel": {
-    "Endpoints": {
-      "Http": {
-        "Url": "http://[::]:5005"
-      }
-    }
-  },
-  "Settings": {
-    "UserAgent": "UmlautAdaptarr/1.0",
-    "UmlautAdaptarrApiHost": "https://umlautadaptarr.pcjones.de/api/v1",
-    "IndexerRequestsCacheDurationInMinutes": 12
-  },
-  "Sonarr": [
-    {
-      "Enabled": false,
-      "Name": "Sonarr",
-      "Host": "http://192.168.1.100:8989",
-      "ApiKey": "dein_sonarr_api_key"
-    }
-  ],
-  "Radarr": [
-    {
-      "Enabled": false,
-      "Name": "Radarr",
-      "Host": "http://192.168.1.101:7878",
-      "ApiKey": "dein_radarr_api_key"
-    }
-  ],
-  "Lidarr": [
-  {
-    "Enabled": false,
-    "Host": "http://192.168.1.102:8686",
-    "ApiKey": "dein_lidarr_api_key"
-  },
- ],
-  "Readarr": [
-  {
-    "Enabled": false,
-    "Host": "http://192.168.1.103:8787",
-    "ApiKey": "dein_readarr_api_key"
-  },
- ],
-  "IpLeakTest": {
-    "Enabled": false
-  }
-}
-EOF
-msg_ok "Setup UmlautAdaptarr"
-
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/umlautadaptarr.service
 [Unit]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The install script overwrote the correct appsettings.json shipped in the release archive with a hardcoded copy that was missing newer required fields (ApiKey, ProxyPort, EnableChangedTitleCache) and had structural differences (Lidarr/Readarr as arrays instead of objects), causing the service to fail on startup.

- Remove hardcoded appsettings.json from install script (release archive already ships the correct version)
- Backup and restore appsettings.json during updates to preserve user configuration

## 🔗 Related Issue

Fixes #11665

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
