### PR TITLE
core: standardize exit codes and add mappings

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -119,12 +119,12 @@ update_os() {
   local tools_content
   tools_content=$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/tools.func) || {
     msg_error "Failed to download tools.func"
-    exit 6
+    exit 115
   }
   source /dev/stdin <<<"$tools_content"
   if ! declare -f fetch_and_deploy_gh_release >/dev/null 2>&1; then
     msg_error "tools.func loaded but incomplete — missing expected functions"
-    exit 6
+    exit 115
   fi
   msg_ok "Updated Container OS"
   post_progress_to_api

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -79,7 +79,7 @@ setting_up_container() {
   if [ "$(ip addr show | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | cut -d'/' -f1)" = "" ]; then
     echo 1>&2 -e "\n${CROSS}${RD} No Network After $RETRY_NUM Tries${CL}"
     echo -e "${NETWORK}Check Network Settings"
-    exit 1
+    exit 121
   fi
   msg_ok "Set up Container OS"
   msg_ok "Network Connected: ${BL}$(ip addr show | grep 'inet ' | awk '{print $2}' | cut -d'/' -f1 | tail -n1)${CL}"
@@ -99,7 +99,7 @@ network_check() {
       echo -e "${INFO}${RD}Expect Issues Without Internet${CL}"
     else
       echo -e "${NETWORK}Check Network Settings"
-      exit 1
+      exit 122
     fi
   fi
   RESOLVEDIP=$(getent hosts github.com | awk '{ print $1 }')

--- a/misc/api.func
+++ b/misc/api.func
@@ -132,6 +132,7 @@ detect_repo_source
 #   * MySQL/MariaDB errors (180-183)
 #   * MongoDB errors (190-193)
 #   * Proxmox custom codes (200-231)
+#   * Tools & Addon Scripts (232-238)
 #   * Node.js/npm errors (239, 243, 245-249)
 # - Returns description string for given exit code
 # ------------------------------------------------------------------------------
@@ -301,6 +302,15 @@ explain_exit_code() {
   224) echo "Proxmox: PBS storage is for backups only" ;;
   225) echo "Proxmox: No template available for OS/Version" ;;
   231) echo "Proxmox: LXC stack upgrade failed" ;;
+
+  # --- Tools & Addon Scripts (232-238) ---
+  232) echo "Tools: Wrong execution environment (run on PVE host, not inside LXC)" ;;
+  233) echo "Tools: Application not installed (update prerequisite missing)" ;;
+  234) echo "Tools: No LXC containers found or available" ;;
+  235) echo "Tools: Backup or restore operation failed" ;;
+  236) echo "Tools: Required hardware not detected" ;;
+  237) echo "Tools: Dependency package installation failed" ;;
+  238) echo "Tools: OS or distribution not supported for this addon" ;;
 
   # --- Node.js / npm / pnpm / yarn (239-249) ---
   239) echo "npm/Node.js: Unexpected runtime error or dependency failure" ;;

--- a/misc/api.func
+++ b/misc/api.func
@@ -301,6 +301,7 @@ explain_exit_code() {
   223) echo "Proxmox: Template not available after download" ;;
   224) echo "Proxmox: PBS storage is for backups only" ;;
   225) echo "Proxmox: No template available for OS/Version" ;;
+  226) echo "Proxmox: VM disk import or post-creation setup failed" ;;
   231) echo "Proxmox: LXC stack upgrade failed" ;;
 
   # --- Tools & Addon Scripts (232-238) ---

--- a/misc/api.func
+++ b/misc/api.func
@@ -124,6 +124,7 @@ detect_repo_source
 #   * Generic/Shell errors (1-3, 10, 124-132, 134, 137, 139, 141, 143-146)
 #   * curl/wget errors (4-8, 16, 18, 22-28, 30, 32-36, 39, 44-48, 51-52, 55-57, 59, 61, 63, 75, 78-79, 92, 95)
 #   * Package manager errors (APT, DPKG: 100-102, 255)
+#   * Script Validation & Setup (103-123)
 #   * BSD sysexits (64-78)
 #   * Systemd/Service errors (150-154)
 #   * Python/pip/uv errors (160-162)
@@ -188,6 +189,29 @@ explain_exit_code() {
   100) echo "APT: Package manager error (broken packages / dependency problems)" ;;
   101) echo "APT: Configuration error (bad sources.list, malformed config)" ;;
   102) echo "APT: Lock held by another process (dpkg/apt still running)" ;;
+
+  # --- Script Validation & Setup (103-123) ---
+  103) echo "Validation: Shell is not Bash" ;;
+  104) echo "Validation: Not running as root (or invoked via sudo)" ;;
+  105) echo "Validation: Proxmox VE version not supported" ;;
+  106) echo "Validation: Architecture not supported (ARM / PiMox)" ;;
+  107) echo "Validation: Kernel key parameters unreadable" ;;
+  108) echo "Validation: Kernel key limits exceeded" ;;
+  109) echo "Proxmox: No available container ID after max attempts" ;;
+  110) echo "Proxmox: Failed to apply default.vars" ;;
+  111) echo "Proxmox: App defaults file not available" ;;
+  112) echo "Proxmox: Invalid install menu option" ;;
+  113) echo "LXC: Under-provisioned — user aborted update" ;;
+  114) echo "LXC: Storage too low — user aborted update" ;;
+  115) echo "Download: install.func download failed or incomplete" ;;
+  116) echo "Proxmox: Default bridge vmbr0 not found" ;;
+  117) echo "LXC: Container did not reach running state" ;;
+  118) echo "LXC: No IP assigned to container after timeout" ;;
+  119) echo "Proxmox: No valid storage for rootdir content" ;;
+  120) echo "Proxmox: No valid storage for vztmpl content" ;;
+  121) echo "LXC: Container network not ready (no IP after retries)" ;;
+  122) echo "LXC: No internet connectivity — user declined to continue" ;;
+  123) echo "LXC: Local IP detection failed" ;;
 
   # --- BSD sysexits.h (64-78) ---
   64) echo "Usage error (wrong arguments)" ;;

