### PR TITLE
Docker-VM: add error handling for virt-customize finalization

### DIFF
--- a/vm/docker-vm.sh
+++ b/vm/docker-vm.sh
@@ -552,7 +552,7 @@ msg_ok "Finalized image"
 
 # Create first-boot Docker install script (fallback if virt-customize failed)
 if [ "$DOCKER_PREINSTALLED" = "no" ]; then
-  virt-customize -q -a "$WORK_FILE" --run-command 'cat > /root/install-docker.sh << "DOCKERSCRIPT"
+  if virt-customize -q -a "$WORK_FILE" --run-command 'cat > /root/install-docker.sh << "DOCKERSCRIPT"
 #!/bin/bash
 exec > /var/log/install-docker.log 2>&1
 echo "[$(date)] Starting Docker installation"
@@ -581,9 +581,9 @@ systemctl restart docker
 touch /root/.docker-installed
 echo "[$(date)] Docker installation completed"
 DOCKERSCRIPT
-chmod +x /root/install-docker.sh' >/dev/null 2>&1 || true
+chmod +x /root/install-docker.sh' >/dev/null 2>&1; then
 
-  virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/systemd/system/install-docker.service << "DOCKERSERVICE"
+    virt-customize -q -a "$WORK_FILE" --run-command 'cat > /etc/systemd/system/install-docker.service << "DOCKERSERVICE"
 [Unit]
 Description=Install Docker on First Boot
 After=network-online.target
@@ -599,6 +599,10 @@ RemainAfterExit=yes
 WantedBy=multi-user.target
 DOCKERSERVICE
 systemctl enable install-docker.service' >/dev/null 2>&1 || true
+  else
+    msg_warn "virt-customize failed for this image. Docker must be installed manually after first boot:"
+    msg_warn "  curl -fsSL https://get.docker.com | sh"
+  fi
 fi
 
 # Resize disk to target size

--- a/vm/docker-vm.sh
+++ b/vm/docker-vm.sh
@@ -525,9 +525,9 @@ fi
 
 msg_info "Finalizing image (hostname, SSH config)"
 # Set hostname and prepare for unique machine-id
-virt-customize -q -a "$WORK_FILE" --hostname "${HN}" >/dev/null 2>&1
-virt-customize -q -a "$WORK_FILE" --run-command "truncate -s 0 /etc/machine-id" >/dev/null 2>&1
-virt-customize -q -a "$WORK_FILE" --run-command "rm -f /var/lib/dbus/machine-id" >/dev/null 2>&1
+virt-customize -q -a "$WORK_FILE" --hostname "${HN}" >/dev/null 2>&1 || true
+virt-customize -q -a "$WORK_FILE" --run-command "truncate -s 0 /etc/machine-id" >/dev/null 2>&1 || true
+virt-customize -q -a "$WORK_FILE" --run-command "rm -f /var/lib/dbus/machine-id" >/dev/null 2>&1 || true
 
 # Configure SSH for Cloud-Init
 if [ "$USE_CLOUD_INIT" = "yes" ]; then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The finalization `virt-customize` calls for hostname and machine-id cleanup had no error handling (`|| true`), while the SSH config calls directly below already had it.

When `virt-customize` fails on certain images (e.g. Debian 13 Trixie), the script aborted at `--hostname` instead of continuing. These steps are non-critical since Cloud-Init handles hostname assignment later anyway.

## 🔗 Related Issue

Fixes #12073

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
