### PR TITLE
fix(searxng): remove orphaned fi causing syntax error

### DIFF
--- a/ct/searxng.sh
+++ b/ct/searxng.sh
@@ -52,7 +52,6 @@ function update_script() {
   systemctl start searxng
   msg_ok "Started Services"
   msg_ok "Updated successfully!"
- fi
  exit
 }
 start


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

When attempting to update my SearXNG instance using the helper script in the LXC:
```
bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/searxng.sh)"
```

I received the following error:
```
`bash: -c: line 55: syntax error near unexpected token `fi'`
```

Reviewing the script it looks to be orphaned loop closure. Removing the offending "fi" on line 55 results in a script that executes and updated my LXC container.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
