### PR TITLE
booklore v2: embed frontend, bump Java to 25, remove nginx

### DIFF
--- a/ct/booklore.sh
+++ b/ct/booklore.sh
@@ -30,7 +30,7 @@ function update_script() {
   fi
 
   if check_for_gh_release "booklore" "booklore-app/BookLore"; then
-    JAVA_VERSION="21" setup_java
+    JAVA_VERSION="25" setup_java
     NODE_VERSION="22" setup_nodejs
     setup_mariadb
     setup_yq
@@ -60,11 +60,16 @@ function update_script() {
     $STD npm run build --configuration=production
     msg_ok "Built Frontend"
 
+    msg_info "Embedding Frontend into Backend"
+    mkdir -p /opt/booklore/booklore-api/src/main/resources/static
+    cp -r /opt/booklore/booklore-ui/dist/booklore/browser/* /opt/booklore/booklore-api/src/main/resources/static/
+    msg_ok "Embedded Frontend into Backend"
+
     msg_info "Building Backend"
     cd /opt/booklore/booklore-api
     APP_VERSION=$(get_latest_github_release "booklore-app/BookLore")
     yq eval ".app.version = \"${APP_VERSION}\"" -i src/main/resources/application.yaml
-    $STD ./gradlew clean build --no-daemon
+    $STD ./gradlew clean build -x test --no-daemon
     mkdir -p /opt/booklore/dist
     JAR_PATH=$(find /opt/booklore/booklore-api/build/libs -maxdepth 1 -type f -name "booklore-api-*.jar" ! -name "*plain*" | head -n1)
     if [[ -z "$JAR_PATH" ]]; then
@@ -74,9 +79,22 @@ function update_script() {
     cp "$JAR_PATH" /opt/booklore/dist/app.jar
     msg_ok "Built Backend"
 
+    if systemctl is-active --quiet nginx 2>/dev/null; then
+      msg_info "Removing Nginx (no longer needed)"
+      systemctl disable --now nginx
+      $STD apt-get purge -y nginx nginx-common
+      msg_ok "Removed Nginx"
+    fi
+
+    if ! grep -q "^SERVER_PORT=" /opt/booklore_storage/.env 2>/dev/null; then
+      echo "SERVER_PORT=6060" >>/opt/booklore_storage/.env
+    fi
+
+    sed -i 's|ExecStart=/usr/bin/java -jar|ExecStart=/usr/bin/java -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -jar|' /etc/systemd/system/booklore.service
+    systemctl daemon-reload
+
     msg_info "Starting Service"
     systemctl start booklore
-    systemctl reload nginx
     rm -rf /opt/booklore_bak
     msg_ok "Started Service"
     msg_ok "Updated successfully!"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Upgrade Java from 21 to 25 and add embedding of the built frontend into the backend resources so the Spring Boot app serves static files. 
- Build steps now skip tests (gradle -x test)
- Remove nginx install/configuration paths: install script no longer installs or configures nginx; update script disables and purges nginx if active. 
- Add default SERVER_PORT=6060 to the .env (or append if missing). 
- Update systemd unit ExecStart to include JVM tuning flags and reload systemd. Misc: adjust start/reload steps to reflect nginx removal and clean up previous backup dirs.

## 🔗 Related Issue

Fixes #12222

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
