### PR TITLE
Vaultwarden: export VW_VERSION as version number

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -45,6 +45,8 @@ function update_script() {
 
       msg_info "Updating VaultWarden to $VAULT (Patience)"
       cd /tmp/vaultwarden-src
+      VW_VERSION="$VAULT"
+      export VW_VERSION
       $STD cargo build --features "sqlite,mysql,postgresql" --release
       if [[ -f /usr/bin/vaultwarden ]]; then
         cp target/release/vaultwarden /usr/bin/

--- a/install/vaultwarden-install.sh
+++ b/install/vaultwarden-install.sh
@@ -29,6 +29,8 @@ fetch_and_deploy_gh_release "vaultwarden" "dani-garcia/vaultwarden" "tarball" "l
 
 msg_info "Building Vaultwarden (Patience)"
 cd /tmp/vaultwarden-src
+VW_VERSION=$(get_latest_github_release "dani-garcia/vaultwarden")
+export VW_VERSION
 $STD cargo build --features "sqlite,mysql,postgresql" --release
 msg_ok "Built Vaultwarden"
 


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Set and export the VW_VERSION environment variable prior to running cargo build in both ct & install. In ct VW_VERSION is assigned from $VAULT, and in the install script its obtained via get_latest_github_release. This ensures the build process has the expected VW_VERSION available during compilation.

## 🔗 Related Issue

Fixes #11958 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
