### PR TITLE
Zammad: configure Elasticsearch before zammad start

### DIFF
--- a/install/zammad-install.sh
+++ b/install/zammad-install.sh
@@ -30,10 +30,21 @@ setup_deb822_repo \
 $STD apt install -y elasticsearch
 sed -i 's/^-Xms.*/-Xms2g/' /etc/elasticsearch/jvm.options
 sed -i 's/^-Xmx.*/-Xmx2g/' /etc/elasticsearch/jvm.options
+cat <<EOF >>/etc/elasticsearch/elasticsearch.yml
+discovery.type: single-node
+xpack.security.enabled: false
+bootstrap.memory_lock: false
+EOF
 $STD /usr/share/elasticsearch/bin/elasticsearch-plugin install ingest-attachment -b
 systemctl daemon-reload
 systemctl enable -q elasticsearch
 systemctl restart -q elasticsearch
+for i in $(seq 1 30); do
+  if curl -s http://localhost:9200 >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
 msg_ok "Setup Elasticsearch"
 
 msg_info "Installing Zammad"

--- a/install/zammad-install.sh
+++ b/install/zammad-install.sh
@@ -28,8 +28,8 @@ setup_deb822_repo \
   "stable" \
   "main"
 $STD apt install -y elasticsearch
-sed -i 's/^-Xms.*/-Xms2g/' /etc/elasticsearch/jvm.options
-sed -i 's/^-Xmx.*/-Xmx2g/' /etc/elasticsearch/jvm.options
+sed -i 's/^#\{0,2\} *-Xms[0-9]*g.*/-Xms2g/' /etc/elasticsearch/jvm.options
+sed -i 's/^#\{0,2\} *-Xmx[0-9]*g.*/-Xmx2g/' /etc/elasticsearch/jvm.options
 cat <<EOF >>/etc/elasticsearch/elasticsearch.yml
 discovery.type: single-node
 xpack.security.enabled: false


### PR DESCRIPTION
Fixes #12300-related recurring Elasticsearch startup failures

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Set discovery.type: single-node (required for single-node ES)
- Set xpack.security.enabled: false (not needed in local LXC)
- Set bootstrap.memory_lock: false (fails in unprivileged LXC)
- Add startup wait loop (up to 60s) to ensure ES is ready before Zammad installation continues


## 🔗 Related Issue

Fixes #12300

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
