### PR TITLE
Update Reactive Resume install script with useful .env information for reverse proxy setup

### DIFF
--- a/install/reactive-resume-install.sh
+++ b/install/reactive-resume-install.sh
@@ -69,6 +69,10 @@ cat <<EOF >/opt/Reactive-Resume/.env
 NODE_ENV=production
 PORT=3000
 # for use behind a reverse proxy, use your FQDN for PUBLIC_URL and STORAGE_URL
+# To avoid issues when behind a reverse proxy with downloading PDFs, ensure that the 
+# storage path is accessible via a subdomain (i.e storage.yourapp.xyz) or you set your 
+# reverse proxy to properly rewrite the subpath (/rxresume) to point to the service
+# running on port 9000 (minio).
 PUBLIC_URL=http://${LOCAL_IP}:3000
 STORAGE_URL=http://${LOCAL_IP}:9000/rxresume
 DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}?schema=public


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Adjusts the Reactive Resume install script with useful reverse proxy config information.

Based on my own experimentation/findings when configuring this behind a Caddy proxy. I had run into issues when trying to download a resume and was getting a 404 - some digging showed this was due to the minio storage endpoint not being exposed via the /rxresume path like the previous .env implied. Works fine on localhost, but if you simply change the STORAGE_URL to your FQDN then it breaks with no obvious cause.

## 🔗 Related Issue

None.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
