### PR TITLE
fix contribution/setup-fork

### DIFF
--- a/docs/contribution/setup-fork.sh
+++ b/docs/contribution/setup-fork.sh
@@ -134,7 +134,7 @@ update_links() {
   # Find all files containing the old repo reference
   while IFS= read -r file; do
     # Count occurrences
-    local count=$(grep -c "github.com/$old_repo/$old_name" "$file" 2>/dev/null || echo 0)
+    local count=$(grep -E -c "(github.com|githubusercontent.com)/$old_repo/$old_name" "$file" 2>/dev/null || echo 0)
 
     if [[ $count -gt 0 ]]; then
       # Backup original
@@ -143,16 +143,16 @@ update_links() {
       # Replace links - use different sed syntax for BSD/macOS vs GNU sed
       if sed --version &>/dev/null 2>&1; then
         # GNU sed
-        sed -i "s|github.com/$old_repo/$old_name|github.com/$new_owner/$new_repo|g" "$file"
+        sed -E -i "s@(github.com|githubusercontent.com)/$old_repo/$old_name@\\1/$new_owner/$new_repo@g" "$file"
       else
         # BSD sed (macOS)
-        sed -i '' "s|github.com/$old_repo/$old_name|github.com/$new_owner/$new_repo|g" "$file"
+        sed -E -i '' "s@(github.com|githubusercontent.com)/$old_repo/$old_name@\\1/$new_owner/$new_repo@g" "$file"
       fi
 
       ((files_updated++))
       print_success "Updated $file ($count links)"
     fi
-  done < <(find "$search_path" -type f \( -name "*.md" -o -name "*.sh" -o -name "*.func" -o -name "*.json" \) -not -path "*/.git/*" 2>/dev/null | xargs grep -l "github.com/$old_repo/$old_name" 2>/dev/null)
+  done < <(find "$search_path" -type f \( -name "*.md" -o -name "*.sh" -o -name "*.func" -o -name "*.json" \) -not -path "*/.git/*" 2>/dev/null | xargs grep -E -l "(github.com|githubusercontent.com)/$old_repo/$old_name" 2>/dev/null)
 
   return $files_updated
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
he setup-fork.sh script uses this expression for replacing the "community-scripts/ProxmoxVE" with the forked repo name and owner:
"s|github.com/$old_repo/$old_name|github.com/$new_owner/$new_repo|g"  

Issue ist, that some files (e. g. build.func) are not refering to "github.com" but "raw.githubusercontent.com", which does not match - here an example line:
 lxc-attach -n "$CTID" -- bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh)"

Especially when testing new scripts in a forked repository that leads to a 404 coming from that curl, leading to manual changes needed. It also doesn't fit the documentation for contribution.

As "raw.github.com" is not longer supported to my knowledge, the only option is to changes the setup-fork.sh script.

The fix includes both github.com and githubusercontent.com.

## 🔗 Related Issue
Fixes #12045 


## ✅ Prerequisites (**X** in brackets)

- [ x ] **Self-review completed** – Code follows project standards.
- [ x ] **Tested thoroughly** – Changes work as expected. -> test on MacOs only
- [ x ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ x ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
