### PR TITLE
Planka: migrate data paths to new v2 directory structure

### DIFF
--- a/ct/planka.sh
+++ b/ct/planka.sh
@@ -37,10 +37,18 @@ function update_script() {
     BK="/opt/planka-backup"
     mkdir -p "$BK"/{favicons,user-avatars,background-images,attachments}
     [ -f /opt/planka/.env ] && mv /opt/planka/.env "$BK"/
-    [ -d /opt/planka/public/favicons ] && cp -a /opt/planka/public/favicons/. "$BK/favicons/"
-    [ -d /opt/planka/public/user-avatars ] && cp -a /opt/planka/public/user-avatars/. "$BK/user-avatars/"
-    [ -d /opt/planka/public/background-images ] && cp -a /opt/planka/public/background-images/. "$BK/background-images/"
-    [ -d /opt/planka/private/attachments ] && cp -a /opt/planka/private/attachments/. "$BK/attachments/"
+    # Support both old (pre-v2) and new (v2) directory layouts
+    if [ -d /opt/planka/data/protected ]; then
+      [ -d /opt/planka/data/protected/favicons ] && cp -a /opt/planka/data/protected/favicons/. "$BK/favicons/"
+      [ -d /opt/planka/data/protected/user-avatars ] && cp -a /opt/planka/data/protected/user-avatars/. "$BK/user-avatars/"
+      [ -d /opt/planka/data/protected/background-images ] && cp -a /opt/planka/data/protected/background-images/. "$BK/background-images/"
+      [ -d /opt/planka/data/private/attachments ] && cp -a /opt/planka/data/private/attachments/. "$BK/attachments/"
+    else
+      [ -d /opt/planka/public/favicons ] && cp -a /opt/planka/public/favicons/. "$BK/favicons/"
+      [ -d /opt/planka/public/user-avatars ] && cp -a /opt/planka/public/user-avatars/. "$BK/user-avatars/"
+      [ -d /opt/planka/public/background-images ] && cp -a /opt/planka/public/background-images/. "$BK/background-images/"
+      [ -d /opt/planka/private/attachments ] && cp -a /opt/planka/private/attachments/. "$BK/attachments/"
+    fi
     rm -rf /opt/planka
     msg_ok "Backed up data"
 
@@ -53,11 +61,12 @@ function update_script() {
 
     msg_info "Restoring data"
     [ -f "$BK/.env" ] && mv "$BK/.env" /opt/planka/.env
-    mkdir -p /opt/planka/public/{favicons,user-avatars,background-images} /opt/planka/private/attachments
-    [ -d "$BK/favicons" ] && cp -a "$BK/favicons/." /opt/planka/public/favicons/
-    [ -d "$BK/user-avatars" ] && cp -a "$BK/user-avatars/." /opt/planka/public/user-avatars/
-    [ -d "$BK/background-images" ] && cp -a "$BK/background-images/." /opt/planka/public/background-images/
-    [ -d "$BK/attachments" ] && cp -a "$BK/attachments/." /opt/planka/private/attachments/
+    # Planka v2 uses unified data directory structure
+    mkdir -p /opt/planka/data/protected/{favicons,user-avatars,background-images} /opt/planka/data/private/attachments
+    [ -d "$BK/favicons" ] && cp -a "$BK/favicons/." /opt/planka/data/protected/favicons/
+    [ -d "$BK/user-avatars" ] && cp -a "$BK/user-avatars/." /opt/planka/data/protected/user-avatars/
+    [ -d "$BK/background-images" ] && cp -a "$BK/background-images/." /opt/planka/data/protected/background-images/
+    [ -d "$BK/attachments" ] && cp -a "$BK/attachments/." /opt/planka/data/private/attachments/
     rm -rf "$BK"
     msg_ok "Restored data"
 

--- a/install/planka-install.sh
+++ b/install/planka-install.sh
@@ -50,6 +50,7 @@ cp .env.sample .env
 sed -i "s#http://localhost:1337#http://$LOCAL_IP:1337#g" /opt/planka/.env
 sed -i "s#postgres@localhost#planka:$DB_PASS@localhost#g" /opt/planka/.env
 sed -i "s#notsecretkey#$SECRET_KEY#g" /opt/planka/.env
+mkdir -p /opt/planka/data/protected/{favicons,user-avatars,background-images} /opt/planka/data/private/attachments
 $STD npm run db:init
 msg_ok "Configured PLANKA"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Planka v2.0.1 moved all uploads to a unified data directory:
- public/{favicons,user-avatars,background-images} -> data/protected/
- private/attachments -> data/private/

The update script was still restoring files to the old locations, which made attachments, avatars and backgrounds disappear after updating from rc.4 to 2.0.1.

Changes:
- update_script: backup handles both old and new layouts
- update_script: restore now uses new v2 paths
- install script: create v2 data directories on fresh install

## 🔗 Related Issue

Fixes #12066

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