--- a/misc/build.func
+++ b/misc/build.func
@@ -119,7 +119,7 @@ maxkeys_check() {
   # Exit if kernel parameters are unavailable
   if [[ "$per_user_maxkeys" -eq 0 || "$per_user_maxbytes" -eq 0 ]]; then
     msg_error "Unable to read kernel key parameters. Ensure proper permissions."
-    exit 1
+    exit 107
   fi
 
   # Fetch key usage for user ID 100000 (typical for containers)
@@ -148,7 +148,7 @@ maxkeys_check() {
   # Provide next steps if issues are detected
   if [[ "$failure" -eq 1 ]]; then
     msg_error "Kernel key limits exceeded - see suggestions above"
-    exit 1
+    exit 108
   fi
 
   # Silent success - only show errors if they exist
@@ -355,7 +355,7 @@ get_valid_container_id() {
     attempts=$((attempts + 1))
     if [[ $attempts -ge $max_attempts ]]; then
       msg_error "Could not find available container ID after $max_attempts attempts"
-      exit 1
+      exit 109
     fi
   done
 
@@ -2035,7 +2035,7 @@ advanced_settings() {
         else
           whiptail --msgbox "Default bridge 'vmbr0' not found!\n\nPlease configure a network bridge in Proxmox first." 10 58
           msg_error "Default bridge 'vmbr0' not found"
-          exit 1
+          exit 116
         fi
       else
         if result=$(whiptail --backtitle "Proxmox VE Helper Scripts [Step $STEP/$MAX_STEP]" \
@@ -3023,7 +3023,7 @@ install_script() {
     3 | mydefaults | MYDEFAULTS | userdefaults | USERDEFAULTS)
       default_var_settings || {
         msg_error "Failed to apply default.vars"
-        exit 1
+        exit 110
       }
       defaults_target="/usr/local/community-scripts/default.vars"
       break
@@ -3040,7 +3040,7 @@ install_script() {
         break
       else
         msg_error "No App Defaults available for ${APP}"
-        exit 1
+        exit 111
       fi
       ;;
     "$SETTINGS_OPTION" | settings | SETTINGS)
@@ -3051,7 +3051,7 @@ install_script() {
       ;;
     *)
       msg_error "Invalid option: $CHOICE"
-      exit 1
+      exit 112
       ;;
     esac
   done
@@ -3135,7 +3135,7 @@ check_container_resources() {
     read -r prompt </dev/tty
     if [[ ! ${prompt,,} =~ ^(yes)$ ]]; then
       msg_error "Aborted: under-provisioned LXC (${current_cpu} CPU/${current_ram}MB RAM < ${var_cpu} CPU/${var_ram}MB RAM)"
-      exit 1
+      exit 113
     fi
   else
     echo -e ""
@@ -3158,7 +3158,7 @@ check_container_storage() {
     read -r prompt </dev/tty
     if [[ ! ${prompt,,} =~ ^(y|yes)$ ]]; then
       msg_error "Aborted: storage too low (${usage}% used)"
-      exit 1
+      exit 114
     fi
   fi
 }
@@ -3446,7 +3446,7 @@ start() {
     3)
       clear
       exit_script
-      exit
+      exit 0
       ;;
     esac
     ensure_profile_loaded
@@ -3556,7 +3556,7 @@ build_container() {
   export FUNCTIONS_FILE_PATH="$(curl -fsSL "$_func_url")"
   if [[ -z "$FUNCTIONS_FILE_PATH" || ${#FUNCTIONS_FILE_PATH} -lt 100 ]]; then
     msg_error "Failed to download install functions from: $_func_url"
-    exit 1
+    exit 115
   fi
 
   # Core exports for install.func
@@ -3938,7 +3938,7 @@ EOF
       local ct_status
       ct_status=$(pct status "$CTID" 2>/dev/null || echo "unknown")
       msg_error "LXC Container did not reach running state (status: ${ct_status})"
-      exit 1
+      exit 117
     fi
   done
 
@@ -3967,7 +3967,7 @@ EOF
       echo "  • Verify static IP configuration (if using static IP)"
       echo "  • Check Proxmox firewall rules"
       echo "  • If using Tailscale: Disable MagicDNS temporarily"
-      exit 1
+      exit 118
     fi
 
     # Verify basic connectivity (ping test)
@@ -5014,11 +5014,11 @@ create_lxc_container() {
   # Storage capability check
   check_storage_support "rootdir" || {
     msg_error "No valid storage found for 'rootdir' [Container]"
-    exit 1
+    exit 119
   }
   check_storage_support "vztmpl" || {
     msg_error "No valid storage found for 'vztmpl' [Template]"
-    exit 1
+    exit 120
   }
 
   # Template storage selection
@@ -5296,7 +5296,7 @@ create_lxc_container() {
           }
         else
           msg_custom "🚫" "${YW}" "Installation cancelled"
-          exit 1
+          exit 0
         fi
       else
         msg_error "No ${PCT_OSTYPE} templates available"

--- a/misc/core.func
+++ b/misc/core.func
@@ -276,7 +276,7 @@ shell_check() {
     msg_error "Your default shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
     echo -e "\nExiting..."
     sleep 2
-    exit 1
+    exit 103
   fi
 }
 
@@ -293,7 +293,7 @@ root_check() {
     msg_error "Please run this script as root."
     echo -e "\nExiting..."
     sleep 2
-    exit 1
+    exit 104
   fi
 }
 
@@ -314,7 +314,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -325,7 +325,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not yet supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -333,7 +333,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.9 or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 # ------------------------------------------------------------------------------
@@ -348,7 +348,7 @@ arch_check() {
     msg_error "This script will not work with PiMox (ARM architecture detected)."
     msg_warn "Visit https://github.com/asylumexp/Proxmox for ARM64 support."
     sleep 2
-    exit 1
+    exit 106
   fi
 }
 

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -94,6 +94,29 @@ if ! declare -f explain_exit_code &>/dev/null; then
     100) echo "APT: Package manager error (broken packages / dependency problems)" ;;
     101) echo "APT: Configuration error (bad sources.list, malformed config)" ;;
     102) echo "APT: Lock held by another process (dpkg/apt still running)" ;;
+
+    # --- Script Validation & Setup (103-123) ---
+    103) echo "Validation: Shell is not Bash" ;;
+    104) echo "Validation: Not running as root (or invoked via sudo)" ;;
+    105) echo "Validation: Proxmox VE version not supported" ;;
+    106) echo "Validation: Architecture not supported (ARM / PiMox)" ;;
+    107) echo "Validation: Kernel key parameters unreadable" ;;
+    108) echo "Validation: Kernel key limits exceeded" ;;
+    109) echo "Proxmox: No available container ID after max attempts" ;;
+    110) echo "Proxmox: Failed to apply default.vars" ;;
+    111) echo "Proxmox: App defaults file not available" ;;
+    112) echo "Proxmox: Invalid install menu option" ;;
+    113) echo "LXC: Under-provisioned — user aborted update" ;;
+    114) echo "LXC: Storage too low — user aborted update" ;;
+    115) echo "Download: install.func download failed or incomplete" ;;
+    116) echo "Proxmox: Default bridge vmbr0 not found" ;;
+    117) echo "LXC: Container did not reach running state" ;;
+    118) echo "LXC: No IP assigned to container after timeout" ;;
+    119) echo "Proxmox: No valid storage for rootdir content" ;;
+    120) echo "Proxmox: No valid storage for vztmpl content" ;;
+    121) echo "LXC: Container network not ready (no IP after retries)" ;;
+    122) echo "LXC: No internet connectivity — user declined to continue" ;;
+    123) echo "LXC: Local IP detection failed" ;;
     124) echo "Command timed out (timeout command)" ;;
     125) echo "Command failed to start (Docker daemon or execution error)" ;;
     126) echo "Command invoked cannot execute (permission problem?)" ;;

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -178,6 +178,16 @@ if ! declare -f explain_exit_code &>/dev/null; then
     224) echo "Proxmox: PBS storage is for backups only" ;;
     225) echo "Proxmox: No template available for OS/Version" ;;
     231) echo "Proxmox: LXC stack upgrade failed" ;;
