### PR TITLE
[Fix] PatchMon: use `SERVER_PORT` in Nginx config if set in env

### DIFF
--- a/ct/patchmon.sh
+++ b/ct/patchmon.sh
@@ -46,6 +46,7 @@ function update_script() {
     VERSION=$(get_latest_github_release "PatchMon/PatchMon")
     PROTO="$(sed -n '/SERVER_PROTOCOL/s/[^=]*=//p' /opt/backend.env)"
     HOST="$(sed -n '/SERVER_HOST/s/[^=]*=//p' /opt/backend.env)"
+    SERVER_PORT="$(sed -n '/SERVER_PORT/s/[^=]*=//p' /opt/backend.env)"
     [[ "${PROTO:-http}" == "http" ]] && PORT=":3001"
     sed -i 's/PORT=3399/PORT=3001/' /opt/backend.env
     sed -i -e "s/VERSION=.*/VERSION=$VERSION/" \
@@ -66,6 +67,9 @@ function update_script() {
       -e '\|try_files |i\        root /opt/patchmon/frontend/dist;' \
       -e 's|alias.*|alias /opt/patchmon/frontend/dist/assets;|' \
       -e '\|expires 1y|i\        root /opt/patchmon/frontend/dist;' /etc/nginx/sites-available/patchmon.conf
+    if [[ -n "$SERVER_PORT" ]] && [[ "$SERVER_PORT" != "443" ]]; then
+      sed -i "s/listen [[:digit:]]/listen ${SERVER_PORT};/" /etc/nginx/sites-available/patchmon.conf
+    fi
     ln -sf /etc/nginx/sites-available/patchmon.conf /etc/nginx/sites-enabled/
     rm -f /etc/nginx/sites-enabled/default
     $STD nginx -t


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- This PR will add the ability to change the PatchMon listen port in the Nginx config during update, if the `SERVER_PORT` env var is set in `/opt/patchmon/backend.env` and if the port is not 443
- If not set, or if set and the port is 443, then no changes are made to the listen port in the Nginx config

## 🔗 Related Issue

Related https://github.com/PatchMon/PatchMon/issues/500

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
