### PR TITLE
error_handler: prevent stuck 'installing' status

### DIFF
--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -243,6 +243,18 @@ error_handler() {
 # ------------------------------------------------------------------------------
 on_exit() {
   local exit_code=$?
+  # Report orphaned "installing" records to telemetry API
+  # Catches ALL exit paths: errors (non-zero), signals, AND clean exits where
+  # post_to_api was called ("installing" sent) but post_update_to_api was never called
+  if [[ "${POST_TO_API_DONE:-}" == "true" && "${POST_UPDATE_DONE:-}" != "true" ]]; then
+    if declare -f post_update_to_api >/dev/null 2>&1; then
+      if [[ $exit_code -ne 0 ]]; then
+        post_update_to_api "failed" "$exit_code"
+      else
+        post_update_to_api "failed" "1"
+      fi
+    fi
+  fi
   [[ -n "${lockfile:-}" && -e "$lockfile" ]] && rm -f "$lockfile"
   exit "$exit_code"
 }
@@ -255,6 +267,10 @@ on_exit() {
 # - Exits with code 130 (128 + SIGINT=2)
 # ------------------------------------------------------------------------------
 on_interrupt() {
+  # Report interruption to telemetry API (prevents stuck "installing" records)
+  if declare -f post_update_to_api >/dev/null 2>&1; then
+    post_update_to_api "failed" "130"
+  fi
   if declare -f msg_error >/dev/null 2>&1; then
     msg_error "Interrupted by user (SIGINT)"
   else
@@ -272,6 +288,10 @@ on_interrupt() {
 # - Triggered by external process termination
 # ------------------------------------------------------------------------------
 on_terminate() {
+  # Report termination to telemetry API (prevents stuck "installing" records)
+  if declare -f post_update_to_api >/dev/null 2>&1; then
+    post_update_to_api "failed" "143"
+  fi
   if declare -f msg_error >/dev/null 2>&1; then
     msg_error "Terminated by signal (SIGTERM)"
   else


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The catch_errors() function in CT scripts overrides the API telemetry traps set by build.func. This caused on_exit, on_interrupt, and on_terminate to never call post_update_to_api, leaving telemetry records permanently stuck on 'installing'.

Changes:
- on_exit: Report orphaned 'installing' records on ANY exit where post_to_api was called but post_update_to_api was not
- on_interrupt: Call post_update_to_api('failed', '130') before exit
- on_terminate: Call post_update_to_api('failed', '143') before exit

All calls are guarded by POST_UPDATE_DONE flag to prevent duplicates.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
