### PR TITLE
Pangolin: switch sqlite-specific back to generic

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -51,7 +51,7 @@ function update_script() {
     $STD npm run db:generate
     $STD npm run build
     $STD npm run build:cli
-    $STD npm run db:sqlite:push
+    $STD npm run db:push
     cp -R .next/standalone ./
     chmod +x ./dist/cli.mjs
     cp server/db/names.json ./dist/names.json

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -36,7 +36,7 @@ $STD npm ci
 $STD npm run set:sqlite
 $STD npm run set:oss
 rm -rf server/private
-$STD npm run db:sqlite:generate
+$STD npm run db:generate
 $STD npm run build
 $STD npm run build:cli
 cp -R .next/standalone ./
@@ -178,7 +178,7 @@ http:
         servers:
           - url: "http://$LOCAL_IP:3000"
 EOF
-$STD npm run db:sqlite:push
+$STD npm run db:push
 
 . /etc/os-release
 if [ "$VERSION_CODENAME" = "trixie" ]; then


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Changed in Upstream the 3th or 4th time in last 2 weeks.
Replace npm script calls to db:sqlite:generate and db:sqlite:push with db:generate and db:push in ct/pangolin.sh and install/pangolin-install.sh. This makes the build/install steps use the generic DB task names for consistency across update and install workflows.

To Track: https://github.com/fosrl/pangolin/issues/2473

## 🔗 Related Issue

Fixes #11865

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
