### PR TITLE
core: handle missing RAM speed in nested VMs

### DIFF
--- a/misc/api.func
+++ b/misc/api.func
@@ -402,12 +402,17 @@ detect_ram() {
 
   if command -v dmidecode &>/dev/null; then
     # Get configured memory speed (actual running speed)
-    RAM_SPEED=$(dmidecode -t memory 2>/dev/null | grep -m1 "Configured Memory Speed:" | grep -oE "[0-9]+" | head -1)
+    RAM_SPEED=$(dmidecode -t memory 2>/dev/null | grep -m1 "Configured Memory Speed:" | grep -oE "[0-9]+" | head -1 || true)
 
     # Fallback to Speed: if Configured not available
     if [[ -z "$RAM_SPEED" ]]; then
-      RAM_SPEED=$(dmidecode -t memory 2>/dev/null | grep -m1 "Speed:" | grep -oE "[0-9]+" | head -1)
+      RAM_SPEED=$(dmidecode -t memory 2>/dev/null | grep -m1 "Speed:" | grep -oE "[0-9]+" | head -1 || true)
     fi
+  fi
+
+  # Ensure RAM_SPEED is a valid integer (PocketBase stores it as integer)
+  if [[ -z "$RAM_SPEED" || ! "$RAM_SPEED" =~ ^[0-9]+$ ]]; then
+    RAM_SPEED=0
   fi
 
   export RAM_SPEED
@@ -504,7 +509,7 @@ post_to_api() {
     "gpu_vendor": "${gpu_vendor}",
     "gpu_model": "${gpu_model}",
     "gpu_passthrough": "${gpu_passthrough}",
-    "ram_speed": "${ram_speed}",
+    "ram_speed": ${ram_speed:-0},
     "repo_source": "${REPO_SOURCE}"
 }
 EOF
@@ -608,7 +613,7 @@ post_to_api_vm() {
     "gpu_vendor": "${gpu_vendor}",
     "gpu_model": "${gpu_model}",
     "gpu_passthrough": "${gpu_passthrough}",
-    "ram_speed": "${ram_speed}",
+    "ram_speed": ${ram_speed:-0},
     "repo_source": "${REPO_SOURCE}"
 }
 EOF
@@ -742,7 +747,7 @@ post_update_to_api() {
     "gpu_vendor": "${gpu_vendor}",
     "gpu_model": "${gpu_model}",
     "gpu_passthrough": "${gpu_passthrough}",
-    "ram_speed": "${ram_speed}",
+    "ram_speed": ${ram_speed:-0},
     "repo_source": "${REPO_SOURCE}"
 }
 EOF
@@ -784,7 +789,7 @@ EOF
     "gpu_vendor": "${gpu_vendor}",
     "gpu_model": "${gpu_model}",
     "gpu_passthrough": "${gpu_passthrough}",
-    "ram_speed": "${ram_speed}",
+    "ram_speed": ${ram_speed:-0},
     "repo_source": "${REPO_SOURCE}"
 }
 EOF
@@ -881,7 +886,7 @@ categorize_error() {
   # Signal/Process errors (SIGTERM, SIGPIPE, SIGSEGV)
   139 | 141 | 143) echo "signal" ;;
 
-  # Shell errors (general error, syntax error)  
+  # Shell errors (general error, syntax error)
   1 | 2) echo "shell" ;;
 
   # Default - truly unknown


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add || true to dmidecode pipelines to prevent error when speed is 'Unknown'
Validate RAM_SPEED is a valid integer, fallback to 0


## 🔗 Related Issue

Fixes #11912

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
