### PR TITLE
recyclarr: adjust paths for v8.0 breaking changes

### DIFF
--- a/ct/recyclarr.sh
+++ b/ct/recyclarr.sh
@@ -23,7 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /root/.config/recyclarr/recyclarr.yml ]]; then
+  if [[ ! -f /root/.config/recyclarr/recyclarr.yml ]] && [[ ! -d /root/.config/recyclarr/configs ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
@@ -32,6 +32,20 @@ function update_script() {
     msg_info "Updating ${APP}"
 
     fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-x64.tar.xz"
+
+    # Migrate includes from configs/ to includes/ (recyclarr v8)
+    RECYCLARR_DIR="/root/.config/recyclarr"
+    mkdir -p "$RECYCLARR_DIR/includes"
+    if [[ -d "$RECYCLARR_DIR/configs" ]]; then
+      for item in "$RECYCLARR_DIR/configs"/*/; do
+        [[ -d "$item" ]] || continue
+        dir_name=$(basename "$item")
+        # Only move subdirs that look like include dirs (not the configs themselves)
+        if [[ "$dir_name" != "configs" ]] && [[ ! -d "$RECYCLARR_DIR/includes/$dir_name" ]]; then
+          mv "$item" "$RECYCLARR_DIR/includes/"
+        fi
+      done
+    fi
 
     msg_ok "Updated successfully!"
   fi

--- a/install/recyclarr-install.sh
+++ b/install/recyclarr-install.sh
@@ -20,7 +20,7 @@ msg_ok "Installed Dependencies"
 fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-x64.tar.xz"
 
 msg_info "Configuring Recyclarr"
-mkdir -p /root/.config/recyclarr
+mkdir -p /root/.config/recyclarr/{configs,includes}
 $STD recyclarr config create
 msg_ok "Configured Recyclarr"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Recyclarr v8.0 moved local includes from configs/ to a dedicated includes/ directory. The install script now creates both dirs upfront. The update script migrates existing include subdirs from configs/ to includes/ after the binary update and also handles detection for both old (recyclarr.yml) and new (configs/) config layouts.

See https://recyclarr.dev/guide/upgrade-guide/v8.0


## 🔗 Related Issue

Fixes #12109

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
