### PR TITLE
feat: add CLIProxyAPI LXC container script

### DIFF
--- a/ct/cliproxyapi.sh
+++ b/ct/cliproxyapi.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: mathiasnagler
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/router-for-me/CLIProxyAPI
+
+APP="CLIProxyAPI"
+var_tags="${var_tags:-ai;proxy}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-2}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/cliproxyapi ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+  if check_for_gh_release "cliproxyapi" "router-for-me/CLIProxyAPI"; then
+    systemctl stop cliproxyapi
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cliproxyapi" "router-for-me/CLIProxyAPI" "prebuild" "latest" "/opt/cliproxyapi" "CLIProxyAPI_*_linux_amd64.tar.gz"
+    systemctl start cliproxyapi
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+MGMT_KEY=$(pct exec "$CTID" -- grep "Management Password:" /root/cliproxyapi.creds | awk '{print $NF}')
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Management Panel:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8317/management.html${CL}"
+echo -e "${INFO}${YW} Management Key:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}${MGMT_KEY}${CL}"
+echo -e "${INFO}${YW} OpenAI-compatible API endpoint:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8317/v1${CL}"
+echo -e "${INFO}${YW} All credentials stored at: /root/cliproxyapi.creds (inside LXC)${CL}"

--- a/frontend/public/json/cliproxyapi.json
+++ b/frontend/public/json/cliproxyapi.json
@@ -1,0 +1,44 @@
+{
+  "name": "CLIProxyAPI",
+  "slug": "cliproxyapi",
+  "categories": [
+    20
+  ],
+  "date_created": "2026-02-24",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 8317,
+  "documentation": "https://help.router-for.me/",
+  "website": "https://github.com/router-for-me/CLIProxyAPI",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/openai.webp",
+  "config_path": "/opt/cliproxyapi/config.yaml",
+  "description": "CLIProxyAPI is a proxy server that provides OpenAI-compatible API endpoints for multiple AI CLI tools including Claude Code, Gemini CLI, OpenAI Codex, and more. It enables leveraging free-tier AI subscriptions through a unified API with features like credential routing, quota management, and request retrying.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/cliproxyapi.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 512,
+        "hdd": 2,
+        "os": "debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "Generated credentials (API Key, Management Password) are saved to `/root/cliproxyapi.creds` inside the LXC.",
+      "type": "info"
+    },
+    {
+      "text": "After setup, authenticate your AI providers via the built-in management panel at port 8317.",
+      "type": "warning"
+    }
+  ]
+}

--- a/install/cliproxyapi-install.sh
+++ b/install/cliproxyapi-install.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: mathiasnagler
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/router-for-me/CLIProxyAPI
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  openssl
+msg_ok "Installed Dependencies"
+
+fetch_and_deploy_gh_release "cliproxyapi" "router-for-me/CLIProxyAPI" "prebuild" "latest" "/opt/cliproxyapi" "CLIProxyAPI_*_linux_amd64.tar.gz"
+
+msg_info "Configuring CLIProxyAPI"
+MANAGEMENT_PASSWORD=$(openssl rand -hex 32)
+API_KEY="sk-$(openssl rand -hex 16)"
+
+mkdir -p /root/.cli-proxy-api
+
+cat <<EOF >/opt/cliproxyapi/config.yaml
+host: ""
+port: 8317
+auth-dir: "/root/.cli-proxy-api"
+remote-management:
+  allow-remote: true
+  secret-key: "${MANAGEMENT_PASSWORD}"
+api-keys:
+  - "${API_KEY}"
+request-retry: 3
+quota-exceeded:
+  switch-project: true
+  switch-preview-model: true
+routing:
+  strategy: "round-robin"
+EOF
+
+{
+  echo "CLIProxyAPI Credentials"
+  echo "======================="
+  echo "API Key:              ${API_KEY}"
+  echo "Management Password:  ${MANAGEMENT_PASSWORD}"
+} >~/cliproxyapi.creds
+chmod 600 ~/cliproxyapi.creds
+msg_ok "Configured CLIProxyAPI"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/cliproxyapi.service
+[Unit]
+Description=CLIProxyAPI
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/cliproxyapi
+ExecStart=/opt/cliproxyapi/cli-proxy-api
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl daemon-reload
+systemctl enable -q --now cliproxyapi
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## ✍️ Description

Add community script to deploy **CLIProxyAPI** — a proxy server that provides OpenAI-compatible API endpoints for multiple AI CLI tools (Claude Code, Gemini CLI, OpenAI Codex, Qwen, and more). It enables leveraging free-tier AI subscriptions through a unified API with credential routing, quota management, and request retrying.

Installs the Go binary directly from GitHub releases (bare-metal, no Docker) with a systemd service. Includes a built-in management panel at port 8317.

**Source:** https://github.com/router-for-me/CLIProxyAPI

## 🔗 Related Issue

N/A

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.