### PR TITLE
cryptpad: restore config earlier and run onlyoffice upgrade

### DIFF
--- a/ct/cryptpad.sh
+++ b/ct/cryptpad.sh
@@ -39,16 +39,19 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cryptpad" "cryptpad/cryptpad" "tarball"
 
+    msg_info "Restoring configuration"
+    mv /opt/config.js /opt/cryptpad/config/
+    msg_ok "Configuration restored"
+
     msg_info "Updating CryptaPad"
     cd /opt/cryptpad
     $STD npm ci
     $STD npm run install:components
+    if [ -f "/opt/cryptpad/install-onlyoffice.sh" ]; then
+      $STD bash /opt/cryptpad/install-onlyoffice.sh --accept-license
+    fi
     $STD npm run build
     msg_ok "Updated CryptaPad"
-
-    msg_info "Restoring configuration"
-    mv /opt/config.js /opt/cryptpad/config/
-    msg_ok "Configuration restored"
 
     msg_info "Starting Service"
     systemctl start cryptpad

--- a/install/cryptpad-install.sh
+++ b/install/cryptpad-install.sh
@@ -26,13 +26,13 @@ msg_info "Setup CryptPad"
 cd /opt/cryptpad
 $STD npm ci
 $STD npm run install:components
-$STD npm run build
-cp config/config.example.js config/config.js
-sed -i "51s/localhost/${LOCAL_IP}/g" /opt/cryptpad/config/config.js
-sed -i "80s#//httpAddress: 'localhost'#httpAddress: '0.0.0.0'#g" /opt/cryptpad/config/config.js
 if [[ "$onlyoffice" =~ ^[Yy]$ ]]; then
   $STD bash -c "./install-onlyoffice.sh --accept-license"
 fi
+cp config/config.example.js config/config.js
+sed -i "51s/localhost/${LOCAL_IP}/g" /opt/cryptpad/config/config.js
+sed -i "80s#//httpAddress: 'localhost'#httpAddress: '0.0.0.0'#g" /opt/cryptpad/config/config.js
+$STD npm run build
 msg_ok "Setup CryptPad"
 
 msg_info "Creating Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
restore config earlier and run onlyoffice upgrade - i havent seen any other changes (Dockerfile, ...)

## 🔗 Related Issue

Fixes #11959

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
