### PR TITLE
Tailscale: fix DNS check and keyrings directory issues

### DIFF
--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -75,14 +75,37 @@ pct exec "$CTID" -- bash -c '
 set -e
 export DEBIAN_FRONTEND=noninteractive
 
-ID=$(grep "^ID=" /etc/os-release | cut -d"=" -f2)
-VER=$(grep "^VERSION_CODENAME=" /etc/os-release | cut -d"=" -f2)
+# Source os-release properly (handles quoted values)
+source /etc/os-release
 
-# fallback if DNS is poisoned or blocked
+# Fallback if DNS is poisoned or blocked
 ORIG_RESOLV="/etc/resolv.conf"
 BACKUP_RESOLV="/tmp/resolv.conf.backup"
 
-if ! dig +short pkgs.tailscale.com | grep -qvE "^127\.|^0\.0\.0\.0$"; then
+# Check DNS resolution using multiple methods (dig may not be installed)
+dns_check_failed=true
+if command -v dig &>/dev/null; then
+  if dig +short pkgs.tailscale.com 2>/dev/null | grep -qvE "^127\.|^0\.0\.0\.0$|^$"; then
+    dns_check_failed=false
+  fi
+elif command -v host &>/dev/null; then
+  if host pkgs.tailscale.com 2>/dev/null | grep -q "has address"; then
+    dns_check_failed=false
+  fi
+elif command -v nslookup &>/dev/null; then
+  if nslookup pkgs.tailscale.com 2>/dev/null | grep -q "Address:"; then
+    dns_check_failed=false
+  fi
+elif command -v getent &>/dev/null; then
+  if getent hosts pkgs.tailscale.com &>/dev/null; then
+    dns_check_failed=false
+  fi
+else
+  # No DNS tools available, try curl directly and assume DNS works
+  dns_check_failed=false
+fi
+
+if $dns_check_failed; then
   echo "[INFO] DNS resolution for pkgs.tailscale.com failed (blocked or redirected)."
   echo "[INFO] Temporarily overriding /etc/resolv.conf with Cloudflare DNS (1.1.1.1)"
   cp "$ORIG_RESOLV" "$BACKUP_RESOLV"
@@ -95,10 +118,13 @@ if ! command -v curl &>/dev/null; then
   apt-get install -y curl >/dev/null
 fi
 
-curl -fsSL https://pkgs.tailscale.com/stable/${ID}/${VER}.noarmor.gpg \
+# Ensure keyrings directory exists
+mkdir -p /usr/share/keyrings
+
+curl -fsSL "https://pkgs.tailscale.com/stable/${ID}/${VERSION_CODENAME}.noarmor.gpg" \
   | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
 
-echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/${ID} ${VER} main" \
+echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/${ID} ${VERSION_CODENAME} main" \
   >/etc/apt/sources.list.d/tailscale.list
 
 apt-get update -qq

--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -129,7 +129,8 @@ echo "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://
   >/etc/apt/sources.list.d/tailscale.list
 
 apt-get update -qq
-apt-get install -y tailscale >/dev/null
+apt update -qq
+apt install -y tailscale >/dev/null
 
 if [[ -f /tmp/resolv.conf.backup ]]; then
   echo "[INFO] Restoring original /etc/resolv.conf"

--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -115,7 +115,8 @@ fi
 if ! command -v curl &>/dev/null; then
   echo "[INFO] curl not found, installing..."
   apt-get update -qq
-  apt-get install -y curl >/dev/null
+ apt update -qq
+ apt install -y curl >/dev/null
 fi
 
 # Ensure keyrings directory exists


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Source /etc/os-release instead of grep to handle quoted values properly
- Use VERSION_CODENAME variable instead of VER for correct URL
- Add fallback DNS resolution methods (host, nslookup, getent) when dig is missing
- Create /usr/share/keyrings directory if it doesn't exist
- Skip DNS check gracefully when no DNS tools are available

## 🔗 Related Issue

Fixes installation failures with 'dig: command not found' and 'No such file or directory' for keyrings path


## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
