### PR TITLE
core: call get_lxc_ip in start() before updates

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3427,6 +3427,7 @@ start() {
     VERBOSE="no"
     set_std_mode
     ensure_profile_loaded
+    get_lxc_ip
     update_script
     update_motd_ip
     cleanup_lxc
@@ -3454,6 +3455,7 @@ start() {
       ;;
     esac
     ensure_profile_loaded
+    get_lxc_ip
     update_script
     update_motd_ip
     cleanup_lxc


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
add additional calls to get_lxc_ip in start() (two code paths) immediately after ensure_profile_loaded so the container IP is fetched before update_script and update_motd_ip run. This ensures scripts and MOTD are updated with the correct LXC IP.

## 🔗 Related Issue

Fixes #12003

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
