### PR TITLE
Tautulli: Add setuptools < 81

### DIFF
--- a/install/tautulli-install.sh
+++ b/install/tautulli-install.sh
@@ -29,6 +29,7 @@ $STD uv venv --clear
 $STD source /opt/Tautulli/.venv/bin/activate
 $STD uv pip install -r requirements.txt
 $STD uv pip install pyopenssl
+$STD uv pip install "setuptools<81"
 msg_ok "Installed Tautulli"
 
 msg_info "Creating Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Same issue as with LibreTranslate, `setuptools>81` break the install. Installed `setuptools<81`

## 🔗 Related Issue

Fixes #11934 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
