### PR TITLE
Add optional apt and npm registry mirror configurations

### DIFF
--- a/misc/install.func
+++ b/misc/install.func
@@ -236,13 +236,20 @@ EOF
   fi
 
   if [[ -n "${APT_MIRROR:-}" ]]; then
-    msg_info "Configuring APT mirror (${APT_MIRROR})"
-    sed -E -i \
-      -e "s|deb.debian.org/debian|${APT_MIRROR}/debian|g" \
-      -e "s|security.debian.org/debian-security|${APT_MIRROR}/debian-security|g" \
-      -e "s|deb.debian.org/debian-security|${APT_MIRROR}/debian-security|g" \
-      /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
-    msg_ok "Configured APT mirror"
+    # Validate APT_MIRROR to avoid injecting arbitrary sed commands.
+    # Only allow http/https URLs with a restricted character set.
+    if [[ ! "${APT_MIRROR}" =~ ^https?://[A-Za-z0-9._~:-/]+$ ]]; then
+      msg_error "Invalid APT_MIRROR '${APT_MIRROR}' — skipping custom mirror configuration and using defaults"
+    else
+      local SAFE_APT_MIRROR="${APT_MIRROR}"
+      msg_info "Configuring APT mirror (${SAFE_APT_MIRROR})"
+      sed -E -i \
+        -e "s|deb.debian.org/debian|${SAFE_APT_MIRROR}/debian|g" \
+        -e "s|security.debian.org/debian-security|${SAFE_APT_MIRROR}/debian-security|g" \
+        -e "s|deb.debian.org/debian-security|${SAFE_APT_MIRROR}/debian-security|g" \
+        /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+      msg_ok "Configured APT mirror"
+    fi
   fi
 
   apt_update_safe

--- a/misc/install.func
+++ b/misc/install.func
@@ -215,6 +215,7 @@ network_check() {
 #
 # - Updates container OS via apt-get update and dist-upgrade
 # - Configures APT cacher proxy if CACHER=yes (accelerates package downloads)
+# - Optionally rewrites Debian APT sources when APT_MIRROR is set
 # - Removes Python EXTERNALLY-MANAGED restrictions for pip
 # - Sources tools.func for additional setup functions after update
 # - Uses $STD wrapper to suppress output unless VERBOSE=yes
@@ -233,6 +234,17 @@ fi
 EOF
     chmod +x /usr/local/bin/apt-proxy-detect.sh
   fi
+
+  if [[ -n "${APT_MIRROR:-}" ]]; then
+    msg_info "Configuring APT mirror (${APT_MIRROR})"
+    sed -E -i \
+      -e "s|deb.debian.org/debian|${APT_MIRROR}/debian|g" \
+      -e "s|security.debian.org/debian-security|${APT_MIRROR}/debian-security|g" \
+      -e "s|deb.debian.org/debian-security|${APT_MIRROR}/debian-security|g" \
+      /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+    msg_ok "Configured APT mirror"
+  fi
+
   apt_update_safe
   $STD apt-get -o Dpkg::Options::="--force-confold" -y dist-upgrade
   rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -5372,11 +5372,14 @@ EOF
 # Variables:
 #   NODE_VERSION   - Node.js version to install (default: 24 LTS)
 #   NODE_MODULE    - Comma-separated list of global modules (e.g. "yarn,@vue/cli@5.0.0")
+#   NPM_MIRROR     - Optional npm registry mirror URL
+#   NPM_REGISTRY   - Optional npm registry URL (fallback when NPM_MIRROR is unset)
 # ------------------------------------------------------------------------------
 
 function setup_nodejs() {
   local NODE_VERSION="${NODE_VERSION:-24}"
   local NODE_MODULE="${NODE_MODULE:-}"
+  local NPM_REGISTRY_MIRROR="${NPM_MIRROR:-${NPM_REGISTRY:-}}"
 
   # ALWAYS clean up legacy installations first (nvm, etc.) to prevent conflicts
   cleanup_legacy_install "nodejs"
@@ -5476,6 +5479,15 @@ function setup_nodejs() {
 
     cache_installed_version "nodejs" "$NODE_VERSION"
     msg_ok "Setup Node.js $NODE_VERSION"
+  fi
+
+  if [[ -n "$NPM_REGISTRY_MIRROR" ]] && command -v npm >/dev/null 2>&1; then
+    msg_info "Configuring npm registry mirror"
+    if $STD npm config set registry "$NPM_REGISTRY_MIRROR"; then
+      msg_ok "Configured npm registry mirror"
+    else
+      msg_warn "Failed to configure npm registry mirror: $NPM_REGISTRY_MIRROR"
+    fi
   fi
 
   export NODE_OPTIONS="--max-old-space-size=4096"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

This PR introduces optional mirror configurations for both apt and npm.

Users in specific geographic regions or behind certain firewalls experience very slow download speeds from official Debian repositories and the default npm registry. This makes the script execution inefficient and prone to failure.

I've added support for:

APT_MIRROR: Rewrites Debian source URLs during update_os.

NPM_REGISTRY_MIRROR: Configures the npm registry before installing global modules.

These changes are optional and won't affect users who don't define these variables, but they provide a much-needed performance boost for those in constrained network environments.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
