### PR TITLE
tools.func: ensure /usr/local/bin PATH persists for pct enter sessions

### DIFF
--- a/misc/alpine-tools.func
+++ b/misc/alpine-tools.func
@@ -34,11 +34,19 @@ net_resolves() {
 }
 
 ensure_usr_local_bin_persist() {
+  # Login shells: /etc/profile.d/
   local PROFILE_FILE="/etc/profile.d/10-localbin.sh"
   if [ ! -f "$PROFILE_FILE" ]; then
     echo 'case ":$PATH:" in *:/usr/local/bin:*) ;; *) export PATH="/usr/local/bin:$PATH";; esac' >"$PROFILE_FILE"
     chmod +x "$PROFILE_FILE"
   fi
+
+  # Non-login shells (pct enter): /root/.profile and /root/.bashrc
+  for rc_file in /root/.profile /root/.bashrc; do
+    if [ -f "$rc_file" ] && ! grep -q '/usr/local/bin' "$rc_file"; then
+      echo 'export PATH="/usr/local/bin:$PATH"' >>"$rc_file"
+    fi
+  done
 }
 
 download_with_progress() {

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1851,15 +1851,25 @@ function download_with_progress() {
 # Ensures /usr/local/bin is permanently in system PATH.
 #
 # Description:
-#   - Adds to /etc/profile.d if not present
+#   - Adds to /etc/profile.d for login shells (SSH, noVNC)
+#   - Adds to /root/.bashrc for non-login shells (pct enter)
 # ------------------------------------------------------------------------------
 
 function ensure_usr_local_bin_persist() {
-  local PROFILE_FILE="/etc/profile.d/custom_path.sh"
+  # Skip on Proxmox host
+  command -v pveversion &>/dev/null && return
 
-  if [[ ! -f "$PROFILE_FILE" ]] && ! command -v pveversion &>/dev/null; then
+  # Login shells: /etc/profile.d/
+  local PROFILE_FILE="/etc/profile.d/custom_path.sh"
+  if [[ ! -f "$PROFILE_FILE" ]]; then
     echo 'export PATH="/usr/local/bin:$PATH"' >"$PROFILE_FILE"
     chmod +x "$PROFILE_FILE"
+  fi
+
+  # Non-login shells (pct enter): /root/.bashrc
+  local BASHRC="/root/.bashrc"
+  if [[ -f "$BASHRC" ]] && ! grep -q '/usr/local/bin' "$BASHRC"; then
+    echo 'export PATH="/usr/local/bin:$PATH"' >>"$BASHRC"
   fi
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Fixes the issue where tools installed to /usr/local/bin (e.g. uv, yq, go, composer) are not found when accessing LXCs via pct enter, because it spawns a non-login shell that only sources .bashrc, not /etc/profile.d/.

- /etc/profile.d/ → works for login shells (SSH, noVNC) 
- /root/.bashrc → works for non-login shells (pct enter) 

## 🔗 Related Issue

Fixes https://discord.com/channels/1302816934508630047/1472546578609868924

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
