### PR TITLE
jellyseerr/overseerr: Migrate update script to Seerr; prompt rerun

### DIFF
--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -45,16 +45,18 @@ function update_script() {
     fi
 
     msg_info "Switching update script to Seerr"
-    cat <<EOF >/usr/bin/update
+    cat <<'EOF' >/usr/bin/update
+#!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
     chmod +x /usr/bin/update
-    msg_ok "Switched update script to Seerr. Running update..."
-    exec /usr/bin/update
+    msg_ok "Switched update script to Seerr"
+    msg_warn "Please type 'update' again to complete the migration"
+    exit
   fi
 
   msg_info "Updating Jellyseerr"
-  cd /opt/jellyseerr 
+  cd /opt/jellyseerr
   systemctl stop jellyseerr
   output=$(git pull --no-rebase)
   pnpm_desired=$(grep -Po '"pnpm":\s*"\K[^"]+' /opt/jellyseerr/package.json)
@@ -65,7 +67,7 @@ EOF
   fi
   rm -rf dist .next node_modules
   export CYPRESS_INSTALL_BINARY=0
-  cd /opt/jellyseerr 
+  cd /opt/jellyseerr
   $STD pnpm install --frozen-lockfile
   export NODE_OPTIONS="--max-old-space-size=3072"
   $STD pnpm build

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -44,12 +44,14 @@ function update_script() {
     fi
 
     msg_info "Switching update script to Seerr"
-    cat <<EOF >/usr/bin/update
+    cat <<'EOF' >/usr/bin/update
+#!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
     chmod +x /usr/bin/update
-    msg_ok "Switched update script to Seerr. Running update..."
-    exec /usr/bin/update
+    msg_ok "Switched update script to Seerr"
+    msg_warn "Please type 'update' again to complete the migration"
+    exit 0
   fi
 
   if check_for_gh_release "overseerr" "sct/overseerr"; then


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update jellyseerr nd overseerr to switch the container update handler to the Seerr script. The here-doc now uses a single-quoted EOF to avoid shell expansion and includes an explicit shebang for the generated /usr/bin/update. Instead of auto-executing the new update script, the code now informs the user to run 'update' again and exits (overseerr exits with 0)

## 🔗 Related Issue

Fixes #11961

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
