### PR TITLE
tools.func: auto-detect binary vs armored GPG keys in setup_deb822_repo

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1294,11 +1294,31 @@ setup_deb822_repo() {
     return 1
   }
 
-  # Import GPG
-  curl -fsSL "$gpg_url" | gpg --dearmor --yes -o "/etc/apt/keyrings/${name}.gpg" || {
-    msg_error "Failed to import GPG key for ${name}"
+  # Import GPG key (auto-detect binary vs ASCII-armored format)
+  local tmp_gpg
+  tmp_gpg=$(mktemp) || return 1
+  curl -fsSL "$gpg_url" -o "$tmp_gpg" || {
+    msg_error "Failed to download GPG key for ${name}"
+    rm -f "$tmp_gpg"
     return 1
   }
+
+  if file "$tmp_gpg" | grep -qi 'PGP\|GPG\|public key'; then
+    # Already in binary GPG format — copy directly
+    cp "$tmp_gpg" "/etc/apt/keyrings/${name}.gpg" || {
+      msg_error "Failed to install GPG key for ${name}"
+      rm -f "$tmp_gpg"
+      return 1
+    }
+  else
+    # ASCII-armored — dearmor to binary
+    gpg --dearmor --yes -o "/etc/apt/keyrings/${name}.gpg" < "$tmp_gpg" || {
+      msg_error "Failed to dearmor GPG key for ${name}"
+      rm -f "$tmp_gpg"
+      return 1
+    }
+  fi
+  rm -f "$tmp_gpg"
 
   # Write deb822
   {


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The UniFi GPG key at dl.ui.com/unifi/unifi-repo.gpg is already in binary format. setup_deb822_repo unconditionally ran gpg --dearmor which expects ASCII-armored input, corrupting binary keys and causing apt to fail with "Unable to locate package unifi".

setup_deb822_repo now downloads the key to a temp file first and uses the file command to detect whether it is already a binary PGP/GPG key. Binary keys are copied directly; armored keys are dearmored as before.

## 🔗 Related Issue

Fixes #11740

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
