### PR TITLE
Zammad: fix Elasticsearch JVM config and add daemon-reload

### DIFF
--- a/install/zammad-install.sh
+++ b/install/zammad-install.sh
@@ -28,9 +28,10 @@ setup_deb822_repo \
   "stable" \
   "main"
 $STD apt install -y elasticsearch
-echo "-Xms2g" >>/etc/elasticsearch/jvm.options
-echo "-Xmx2g" >>/etc/elasticsearch/jvm.options
+sed -i 's/^-Xms.*/-Xms2g/' /etc/elasticsearch/jvm.options
+sed -i 's/^-Xmx.*/-Xmx2g/' /etc/elasticsearch/jvm.options
 $STD /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachment -b
+systemctl daemon-reload
 systemctl enable -q elasticsearch
 systemctl restart -q elasticsearch
 msg_ok "Setup Elasticsearch"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

1. JVM heap options were appended with `>>` to `jvm.options`, leaving the old `-Xms1g`/`-Xmx1g` defaults in place. Changed to `sed` to replace the existing values properly.

2. Missing `systemctl daemon-reload`

## 🔗 Related Issue

Fixes #12111

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.