### PR TITLE
Kasm: Support new version URL format without hash suffix

### DIFF
--- a/ct/kasm.sh
+++ b/ct/kasm.sh
@@ -34,10 +34,19 @@ function update_script() {
   CURRENT_VERSION=$(readlink -f /opt/kasm/current | awk -F'/' '{print $4}')
   KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
   if [[ -z "$KASM_URL" ]]; then
+    SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+    if [[ -n "$SERVICE_IMAGE_URL" ]]; then
+      KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+      KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
+    fi
+  else
+    KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  fi
+  
+  if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
     msg_error "Unable to detect latest Kasm release URL."
     exit 1
   fi
-  KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
   msg_info "Checked for new version"
 
   msg_info "Removing outdated docker-compose plugin"

--- a/install/kasm-install.sh
+++ b/install/kasm-install.sh
@@ -20,10 +20,19 @@ msg_ok "Installed Docker"
 msg_info "Detecting latest Kasm Workspaces release"
 KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
 if [[ -z "$KASM_URL" ]]; then
+  SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+  if [[ -n "$SERVICE_IMAGE_URL" ]]; then
+    KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+    KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
+  fi
+else
+  KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+fi
+
+if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
   msg_error "Unable to detect latest Kasm release URL."
   exit 1
 fi
-KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 msg_ok "Detected Kasm Workspaces version $KASM_VERSION"
 
 msg_warn "WARNING: This script will run an external installer from a third-party source (https://www.kasmweb.com/)."


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Kasm changed their release URL format again starting with v1.18.1:
- Old format: kasm_release_1.18.0.09f70a.tar.gz (with hash)
- New format: kasm_release_1.18.1.tar.gz (without hash)

The script now tries both detection methods:
1. First tries to find URL with hash suffix (old format)
2. Falls back to detecting version from service_images URLs and constructing the new URL format

This fixes the update detection for Kasm v1.18.1 and future versions.

## 🔗 Related Issue

Fixes #11785 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
