### PR TITLE
Pangolin: restore config before db migration, use drizzle-kit push

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -51,7 +51,6 @@ function update_script() {
     $STD npm run db:generate
     $STD npm run build
     $STD npm run build:cli
-    $STD npm run db:push
     cp -R .next/standalone ./
     chmod +x ./dist/cli.mjs
     cp server/db/names.json ./dist/names.json
@@ -63,6 +62,11 @@ function update_script() {
     tar -xzf /opt/pangolin_config_backup.tar.gz -C /opt/pangolin --overwrite
     rm -f /opt/pangolin_config_backup.tar.gz
     msg_ok "Restored config"
+
+    msg_info "Running database migrations"
+    cd /opt/pangolin
+    ENVIRONMENT=prod $STD npx drizzle-kit push --config drizzle.sqlite.config.ts
+    msg_ok "Ran database migrations"
 
     msg_info "Updating Badger plugin version"
     BADGER_VERSION=$(get_latest_github_release "fosrl/badger" "false")


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
npm run db:push ran drizzle migrate (CREATE TABLE) on an empty directory before the config backup was restored, creating a fresh DB that got immediately overwritten by the old backup. The old DB was missing new columns like resources.postAuthPath (added in 1.15.4).

Replace with drizzle-kit push after config restore, which introspects the existing DB and applies schema diffs (ALTER TABLE) instead.


## 🔗 Related Issue

Fixes #12068

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
