### PR TITLE
fix: make donetick 0.1.71 compatible

### DIFF
--- a/ct/donetick.sh
+++ b/ct/donetick.sh
@@ -35,13 +35,14 @@ function update_script() {
     msg_ok "Stopped Service"
 
     msg_info "Backing Up Configurations"
-    mv /opt/donetick/config/selfhosted.yml /opt/donetick/donetick.db /opt
+    mv /opt/donetick/config/selfhosted.yaml /opt/donetick/donetick.db /opt
     msg_ok "Backed Up Configurations"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "donetick" "donetick/donetick" "prebuild" "latest" "/opt/donetick" "donetick_Linux_x86_64.tar.gz"
 
     msg_info "Restoring Configurations"
-    mv /opt/selfhosted.yml /opt/donetick/config
+    mv /opt/selfhosted.yaml /opt/donetick/config
+    sed -i '/capacitor:\/\/localhost/d' /opt/donetick/config/selfhosted.yaml
     mv /opt/donetick.db /opt/donetick
     msg_ok "Restored Configurations"
 


### PR DESCRIPTION
## ✍️ Description
- fixes wrong config file ending
- removes now unsupported CORS origin (if the old origin is present, the app won't start) donetick/donetick#510

## 🔗 Related Issue

Fixes #11799

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
