### PR TITLE
Improves adguardhome-sync addon when running on alpine LXCs

### DIFF
--- a/tools/addon/adguardhome-sync.sh
+++ b/tools/addon/adguardhome-sync.sh
@@ -79,9 +79,6 @@ if ! command -v jq &>/dev/null; then
   printf "\r\e[2K%b" '\033[93m Installing jq \033[m' >&2
   if [[ "$OS" == "Alpine" ]]; then
     apk -U add jq >/dev/null 2>&1
-  else            
-    apt-get update >/dev/null 2>&1
-    apt-get install -y jq >/dev/null 2>&1
   fi
 fi
 

--- a/tools/addon/adguardhome-sync.sh
+++ b/tools/addon/adguardhome-sync.sh
@@ -7,8 +7,12 @@
 
 if ! command -v curl &>/dev/null; then
   printf "\r\e[2K%b" '\033[93m Setup Source \033[m' >&2
-  apt-get update >/dev/null 2>&1
-  apt-get install -y curl >/dev/null 2>&1
+  if [[ -f "/etc/alpine-release" ]]; then
+    apk -U add curl >/dev/null 2>&1
+  else
+    apt-get update >/dev/null 2>&1
+    apt-get install -y curl >/dev/null 2>&1
+  fi
 fi
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/core.func)
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/tools.func)
@@ -51,7 +55,7 @@ EOF
 # HELPER FUNCTIONS
 # ==============================================================================
 get_ip() {
-  hostname -I 2>/dev/null | awk '{print $1}' || echo "127.0.0.1"
+ ifconfig | grep -v '127.0.0.1' | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -m1 -Eo '([0-9]*\.){3}[0-9]*' || echo "127.0.0.1"
 }
 
 # ==============================================================================
@@ -66,6 +70,19 @@ elif [[ -f "/etc/debian_version" ]]; then
 else
   msg_error "Unsupported OS detected. Exiting."
   exit 1
+fi
+
+# ==============================================================================
+# DEPENDENCY CHECK
+# ==============================================================================
+if ! command -v jq &>/dev/null; then
+  printf "\r\e[2K%b" '\033[93m Installing jq \033[m' >&2
+  if [[ "$OS" == "Alpine" ]]; then
+    apk -U add jq >/dev/null 2>&1
+  else            
+    apt-get update >/dev/null 2>&1
+    apt-get install -y jq >/dev/null 2>&1
+  fi
 fi
 
 # ==============================================================================


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Improves the adguardhome-sync addon script usage on clean alpine LXC, not created thought community scripts.
Installs required `jq` dependency if not found, otherwise the script fails.
The old function used to get the container ip address doesn't work with alpines busybox utils, so it was rewritten.


## 🔗 Related Issue
Fixes #12337

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