+
+    # --- Tools & Addon Scripts (232-238) ---
+    232) echo "Tools: Wrong execution environment (run on PVE host, not inside LXC)" ;;
+    233) echo "Tools: Application not installed (update prerequisite missing)" ;;
+    234) echo "Tools: No LXC containers found or available" ;;
+    235) echo "Tools: Backup or restore operation failed" ;;
+    236) echo "Tools: Required hardware not detected" ;;
+    237) echo "Tools: Dependency package installation failed" ;;
+    238) echo "Tools: OS or distribution not supported for this addon" ;;
+
     239) echo "npm/Node.js: Unexpected runtime error or dependency failure" ;;
     243) echo "Node.js: Out of memory (JavaScript heap out of memory)" ;;
     245) echo "Node.js: Invalid command-line option" ;;

--- a/misc/install.func
+++ b/misc/install.func
@@ -126,7 +126,7 @@ setting_up_container() {
   if [ "$(hostname -I)" = "" ]; then
     echo 1>&2 -e "\n${CROSS}${RD} No Network After $RETRY_NUM Tries${CL}"
     echo -e "${NETWORK}Check Network Settings"
-    exit 1
+    exit 121
   fi
   rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
   systemctl disable -q --now systemd-networkd-wait-online.service
@@ -177,7 +177,7 @@ network_check() {
       echo -e "${INFO}${RD}Expect Issues Without Internet${CL}"
     else
       echo -e "${NETWORK}Check Network Settings"
-      exit 1
+      exit 122
     fi
   fi
 
@@ -242,12 +242,12 @@ EOF
   local tools_content
   tools_content=$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/tools.func) || {
     msg_error "Failed to download tools.func"
-    exit 6
+    exit 115
   }
   source /dev/stdin <<<"$tools_content"
   if ! declare -f fetch_and_deploy_gh_release >/dev/null 2>&1; then
     msg_error "tools.func loaded but incomplete — missing expected functions"
-    exit 6
+    exit 115
   fi
 }
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -5142,7 +5142,7 @@ current_ip="$(get_current_ip)"
 
 if [[ -z "$current_ip" ]]; then
     echo "[ERROR] Could not detect local IP" >&2
-    exit 1
+    exit 123
 fi
 
 if [[ -f "$IP_FILE" ]]; then

