### PR TITLE
Submit/postiz

### DIFF
--- a/ct/postiz.sh
+++ b/ct/postiz.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/jelicanin/ProxmoxVE/main/misc/build.func)
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: jelicanin
-# License: MIT | https://github.com/jelicanin/ProxmoxVE/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://docs.postiz.com/self-hosting/docker-compose
 
 APP="Postiz"

--- a/ct/postiz.sh
+++ b/ct/postiz.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/jelicanin/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: jelicanin
+# License: MIT | https://github.com/jelicanin/ProxmoxVE/raw/main/LICENSE
+# Source: https://docs.postiz.com/self-hosting/docker-compose
+
+APP="Postiz"
+var_tags="${var_tags:-automation;docker}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-4096}"
+var_disk="${var_disk:-20}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /opt/postiz/docker-compose.yaml ]] || [[ ! -f /opt/postiz/docker-compose.override.yaml ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  DOCKER_SKIP_UPDATES="true" setup_docker
+
+  msg_info "Updating Compose Files"
+  $STD curl -fsSL https://raw.githubusercontent.com/gitroomhq/postiz-docker-compose/main/docker-compose.yaml -o /opt/postiz/docker-compose.yaml
+  mkdir -p /opt/postiz/dynamicconfig
+  $STD curl -fsSL https://raw.githubusercontent.com/gitroomhq/postiz-docker-compose/main/dynamicconfig/development-sql.yaml -o /opt/postiz/dynamicconfig/development-sql.yaml
+  msg_ok "Updated Compose Files"
+
+  msg_info "Updating Postiz Containers"
+  cd /opt/postiz
+  $STD docker compose pull
+  $STD docker compose up -d --remove-orphans
+  msg_ok "Updated Postiz Containers"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:4007${CL}"

--- a/frontend/public/json/postiz.json
+++ b/frontend/public/json/postiz.json
@@ -41,6 +41,10 @@
       "type": "info"
     },
     {
+      "text": "First startup can take several minutes while all Postiz containers initialize.",
+      "type": "info"
+    },
+    {
       "text": "Temporal UI and Spotlight are disabled by default in `docker-compose.override.yaml` to avoid extra open ports. Remove their `profiles` entries to enable them.",
       "type": "warning"
     }

--- a/frontend/public/json/postiz.json
+++ b/frontend/public/json/postiz.json
@@ -1,0 +1,48 @@
+{
+  "name": "Postiz",
+  "slug": "postiz",
+  "categories": [
+    19
+  ],
+  "date_created": "2026-02-19",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 4007,
+  "documentation": "https://docs.postiz.com/self-hosting/docker-compose",
+  "website": "https://postiz.com/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/postiz.webp",
+  "config_path": "/opt/postiz/docker-compose.override.yaml",
+  "description": "Postiz is an open-source social media scheduling platform for planning and publishing content across multiple channels.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/postiz.sh",
+      "resources": {
+        "cpu": 2,
+        "ram": 4096,
+        "hdd": 20,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "No default credentials are created. Open the web UI and register your first account.",
+      "type": "info"
+    },
+    {
+      "text": "Main stack files are stored in `/opt/postiz`.",
+      "type": "info"
+    },
+    {
+      "text": "Temporal UI and Spotlight are disabled by default in `docker-compose.override.yaml` to avoid extra open ports. Remove their `profiles` entries to enable them.",
+      "type": "warning"
+    }
+  ]
+}

