### PR TITLE
chore(donetick): add config entry for v0.1.73

### DIFF
--- a/ct/donetick.sh
+++ b/ct/donetick.sh
@@ -42,7 +42,8 @@ function update_script() {
 
     msg_info "Restoring Configurations"
     mv /opt/selfhosted.yaml /opt/donetick/config
-    sed -i '/capacitor:\/\/localhost/d' /opt/donetick/config/selfhosted.yaml
+    grep -q 'http://localhost"$' /opt/donetick/config/selfhosted.yaml || sed -i '/https:\/\/localhost"$/a\    - "http://localhost"' /opt/donetick/config/selfhosted.yaml
+    grep -q 'capacitor://localhost' /opt/donetick/config/selfhosted.yaml || sed -i '/http:\/\/localhost"$/a\    - "capacitor://localhost"' /opt/donetick/config/selfhosted.yaml
     mv /opt/donetick.db /opt/donetick
     msg_ok "Restored Configurations"
 


### PR DESCRIPTION
## ✍️ Description
This adds back a config entry that was previously removed because of preventing the app to start (#11804). The [new dontick version](https://github.com/donetick/donetick/releases/tag/v0.1.73) now re added support of this entry so I updated the script to make sure it gets added again in case someone has already ran the update script for the previous version which removed the entry.

Maybe it's also an option to just remove the `sed -i '/capacitor:\/\/localhost/d' /opt/donetick/config/selfhosted.yaml` I prevously added and have users manaully re-add the ``capacitor://localhost`` CORS entry in case they need it.
Not sure which way to go is the best here 😄 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
