### PR TITLE
core: remove duplicate error handler from alpine-install.func

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -34,42 +34,6 @@ EOF
   fi
 }
 
-set -Eeuo pipefail
-trap 'error_handler $? $LINENO "$BASH_COMMAND"' ERR
-trap on_exit EXIT
-trap on_interrupt INT
-trap on_terminate TERM
-
-error_handler() {
-  local exit_code="$1"
-  local line_number="$2"
-  local command="$3"
-
-  if [[ "$exit_code" -eq 0 ]]; then
-    return 0
-  fi
-
-  printf "\e[?25h"
-  echo -e "\n${RD}[ERROR]${CL} in line ${RD}$line_number${CL}: exit code ${RD}$exit_code${CL}: while executing command ${YW}$command${CL}\n"
-  exit "$exit_code"
-}
-
-on_exit() {
-  local exit_code="$?"
-  [[ -n "${lockfile:-}" && -e "$lockfile" ]] && rm -f "$lockfile"
-  exit "$exit_code"
-}
-
-on_interrupt() {
-  echo -e "\n${RD}Interrupted by user (SIGINT)${CL}"
-  exit 130
-}
-
-on_terminate() {
-  echo -e "\n${RD}Terminated by signal (SIGTERM)${CL}"
-  exit 143
-}
-
 # This function sets up the Container OS by generating the locale, setting the timezone, and checking the network connection
 setting_up_container() {
   msg_info "Setting up Container OS"

--- a/misc/install.func
+++ b/misc/install.func
@@ -172,7 +172,7 @@ network_check() {
   fi
 
   set -e
-  trap 'error_handler $LINENO "$BASH_COMMAND"' ERR
+  trap 'error_handler' ERR
 }
 
 # ==============================================================================


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Remove legacy error_handler(), on_exit(), on_interrupt(), on_terminate() and set/trap definitions from alpine-install.func (already provided by error_handler.func which is sourced on line 10)
- The local error_handler() expected positional args as required, but catch_errors() sets trap as 'error_handler' (without args), causing unbound variable error with set -u (nounset)
- error_handler.func uses default values which is set -u safe
- Also align legacy trap in install.func network_check() to standard format

## 🔗 Related Issue

Fixes #11929

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