--- a/misc/vm-core.func
+++ b/misc/vm-core.func
@@ -244,7 +244,7 @@ curl_handler() {
 
   if [[ -z "$url" ]]; then
     msg_error "no valid url or option entered for curl_handler"
-    exit 1
+    exit 64
   fi
 
   $STD msg_info "Fetching: $url"
@@ -273,7 +273,7 @@ curl_handler() {
         rm -f /tmp/curl_error.log
       fi
       __curl_err_handler "$exit_code" "$url" "$curl_stderr"
-      exit 1 # hard exit if exit_code is not 0
+      exit "$exit_code"
     fi
 
     $STD printf "\r\033[K${INFO}${YW}Retry $attempt/$max_retries in ${delay}s...${CL}" >&2
@@ -316,7 +316,7 @@ __curl_err_handler() {
   esac
 
   [[ -n "$curl_msg" ]] && printf "%s\n" "$curl_msg" >&2
-  exit 1
+  exit "$exit_code"
 }
 
 # ------------------------------------------------------------------------------
@@ -331,7 +331,7 @@ shell_check() {
     msg_error "Your default shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
     echo -e "\nExiting..."
     sleep 2
-    exit
+    exit 103
   fi
 }
 
@@ -552,7 +552,7 @@ check_root() {
     msg_error "Please run this script as root."
     echo -e "\nExiting..."
     sleep 2
-    exit
+    exit 104
   fi
 }
 
@@ -562,7 +562,7 @@ pve_check() {
     echo -e "Requires Proxmox Virtual Environment Version 8.1 - 8.4 or 9.0 - 9.1."
     echo -e "Exiting..."
     sleep 2
-    exit
+    exit 105
   fi
 }
 
@@ -572,21 +572,21 @@ arch_check() {
     echo -e "\n ${YWB}Visit https://github.com/asylumexp/Proxmox for ARM64 support. \n"
     echo -e "Exiting..."
     sleep 2
-    exit
+    exit 106
   fi
 }
 
 exit_script() {
   clear
   echo -e "\n${CROSS}${RD}User exited script${CL}\n"
-  exit
+  exit 0
 }
 
 check_hostname_conflict() {
   local hostname="$1"
   if qm list | awk '{print $2}' | grep -qx "$hostname"; then
     msg_error "Hostname $hostname already in use by another VM."
-    exit 1
+    exit 206
   fi
 }
 

--- a/tools/addon/add-netbird-lxc.sh
+++ b/tools/addon/add-netbird-lxc.sh
@@ -73,7 +73,7 @@ fi
 DISTRO=$(pct exec "$CTID" -- cat /etc/os-release | grep -w "ID" | cut -d'=' -f2 | tr -d '"')
 if [[ "$DISTRO" != "debian" && "$DISTRO" != "ubuntu" ]]; then
   msg "\e[1;31m Error: This script only supports Debian or Ubuntu LXC containers. Detected: $DISTRO. Aborting...\e[0m"
-  exit 1
+  exit 238
 fi
 
 CTID_CONFIG_PATH=/etc/pve/lxc/${CTID}.conf

--- a/tools/addon/add-tailscale-lxc.sh
+++ b/tools/addon/add-tailscale-lxc.sh
@@ -32,7 +32,7 @@ header_info
 
 if ! command -v pveversion &>/dev/null; then
   msg_error "This script must be run on the Proxmox VE host (not inside an LXC container)"
-  exit 1
+  exit 232
 fi
 
 while true; do
@@ -64,7 +64,7 @@ while [[ -z "${CTID}" ]]; do
   CTID=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Containers on $NODE" --radiolist \
     "\nSelect a container to add Tailscale to:\n" \
     16 $((MSG_MAX_LENGTH + 23)) 6 \
-    "${CTID_MENU[@]}" 3>&1 1>&2 2>&3) || exit 1
+    "${CTID_MENU[@]}" 3>&1 1>&2 2>&3) || exit 0
 done
 
 CTID_CONFIG_PATH="/etc/pve/lxc/${CTID}.conf"

--- a/tools/addon/adguardhome-sync.sh
+++ b/tools/addon/adguardhome-sync.sh
@@ -69,7 +69,7 @@ elif [[ -f "/etc/debian_version" ]]; then
   SERVICE_PATH="/etc/systemd/system/adguardhome-sync.service"
 else
   msg_error "Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -312,7 +312,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/arcane.sh
+++ b/tools/addon/arcane.sh
@@ -87,11 +87,11 @@ function update() {
 function check_docker() {
   if ! command -v docker &>/dev/null; then
     msg_error "Docker is not installed. This script requires an existing Docker LXC. Exiting."
-    exit 1
+    exit 10
   fi
   if ! docker compose version &>/dev/null; then
     msg_error "Docker Compose plugin is not available. Please install it before running this script. Exiting."
-    exit 1
+    exit 10
   fi
   msg_ok "Docker $(docker --version | cut -d' ' -f3 | tr -d ',') and Docker Compose are available"
 }
@@ -171,7 +171,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/coolify.sh
+++ b/tools/addon/coolify.sh
@@ -93,7 +93,7 @@ function check_or_install_docker() {
       msg_ok "Docker Compose is available"
     else
       msg_error "Docker Compose plugin is not available. Please install it."
-      exit 1
+      exit 10
     fi
     return
   fi
@@ -103,7 +103,7 @@ function check_or_install_docker() {
   read -r install_docker_prompt
   if [[ ! "${install_docker_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_error "Docker is required for ${APP}. Exiting."
-    exit 1
+    exit 10
   fi
 
   msg_info "Installing Docker"
@@ -165,7 +165,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/copyparty.sh
+++ b/tools/addon/copyparty.sh
@@ -49,7 +49,7 @@ elif grep -qE 'ID=debian|ID=ubuntu' /etc/os-release; then
   SERVICE_PATH="/etc/systemd/system/copyparty.service"
 else
   msg_error "Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -318,7 +318,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/cronmaster.sh
+++ b/tools/addon/cronmaster.sh
@@ -51,7 +51,7 @@ EOF
 # ==============================================================================
 if ! grep -qE 'ID=debian|ID=ubuntu' /etc/os-release 2>/dev/null; then
   echo -e "${CROSS} Unsupported OS detected. This script only supports Debian and Ubuntu."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -183,7 +183,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/dockge.sh
+++ b/tools/addon/dockge.sh
@@ -99,7 +99,7 @@ function check_or_install_docker() {
       msg_ok "Docker Compose is available"
     else
       msg_error "Docker Compose plugin is not available. Please install it."
-      exit 1
+      exit 10
     fi
     return
   fi
@@ -109,7 +109,7 @@ function check_or_install_docker() {
   read -r install_docker_prompt
   if [[ ! "${install_docker_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_error "Docker is required for ${APP}. Exiting."
-    exit 1
+    exit 10
   fi
 
   msg_info "Installing Docker"
@@ -160,7 +160,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/dokploy.sh
+++ b/tools/addon/dokploy.sh
@@ -92,7 +92,7 @@ function check_or_install_docker() {
       msg_ok "Docker Compose is available"
     else
       msg_error "Docker Compose plugin is not available. Please install it."
-      exit 1
+      exit 10
     fi
     return
   fi
@@ -102,7 +102,7 @@ function check_or_install_docker() {
   read -r install_docker_prompt
   if [[ ! "${install_docker_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_error "Docker is required for ${APP}. Exiting."
-    exit 1
+    exit 10
   fi
 
   msg_info "Installing Docker"
@@ -163,7 +163,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -54,7 +54,7 @@ elif [[ -f "/etc/debian_version" ]]; then
   PKG_MANAGER="apt-get install -y"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 header_info

--- a/tools/addon/filebrowser.sh
+++ b/tools/addon/filebrowser.sh
@@ -52,7 +52,7 @@ elif [[ -f "/etc/debian_version" ]]; then
   PKG_MANAGER="apt-get install -y"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 header_info

--- a/tools/addon/glances.sh
+++ b/tools/addon/glances.sh
@@ -93,7 +93,7 @@ EOF
 update_glances_debian() {
   if [[ ! -d /opt/glances/.venv ]]; then
     msg_error "$APP is not installed"
-    exit 1
+    exit 233
   fi
   msg_info "Updating $APP"
   cd /opt/glances
@@ -160,7 +160,7 @@ EOF
 update_glances_alpine() {
   if [[ ! -d /opt/glances/.venv ]]; then
     msg_error "$APP is not installed"
-    exit 1
+    exit 233
   fi
   msg_info "Updating $APP"
   cd /opt/glances

--- a/tools/addon/immich-public-proxy.sh
+++ b/tools/addon/immich-public-proxy.sh
@@ -52,13 +52,13 @@ EOF
 # ==============================================================================
 if [[ -f "/etc/alpine-release" ]]; then
   msg_error "Alpine is not supported for ${APP}. Use Debian."
-  exit 1
+  exit 238
 elif [[ -f "/etc/debian_version" ]]; then
   OS="Debian"
   SERVICE_PATH="/etc/systemd/system/immich-proxy.service"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -231,7 +231,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/jellystat.sh
+++ b/tools/addon/jellystat.sh
@@ -52,13 +52,13 @@ EOF
 # ==============================================================================
 if [[ -f "/etc/alpine-release" ]]; then
   msg_error "Alpine is not supported for ${APP}. Use Debian/Ubuntu."
-  exit 1
+  exit 238
 elif [[ -f "/etc/debian_version" ]]; then
   OS="Debian"
   SERVICE_PATH="/etc/systemd/system/jellystat.service"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -326,7 +326,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/komodo.sh
+++ b/tools/addon/komodo.sh
@@ -37,7 +37,7 @@ function find_compose_file() {
   COMPOSE_FILE=$(find "$INSTALL_PATH" -maxdepth 1 -type f -name '*.compose.yaml' ! -name 'compose.env' | head -n1)
   if [[ -z "${COMPOSE_FILE:-}" ]]; then
     msg_error "No valid compose file found in ${INSTALL_PATH}!"
-    exit 1
+    exit 233
   fi
   COMPOSE_BASENAME=$(basename "$COMPOSE_FILE")
 }
@@ -48,7 +48,7 @@ function check_legacy_db() {
     echo -e "${YW}This configuration is no longer supported since Komodo v1.18.0.${CL}"
     echo -e "${YW}Please follow the migration guide:${CL}"
     echo -e "${BGN}https://github.com/community-scripts/ProxmoxVE/discussions/5689${CL}\n"
-    exit 1
+    exit 238
   fi
 }
 
@@ -79,14 +79,14 @@ function update() {
   BACKUP_FILE="${INSTALL_PATH}/${COMPOSE_BASENAME}.bak_$(date +%Y%m%d_%H%M%S)"
   cp "$COMPOSE_FILE" "$BACKUP_FILE" || {
     msg_error "Failed to create backup of ${COMPOSE_BASENAME}!"
-    exit 1
+    exit 235
   }
 
   GITHUB_URL="https://raw.githubusercontent.com/moghtech/komodo/main/compose/${COMPOSE_BASENAME}"
   if ! curl -fsSL "$GITHUB_URL" -o "$COMPOSE_FILE"; then
     msg_error "Failed to download ${COMPOSE_BASENAME} from GitHub!"
     mv "$BACKUP_FILE" "$COMPOSE_FILE"
-    exit 1
+    exit 115
   fi
 
   if ! grep -qxF 'COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups' "$COMPOSE_ENV"; then
@@ -129,7 +129,7 @@ function check_or_install_docker() {
       msg_ok "Docker Compose is available"
     else
       msg_error "Docker Compose plugin is not available. Please install it."
-      exit 1
+      exit 10
     fi
     return
   fi
@@ -139,7 +139,7 @@ function check_or_install_docker() {
   read -r install_docker_prompt
   if [[ ! "${install_docker_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_error "Docker is required for ${APP}. Exiting."
-    exit 1
+    exit 10
   fi
 
   msg_info "Installing Docker"
@@ -239,7 +239,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/netdata.sh
+++ b/tools/addon/netdata.sh
@@ -58,7 +58,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -69,7 +69,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not yet supported."
       msg_error "Supported: Proxmox VE version 9.0–9.1.x"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -77,19 +77,19 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.9 or 9.0–9.1.x"
-  exit 1
+  exit 105
 }
 
 detect_codename() {
   source /etc/os-release
   if [[ "$ID" != "debian" ]]; then
     msg_error "Unsupported base OS: $ID (only Proxmox VE / Debian supported)."
-    exit 1
+    exit 238
   fi
   CODENAME="${VERSION_CODENAME:-}"
   if [[ -z "$CODENAME" ]]; then
     msg_error "Could not detect Debian codename."
-    exit 1
+    exit 71
   fi
   echo "$CODENAME"
 }
@@ -124,7 +124,7 @@ install() {
   PKG=$(get_latest_repo_pkg "$REPO_URL")
   if [[ -z "$PKG" ]]; then
     msg_error "Could not find netdata-repo package for Debian $CODENAME"
-    exit 1
+    exit 237
   fi
   curl -fsSL "${REPO_URL}${PKG}" -o "$PKG"
   $STD dpkg -i "$PKG"

--- a/tools/addon/nextcloud-exporter.sh
+++ b/tools/addon/nextcloud-exporter.sh
@@ -36,7 +36,7 @@ SERVICE_PATH="/etc/systemd/system/nextcloud-exporter.service"
 # ==============================================================================
 if ! grep -qE 'ID=debian|ID=ubuntu' /etc/os-release 2>/dev/null; then
   echo -e "${CROSS} Unsupported OS detected. This script only supports Debian and Ubuntu."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -170,7 +170,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "Nextcloud-Exporter is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/phpmyadmin.sh
+++ b/tools/addon/phpmyadmin.sh
@@ -52,7 +52,7 @@ elif [[ -f "/etc/debian_version" ]]; then
   INSTALL_DIR="$INSTALL_DIR_DEBIAN"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 header_info
@@ -72,7 +72,7 @@ function check_internet() {
     msg_ok "Internet connectivity OK"
   else
     msg_error "Internet connectivity or GitHub unreachable (Status $HTTP_CODE). Exiting."
-    exit 1
+    exit 115
   fi
 }
 
@@ -105,7 +105,7 @@ function install_php_and_modules() {
       msg_info "Installing missing PHP packages: ${MISSING_PACKAGES[*]}"
       if ! apt-get update &>/dev/null || ! apt-get install -y "${MISSING_PACKAGES[@]}" &>/dev/null; then
         msg_error "Failed to install required PHP modules. Exiting."
-        exit 1
+        exit 237
       fi
       msg_ok "Installed missing PHP packages"
     else
@@ -132,7 +132,7 @@ function install_phpmyadmin() {
   msg_info "Downloading ${TARBALL_URL}"
   if ! curl -fsSL "$TARBALL_URL" -o /tmp/phpmyadmin.tar.gz; then
     msg_error "Download failed: $TARBALL_URL"
-    exit 1
+    exit 115
   fi
 
   mkdir -p "$INSTALL_DIR"
@@ -188,7 +188,7 @@ EOF
       msg_ok "Started PHP-FPM service: $PHP_FPM_SERVICE"
     else
       msg_error "Failed to start PHP-FPM service: $PHP_FPM_SERVICE"
-      exit 1
+      exit 150
     fi
 
     $STD rc-service lighttpd start
@@ -237,7 +237,7 @@ function update_phpmyadmin() {
 
   if ! curl -fsSL "$TARBALL_URL" -o /tmp/phpmyadmin.tar.gz; then
     msg_error "Download failed: $TARBALL_URL"
-    exit 1
+    exit 115
   fi
 
   BACKUP_DIR="/tmp/phpmyadmin-backup-$(date +%Y%m%d-%H%M%S)"
@@ -280,7 +280,7 @@ if is_phpmyadmin_installed; then
     ;;
   *)
     echo -e "${YW}⚠️ Invalid input. Exiting.${CL}"
-    exit 1
+    exit 112
     ;;
   esac
 else

--- a/tools/addon/pihole-exporter.sh
+++ b/tools/addon/pihole-exporter.sh
@@ -41,7 +41,7 @@ elif grep -qE 'ID=debian|ID=ubuntu' /etc/os-release; then
   SERVICE_PATH="/etc/systemd/system/pihole-exporter.service"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -207,7 +207,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "Pihole-Exporter is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/prometheus-paperless-ngx-exporter.sh
+++ b/tools/addon/prometheus-paperless-ngx-exporter.sh
@@ -32,7 +32,7 @@ AUTH_TOKEN_FILE="/etc/prometheus-paperless-ngx-exporter/paperless_auth_token_fil
 # ==============================================================================
 if ! grep -qE 'ID=debian|ID=ubuntu' /etc/os-release 2>/dev/null; then
   echo -e "${CROSS} Unsupported OS detected. This script only supports Debian and Ubuntu."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -144,7 +144,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "Prometheus-Paperless-NGX-Exporter is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/qbittorrent-exporter.sh
+++ b/tools/addon/qbittorrent-exporter.sh
@@ -41,7 +41,7 @@ elif grep -qE 'ID=debian|ID=ubuntu' /etc/os-release; then
   SERVICE_PATH="/etc/systemd/system/qbittorrent-exporter.service"
 else
   echo -e "${CROSS} Unsupported OS detected. Exiting."
-  exit 1
+  exit 238
 fi
 
 # ==============================================================================
@@ -200,7 +200,7 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "qBittorrent-Exporter is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi

--- a/tools/addon/runtipi.sh
+++ b/tools/addon/runtipi.sh
@@ -62,7 +62,7 @@ function check_or_install_docker() {
       msg_ok "Docker Compose is available"
     else
       msg_error "Docker Compose plugin is not available. Please install it."
-      exit 1
+      exit 10
     fi
     return
   fi
@@ -72,7 +72,7 @@ function check_or_install_docker() {
   read -r install_docker_prompt
   if [[ ! "${install_docker_prompt,,}" =~ ^(y|yes)$ ]]; then
     msg_error "Docker is required for ${APP}. Exiting."
-    exit 1
+    exit 10
   fi
 
   msg_info "Installing Docker"
@@ -168,14 +168,14 @@ if [[ "${type:-}" == "update" ]]; then
     update
   else
     msg_error "${APP} is not installed. Nothing to update."
-    exit 1
+    exit 233
   fi
   exit 0
 fi
 
 if [[ -f /etc/alpine-release ]]; then
   msg_error "${APP} does not support Alpine Linux. Please use a Debian or Ubuntu based LXC."
-  exit 1
+  exit 238
 fi
 
 header_info

--- a/tools/pve/container-restore-from-backup.sh
+++ b/tools/pve/container-restore-from-backup.sh
@@ -62,7 +62,7 @@ function msg_error() {
 }
 if [ -z "$(ls -A /var/lib/docker/volumes/hass_config/_data/backups/)" ]; then
   msg_error "No backups found! \n"
-  exit 1
+  exit 235
 fi
 DIR=/var/lib/docker/volumes/hass_config/_data/restore
 if [ -d "$DIR" ]; then

--- a/tools/pve/core-restore-from-backup.sh
+++ b/tools/pve/core-restore-from-backup.sh
@@ -62,7 +62,7 @@ function msg_error() {
 }
 if [ -z "$(ls -A /root/.homeassistant/backups/)" ]; then
   msg_error "No backups found! \n"
-  exit 1
+  exit 235
 fi
 DIR=/root/.homeassistant/restore
 if [ -d "$DIR" ]; then

--- a/tools/pve/fstrim.sh
+++ b/tools/pve/fstrim.sh
@@ -39,7 +39,7 @@ ROOT_FS=$(df -Th "/" | awk 'NR==2 {print $2}')
 if [ "$ROOT_FS" != "ext4" ]; then
   whiptail --backtitle "Proxmox VE Helper Scripts" \
     --title "Warning" \
-    --yesno "Root filesystem is not ext4 ($ROOT_FS).\nContinue anyway?" 12 80 || exit 1
+    --yesno "Root filesystem is not ext4 ($ROOT_FS).\nContinue anyway?" 12 80 || exit 0
 fi
 
 NODE=$(hostname)

--- a/tools/pve/kernel-clean.sh
+++ b/tools/pve/kernel-clean.sh
@@ -57,7 +57,7 @@ done
 
 if [ ${#kernels_to_remove[@]} -eq 0 ]; then
   echo -e "${RD}No valid selection made. Exiting.${CL}"
-  exit 1
+  exit 0
 fi
 
 # Confirm removal
@@ -66,7 +66,7 @@ printf "%s\n" "${kernels_to_remove[@]}"
 read -rp "Proceed with removal? (y/n): " confirm
 if [[ "$confirm" != "y" ]]; then
   echo -e "${RD}Aborted.${CL}"
-  exit 1
+  exit 0
 fi
 
 # Remove kernels

--- a/tools/pve/lxc-delete.sh
+++ b/tools/pve/lxc-delete.sh
@@ -51,7 +51,7 @@ containers=$(pct list | tail -n +2 | awk '{print $0 " " $4}')
 
 if [ -z "$containers" ]; then
   whiptail --title "LXC Container Delete" --msgbox "No LXC containers available!" 10 60
-  exit 1
+  exit 234
 fi
 
 menu_items=("ALL" "Delete ALL containers" "OFF") # Add as first option
@@ -72,7 +72,7 @@ CHOICES=$(whiptail --title "LXC Container Delete" \
 if [ -z "$CHOICES" ]; then
   whiptail --title "LXC Container Delete" \
     --msgbox "No containers selected!" 10 60
-  exit 1
+  exit 0
 fi
 
 read -p "Delete containers manually or automatically? (Default: manual) m/a: " DELETE_MODE

--- a/tools/pve/nic-offloading-fix.sh
+++ b/tools/pve/nic-offloading-fix.sh
@@ -47,7 +47,7 @@ function msg_warn() { echo -e "${WARN} ${YWB}${1}"; }
 # Check for root privileges
 if [ "$(id -u)" -ne 0 ]; then
   msg_error "Error: This script must be run as root."
-  exit 1
+  exit 104
 fi
 
 if ! command -v ethtool >/dev/null 2>&1; then
@@ -55,7 +55,7 @@ if ! command -v ethtool >/dev/null 2>&1; then
   apt-get update &>/dev/null
   apt-get install -y ethtool &>/dev/null || {
     msg_error "Failed to install ethtool. Exiting."
-    exit 1
+    exit 237
   }
   msg_ok "ethtool installed successfully"
 fi
@@ -86,7 +86,7 @@ done
 if [ ${#INTERFACES[@]} -eq 0 ]; then
   whiptail --title "Error" --msgbox "No Intel e1000e or e1000 network interfaces found!" 10 60
   msg_error "No Intel e1000e or e1000 network interfaces found! Exiting."
-  exit 1
+  exit 236
 fi
 
 msg_ok "Found ${BL}$COUNT${GN} Intel e1000e/e1000 interfaces"

--- a/tools/pve/pbs_microcode.sh
+++ b/tools/pve/pbs_microcode.sh
@@ -41,7 +41,7 @@ header_info
 virt=$(systemd-detect-virt)
 if [ "$virt" != "none" ]; then
   msg_error "This script must be run on bare metal. Detected virtual environment: $virt"
-  exit 1
+  exit 232
 fi
 
 # Attempt to obtain the current loaded microcode revision

--- a/tools/pve/post-pbs-install.sh
+++ b/tools/pve/post-pbs-install.sh
@@ -83,7 +83,7 @@ main() {
 
   if command -v pveversion >/dev/null 2>&1; then
     echo -e "\n🛑  PVE Detected, Wrong Script!\n"
-    exit 1
+    exit 232
   fi
 
   local CODENAME
@@ -95,7 +95,7 @@ main() {
   *)
     msg_error "Unsupported Debian codename: $CODENAME"
     echo -e "Supported: bookworm (PBS 3.x) and trixie (PBS 4.x)"
-    exit 1
+    exit 105
     ;;
   esac
 }

--- a/tools/pve/post-pmg-install.sh
+++ b/tools/pve/post-pmg-install.sh
@@ -49,7 +49,7 @@ declare -f init_tool_telemetry &>/dev/null && init_tool_telemetry "post-pmg-inst
 
 if ! grep -q "Proxmox Mail Gateway" /etc/issue 2>/dev/null; then
   msg_error "This script is only intended for Proxmox Mail Gateway"
-  exit 1
+  exit 232
 fi
 
 repo_state() {

--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -88,19 +88,19 @@ main() {
   if [[ "$PVE_MAJOR" == "8" ]]; then
     if ((PVE_MINOR < 0 || PVE_MINOR > 9)); then
       msg_error "Unsupported Proxmox 8 version"
-      exit 1
+      exit 105
     fi
     start_routines_8
   elif [[ "$PVE_MAJOR" == "9" ]]; then
     if ((PVE_MINOR < 0 || PVE_MINOR > 1)); then
       msg_error "Only Proxmox 9.0-9.1.x is currently supported"
-      exit 1
+      exit 105
     fi
     start_routines_9
   else
     msg_error "Unsupported Proxmox VE major version: $PVE_MAJOR"
     echo -e "Supported: 8.0–8.9.x and 9.0–9.1.x"
-    exit 1
+    exit 105
   fi
 }
 

--- a/tools/pve/pve-privilege-converter.sh
+++ b/tools/pve/pve-privilege-converter.sh
@@ -25,7 +25,7 @@ header_info "$APP"
 check_root() {
   if [[ $EUID -ne 0 ]]; then
     msg_error "Script must be run as root"
-    exit 1
+    exit 104
   fi
 }
 
@@ -63,7 +63,7 @@ select_container() {
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
     msg_error "No containers found"
-    exit 1
+    exit 234
   fi
 
   PS3="Enter number of container to convert: "
@@ -101,7 +101,7 @@ backup_container() {
   if [ -z "$BACKUP_PATH" ] || ! grep -q "Backup job finished successfully" "$vzdump_output"; then
     rm "$vzdump_output"
     msg_error "Backup failed"
-    exit 1
+    exit 235
   fi
   rm "$vzdump_output"
   msg_ok "Backup complete: $BACKUP_PATH"
@@ -126,7 +126,7 @@ perform_conversion() {
     msg_ok "Conversion successful"
   else
     msg_error "Conversion failed"
-    exit 1
+    exit 235
   fi
 }
 

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -140,7 +140,7 @@ function backup_container() {
     msg_ok "Backup created"
   else
     msg_error "Backup failed for container $1"
-    exit 1
+    exit 235
   fi
 }
 
@@ -183,7 +183,7 @@ containers=$(pct list | tail -n +2 | awk '{print $0 " " $4}')
 
 if [ -z "$containers" ]; then
   whiptail --title "LXC Container Update" --msgbox "No LXC containers available!" 10 60
-  exit 1
+  exit 234
 fi
 
 menu_items=()
@@ -242,7 +242,7 @@ if [[ -n "$var_container" ]]; then
 
   if [[ -z "$CHOICE" ]]; then
     msg_error "No containers matched the selection criteria: $var_container ${var_tags:-community-script|proxmox-helper-scripts}"
-    exit 1
+    exit 234
   fi
   msg_ok "Selected containers: $CHOICE"
 else
@@ -253,7 +253,7 @@ else
   if [ -z "$CHOICE" ]; then
     whiptail --title "LXC Container Update" \
       --msgbox "No containers selected!" 10 60
-    exit 1
+    exit 0
   fi
 fi
 
@@ -284,7 +284,7 @@ if [ "$BACKUP_CHOICE" == "yes" ]; then
 
   if [ -z "$STORAGES" ]; then
     msg_error "No storage with 'backup' support found!"
-    exit 1
+    exit 119
   fi
 
   # Determine storage based on var_backup_storage
@@ -296,7 +296,7 @@ if [ "$BACKUP_CHOICE" == "yes" ]; then
     else
       msg_error "Specified backup storage '$var_backup_storage' not found or doesn't support backups!"
       msg_info "Available storages: $(echo $STORAGES | tr '\n' ' ')"
-      exit 1
+      exit 119
     fi
   else
     MENU_ITEMS=()
@@ -308,7 +308,7 @@ if [ "$BACKUP_CHOICE" == "yes" ]; then
 
     if [ -z "$STORAGE_CHOICE" ]; then
       msg_error "No storage selected!"
-      exit 1
+      exit 0
     fi
   fi
 fi
@@ -436,11 +436,11 @@ for container in $CHOICE; do
       msg_ok "Restored LXC from backup"
     else
       msg_error "Restored LXC from backup failed"
-      exit 1
+      exit 235
     fi
   else
     msg_error "Update failed for container $container. Exiting"
-    exit 1
+    exit "$exit_code"
   fi
 done
 

--- a/vm/archlinux-vm.sh
+++ b/vm/archlinux-vm.sh
@@ -158,7 +158,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -169,7 +169,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -177,7 +177,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/archlinux-vm.sh
+++ b/vm/archlinux-vm.sh
@@ -513,7 +513,7 @@ DISK_REF_IMPORTED="$(printf '%s\n' "$IMPORT_OUT" | sed -n "s/.*successfully impo
 [[ -z "$DISK_REF_IMPORTED" ]] && {
   msg_error "Unable to determine imported disk reference."
   echo "$IMPORT_OUT"
-  exit 1
+  exit 226
 }
 msg_ok "Imported disk (${CL}${BL}${DISK_REF_IMPORTED}${CL})"
 

--- a/vm/debian-13-vm.sh
+++ b/vm/debian-13-vm.sh
@@ -158,7 +158,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -169,7 +169,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -177,7 +177,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/debian-vm.sh
+++ b/vm/debian-vm.sh
@@ -158,7 +158,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -169,7 +169,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -177,7 +177,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/docker-vm.sh
+++ b/vm/docker-vm.sh
@@ -638,7 +638,7 @@ DISK_REF_IMPORTED="$(printf '%s\n' "$IMPORT_OUT" | sed -n "s/.*successfully impo
 [[ -z "$DISK_REF_IMPORTED" ]] && {
   msg_error "Unable to determine imported disk reference."
   echo "$IMPORT_OUT"
-  exit 1
+  exit 226
 }
 
 msg_ok "Imported disk (${CL}${BL}${DISK_REF_IMPORTED}${CL})"

--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -163,7 +163,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -174,7 +174,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -182,7 +182,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -221,7 +221,7 @@ function ensure_pv() {
     if ! apt-get update -qq &>/dev/null || ! apt-get install -y pv &>/dev/null; then
       msg_error "Failed to install pv automatically."
       echo -e "\nPlease run manually on the Proxmox host:\n  apt install pv\n"
-      exit 1
+      exit 237
     fi
     msg_ok "Installed pv"
   fi
@@ -249,14 +249,14 @@ function download_and_validate_xz() {
   if ! curl -fSL -o "$file" "$url"; then
     msg_error "Download failed: $url"
     rm -f "$file"
-    exit 1
+    exit 115
   fi
 
   # Validate again
   if ! xz -t "$file" &>/dev/null; then
     msg_error "Downloaded file $(basename "$file") is corrupted. Please try again later."
     rm -f "$file"
-    exit 1
+    exit 115
   fi
   msg_ok "Downloaded and validated $(basename "$file")"
 }
@@ -272,7 +272,7 @@ function extract_xz_with_pv() {
   if ! xz -dc "$file" | pv -N "Extracting" >"$target"; then
     msg_error "Failed to extract $file"
     rm -f "$target"
-    exit 1
+    exit 115
   fi
   msg_ok "Decompressed to $target"
 }
@@ -592,7 +592,7 @@ DISK_REF="$(printf '%s\n' "$IMPORT_OUT" | sed -n "s/.*successfully imported disk
 [[ -z "$DISK_REF" ]] && {
   msg_error "Unable to determine imported disk reference."
   echo "$IMPORT_OUT"
-  exit 1
+  exit 226
 }
 msg_ok "Imported disk (${CL}${BL}${DISK_REF}${CL})"
 

--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -159,7 +159,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -170,7 +170,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -178,7 +178,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/nextcloud-vm.sh
+++ b/vm/nextcloud-vm.sh
@@ -158,7 +158,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -169,7 +169,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -177,7 +177,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -226,7 +226,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -237,7 +237,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -245,7 +245,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -556,7 +556,7 @@ fi
 if [[ -z "$DISK_REF" ]]; then
   msg_error "Unable to determine imported disk reference."
   echo "$IMPORT_OUT"
-  exit 1
+  exit 226
 fi
 
 qm set $VMID \
@@ -635,7 +635,7 @@ if qm status "$VMID" | grep -q "running"; then
   msg_ok "Network interfaces configured in OpenWrt"
 else
   msg_error "VM is not running"
-  exit 1
+  exit 226
 fi
 
 msg_info "Waiting for OpenWrt to shut down..."

--- a/vm/opnsense-vm.sh
+++ b/vm/opnsense-vm.sh
@@ -210,7 +210,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -221,7 +221,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -229,7 +229,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/opnsense-vm.sh
+++ b/vm/opnsense-vm.sh
@@ -616,7 +616,7 @@ for ver in $RELEASE_LIST; do
 done
 if [ -z "$URL" ]; then
   msg_error "Could not find generic FreeBSD amd64 qcow2 image (non-UFS/ZFS)."
-  exit 1
+  exit 115
 fi
 msg_ok "Download URL: ${CL}${BL}${URL}${CL}"
 
@@ -626,7 +626,7 @@ if ! check_disk_space "$TEMP_DIR" 20; then
   msg_error "Insufficient disk space in temporary directory ($TEMP_DIR)."
   msg_error "Available: ${AVAILABLE_GB}, Required: ~20GB for FreeBSD image decompression."
   msg_error "Please free up space or ensure /tmp has sufficient storage."
-  exit 1
+  exit 214
 fi
 
 msg_info "Downloading FreeBSD Image"
@@ -639,7 +639,7 @@ if ! check_disk_space "$TEMP_DIR" 15; then
   AVAILABLE_GB=$(df -h "$TEMP_DIR" | awk 'NR==2 {print $4}')
   msg_error "Insufficient disk space for decompression."
   msg_error "Available: ${AVAILABLE_GB}, Required: ~15GB for decompressed image."
-  exit 1
+  exit 214
 fi
 
 msg_info "Decompressing FreeBSD Image (this may take a few minutes)"
@@ -648,7 +648,7 @@ if ! unxz -cv $(basename $URL) >${FILE}; then
   msg_error "Failed to decompress FreeBSD image."
   msg_error "This is usually caused by insufficient disk space."
   df -h "$TEMP_DIR"
-  exit 1
+  exit 115
 fi
 
 # Remove the compressed file to save space

--- a/vm/owncloud-vm.sh
+++ b/vm/owncloud-vm.sh
@@ -159,7 +159,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -170,7 +170,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -178,7 +178,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/pimox-haos-vm.sh
+++ b/vm/pimox-haos-vm.sh
@@ -167,7 +167,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -178,7 +178,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -186,7 +186,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/truenas-vm.sh
+++ b/vm/truenas-vm.sh
@@ -192,7 +192,7 @@ function pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -202,14 +202,14 @@ function pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not yet supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
 
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/truenas-vm.sh
+++ b/vm/truenas-vm.sh
@@ -305,7 +305,7 @@ function advanced_settings() {
 
   if [ $ISO_COUNT -eq 0 ]; then
     echo "No ISOs found."
-    exit 1
+    exit 115
   fi
 
   # Identify the index of the last stable release
@@ -529,7 +529,7 @@ if [ -z "${SELECTED_ISO:-}" ]; then
 
   if [ -z "$SELECTED_ISO" ]; then
     msg_error "Could not find a stable ISO for fallback."
-    exit 1
+    exit 115
   fi
 fi
 

--- a/vm/ubuntu2204-vm.sh
+++ b/vm/ubuntu2204-vm.sh
@@ -155,7 +155,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -166,7 +166,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -174,7 +174,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/ubuntu2404-vm.sh
+++ b/vm/ubuntu2404-vm.sh
@@ -158,7 +158,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -169,7 +169,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -177,7 +177,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/ubuntu2504-vm.sh
+++ b/vm/ubuntu2504-vm.sh
@@ -157,7 +157,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -168,7 +168,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -176,7 +176,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -157,7 +157,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 9)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 8.0 – 8.9"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -168,7 +168,7 @@ pve_check() {
     if ((MINOR < 0 || MINOR > 1)); then
       msg_error "This version of Proxmox VE is not supported."
       msg_error "Supported: Proxmox VE version 9.0 – 9.1"
-      exit 1
+      exit 105
     fi
     return 0
   fi
@@ -176,7 +176,7 @@ pve_check() {
   # All other unsupported versions
   msg_error "This version of Proxmox VE is not supported."
   msg_error "Supported versions: Proxmox VE 8.0 – 8.x or 9.0 – 9.1"
-  exit 1
+  exit 105
 }
 
 function arch_check() {

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -215,7 +215,7 @@ function ensure_pv() {
     if ! apt-get update -qq &>/dev/null || ! apt-get install -y pv &>/dev/null; then
       msg_error "Failed to install pv automatically."
       echo -e "\nPlease run manually on the Proxmox host:\n  apt install pv\n"
-      exit 1
+      exit 237
     fi
     msg_ok "Installed pv"
   fi
@@ -243,14 +243,14 @@ function download_and_validate_xz() {
   if ! curl -fSL -o "$file" "$url"; then
     msg_error "Download failed: $url"
     rm -f "$file"
-    exit 1
+    exit 115
   fi
 
   # Validate again
   if ! xz -t "$file" &>/dev/null; then
     msg_error "Downloaded file $(basename "$file") is corrupted. Please try again later."
     rm -f "$file"
-    exit 1
+    exit 115
   fi
   msg_ok "Downloaded and validated $(basename "$file")"
 }
@@ -266,7 +266,7 @@ function extract_xz_with_pv() {
   if ! xz -dc "$file" | pv -N "Extracting" >"$target"; then
     msg_error "Failed to extract $file"
     rm -f "$target"
-    exit 1
+    exit 115
   fi
   msg_ok "Decompressed to $target"
 }
@@ -514,7 +514,7 @@ done < <(pvesm status -content images | awk 'NR>1 {printf "%s %s %s\n", $1, $2, 
 
 if [ ${#STORAGE_MENU[@]} -eq 0 ]; then
   msg_error "Unable to detect a valid storage location."
-  exit 1
+  exit 119
 elif [ $((${#STORAGE_MENU[@]} / 3)) -eq 1 ]; then
   STORAGE=${STORAGE_MENU[0]}
 else


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replace generic exit 1 usages with specific numeric exit codes and add corresponding explanations to the error lookup. This commit updates multiple misc/* scripts to return distinct codes for validation, Proxmox/LXC, networking, download and curl errors (e.g. 103-123, 64, 107-120, 206, 0 for explicit user cancels). It also updates curl error handling to propagate the original curl exit code and adds new entries in explain_exit_code and the error handler to improve diagnostics.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