--- a/install/postiz-install.sh
+++ b/install/postiz-install.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: jelicanin
+# License: MIT | https://github.com/jelicanin/ProxmoxVE/raw/main/LICENSE
+# Source: https://docs.postiz.com/self-hosting/docker-compose
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+DOCKER_SKIP_UPDATES="true" setup_docker
+get_lxc_ip
+
+msg_info "Downloading Postiz Stack Files"
+mkdir -p /opt/postiz/dynamicconfig
+$STD curl -fsSL https://raw.githubusercontent.com/gitroomhq/postiz-docker-compose/main/docker-compose.yaml -o /opt/postiz/docker-compose.yaml
+$STD curl -fsSL https://raw.githubusercontent.com/gitroomhq/postiz-docker-compose/main/dynamicconfig/development-sql.yaml -o /opt/postiz/dynamicconfig/development-sql.yaml
+msg_ok "Downloaded Postiz Stack Files"
+
+POSTIZ_DB_PASSWORD="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 32)"
+JWT_SECRET="$(tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64)"
+PUBLIC_URL="http://${LOCAL_IP}:4007"
+
+msg_info "Configuring Postiz"
+cat <<EOF >/opt/postiz/docker-compose.override.yaml
+services:
+  postiz:
+    environment:
+      MAIN_URL: "${PUBLIC_URL}"
+      FRONTEND_URL: "${PUBLIC_URL}"
+      NEXT_PUBLIC_BACKEND_URL: "${PUBLIC_URL}/api"
+      JWT_SECRET: "${JWT_SECRET}"
+      DATABASE_URL: "postgresql://postiz-user:${POSTIZ_DB_PASSWORD}@postiz-postgres:5432/postiz-db-local"
+      DISABLE_REGISTRATION: "false"
+      RUN_CRON: "true"
+
+  postiz-postgres:
+    environment:
+      POSTGRES_PASSWORD: "${POSTIZ_DB_PASSWORD}"
+      POSTGRES_USER: "postiz-user"
+      POSTGRES_DB: "postiz-db-local"
+
+  spotlight:
+    profiles: ["debug"]
+
+  temporal-ui:
+    profiles: ["debug"]
+EOF
+msg_ok "Configured Postiz"
+
+msg_info "Starting Postiz Stack (Patience)"
+cd /opt/postiz
+$STD docker compose up -d
+
+msg_info "Waiting for Postiz to Start"
+POSTIZ_CONTAINER_ID=""
+for i in {1..90}; do
+  POSTIZ_CONTAINER_ID="$(docker compose ps -q postiz 2>/dev/null)"
+  if [[ -n "${POSTIZ_CONTAINER_ID}" ]]; then
+    CONTAINER_STATUS="$(docker inspect --format '{{.State.Status}}' "${POSTIZ_CONTAINER_ID}" 2>/dev/null || true)"
+    if [[ "${CONTAINER_STATUS}" == "running" ]]; then
+      if curl -fsS http://127.0.0.1:4007 >/dev/null 2>&1; then
+        msg_ok "Started Postiz Stack"
+        break
+      fi
+    fi
+
+    if [[ "${CONTAINER_STATUS}" == "exited" || "${CONTAINER_STATUS}" == "dead" ]]; then
+      msg_error "Postiz container failed during startup"
+      docker logs "${POSTIZ_CONTAINER_ID}" | tail -n 80
+      exit 1
+    fi
+  fi
+
+  if [[ "${i}" -eq 90 ]]; then
+    msg_error "Timed out waiting for Postiz to become ready on port 4007"
+    if [[ -n "${POSTIZ_CONTAINER_ID}" ]]; then
+      docker logs "${POSTIZ_CONTAINER_ID}" | tail -n 80
+    fi
+    exit 1
+  fi
+  sleep 2
+done
+
+msg_info "Creating Postiz Credentials File"
+cat <<EOF >~/postiz.creds
+Postiz Information
+
+URL: ${PUBLIC_URL}
+Config Path: /opt/postiz/docker-compose.override.yaml
+
+Default Login: No default credentials.
+Open the URL and create your first account.
+EOF
+chmod 600 ~/postiz.creds
+msg_ok "Created Postiz Credentials File"
+
+motd_ssh
+customize
+cleanup_lxc

--- a/install/postiz-install.sh
+++ b/install/postiz-install.sh
@@ -2,7 +2,7 @@
 
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: jelicanin
-# License: MIT | https://github.com/jelicanin/ProxmoxVE/raw/main/LICENSE
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://docs.postiz.com/self-hosting/docker-compose
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"


### PR DESCRIPTION
## ✍️ Description

Adds new Postiz LXC script set:

- `ct/postiz.sh`
- `install/postiz-install.sh`
- `frontend/public/json/postiz.json`

Implementation details:
- Docker-based Postiz deployment using upstream compose files.
- Auto-generates DB password and JWT secret.
- Creates `/opt/postiz/docker-compose.override.yaml`.
- Adds startup resilience for slow first boot (does not fail unnecessarily while containers initialize).
- Includes update flow (`docker compose pull && up -d --remove-orphans`).

Tested on local Proxmox:
- PVE 8.4.16, Debian 13, unprivileged CT
- 2 CPU / 4096 MB RAM / 50 GB disk
- Post-install access verified on `http://<CT_IP>:4007`
- Container stack status verified with `docker compose ps`

## 🔗 Related Issue

Related discussion: https://github.com/community-scripts/ProxmoxVE/discussions/1693

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix**
- [ ] ✨ **New feature**
- [ ] 💥 **Breaking change**
- [x] 🆕 **New script**
- [x] 🌍 **Website update**
- [ ] 🔧 **Refactoring / Code Cleanup**
- [ ] 📝 **Documentation update**
