### PR TITLE
Deluge: add python3-setuptools as dep

### DIFF
--- a/ct/deluge.sh
+++ b/ct/deluge.sh
@@ -28,6 +28,7 @@ function update_script() {
     exit
   fi
   msg_info "Updating Deluge"
+  ensure_dependencies python3-setuptools
   $STD apt update
   $STD pip3 install deluge[all] --upgrade
   msg_ok "Updated Deluge"

--- a/install/deluge-install.sh
+++ b/install/deluge-install.sh
@@ -16,7 +16,8 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   python3-pip \
-  python3-libtorrent
+  python3-libtorrent \
+  python3-setuptools
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Deluge"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
for pkg_resources on Python 3.13

## 🔗 Related Issue

Fixes #11816

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
