### PR TITLE
api: prevent duplicate post_to_api submissions

### DIFF
--- a/misc/api.func
+++ b/misc/api.func
@@ -353,6 +353,9 @@ detect_ram() {
 # - Never blocks or fails script execution
 # ------------------------------------------------------------------------------
 post_to_api() {
+  # Prevent duplicate submissions (post_to_api is called from multiple places)
+  [[ "${POST_TO_API_DONE:-}" == "true" ]] && return 0
+
   # Silent fail - telemetry should never break scripts
   command -v curl &>/dev/null || {
     [[ "${DEV_MODE:-}" == "true" ]] && echo "[DEBUG] curl not found, skipping" >&2
@@ -440,6 +443,8 @@ EOF
       -H "Content-Type: application/json" \
       -d "$JSON_PAYLOAD" &>/dev/null || true
   fi
+
+  POST_TO_API_DONE=true
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add POST_TO_API_DONE idempotency guard to post_to_api() to prevent the same telemetry record from being submitted twice with the same RANDOM_UUID. This mirrors the existing POST_UPDATE_DONE pattern in post_update_to_api().

post_to_api() is called twice in build.func:
- Line 3641: after storage validation (inside CONTAINER_STORAGE check)
- Line 5065: after create_lxc_container() completes

When both execute, the second call fails with a random_id uniqueness violation on PocketBase, generating server-side errors.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
