### PR TITLE
fix(huntarr): add build-essential for native pip dependencies

### DIFF
--- a/install/huntarr-install.sh
+++ b/install/huntarr-install.sh
@@ -13,6 +13,10 @@ setting_up_container
 network_check
 update_os
 
+msg_info "Installing Dependencies"
+$STD apt-get install -y build-essential
+msg_ok "Installed Dependencies"
+
 PYTHON_VERSION="3.12" setup_uv
 fetch_and_deploy_gh_release "huntarr" "plexguide/Huntarr.io" "tarball"
 


### PR DESCRIPTION
## Fix

Some Python packages in huntarr's requirements.txt require a C++ compiler for building native extensions. The install currently fails with:

```
error: command 'c++' failed: No such file or directory
```

This adds `build-essential` as a dependency before `uv pip install`.

Closes #12117