### PR TITLE
ref: replace generic exit 1 with specific exit codes in ct & install

### DIFF
--- a/ct/alpine-komodo.sh
+++ b/ct/alpine-komodo.sh
@@ -39,7 +39,7 @@ function update_script() {
     COMPOSE_FILE=$(find /opt/komodo -maxdepth 1 -type f -name '*.compose.yaml' ! -name 'compose.env' | head -n1)
     if [[ -z "$COMPOSE_FILE" ]]; then
       msg_error "No valid compose file found in /opt/komodo!"
-      exit 1
+      exit 252
     fi
     $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env pull
     $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env up -d

--- a/ct/endurain.sh
+++ b/ct/endurain.sh
@@ -26,7 +26,7 @@ function update_script() {
 
   if [[ ! -d /opt/endurain ]]; then
     msg_error "No ${APP} installation found!"
-    exit 1
+    exit 233
   fi
   if check_for_gh_release "endurain" "endurain-project/endurain"; then
     msg_info "Stopping Service"

--- a/ct/evcc.sh
+++ b/ct/evcc.sh
@@ -25,7 +25,7 @@ function update_script() {
   check_container_resources
   if ! command -v evcc >/dev/null 2>&1; then
     msg_error "No ${APP} Installation Found!"
-    exit 1
+    exit 233
   fi
 
   if [[ -f /etc/apt/sources.list.d/evcc-stable.list ]]; then

--- a/ct/grafana.sh
+++ b/ct/grafana.sh
@@ -26,7 +26,7 @@ function update_script() {
 
   if ! dpkg -s grafana >/dev/null 2>&1; then
     msg_error "No ${APP} Installation Found!"
-    exit 1
+    exit 233
   fi
 
   if [[ -f /etc/apt/sources.list.d/grafana.list ]] || [[ ! -f /etc/apt/sources.list.d/grafana.sources ]]; then

--- a/ct/itsm-ng.sh
+++ b/ct/itsm-ng.sh
@@ -26,7 +26,7 @@ function update_script() {
 
   if [[ ! -f /etc/itsm-ng/config_db.php ]]; then
     msg_error "No ${APP} Installation Found!"
-    exit 1
+    exit 233
   fi
   setup_mariadb
 

--- a/ct/kasm.sh
+++ b/ct/kasm.sh
@@ -45,7 +45,7 @@ function update_script() {
   
   if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
     msg_error "Unable to detect latest Kasm release URL."
-    exit 1
+    exit 250
   fi
   msg_info "Checked for new version"
 

--- a/ct/komodo.sh
+++ b/ct/komodo.sh
@@ -43,7 +43,7 @@ function update_script() {
     COMPOSE_FILE=$(find /opt/komodo -maxdepth 1 -type f -name '*.compose.yaml' ! -name 'compose.env' | head -n1)
     if [[ -z "$COMPOSE_FILE" ]]; then
       msg_error "No valid compose file found in /opt/komodo!"
-      exit 1
+      exit 252
     fi
     $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env pull
     $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file /opt/komodo/compose.env up -d

--- a/ct/loki.sh
+++ b/ct/loki.sh
@@ -26,7 +26,7 @@ function update_script() {
 
   if ! dpkg -s loki >/dev/null 2>&1; then
     msg_error "No ${APP} Installation Found!"
-    exit 1
+    exit 233
   fi
 
   CHOICE=$(msg_menu "Loki Update Options" \

--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -44,7 +44,7 @@ function update_script() {
       echo -e "${TAB}${GATEWAY}${BGN}https://github.com/community-scripts/ProxmoxVE/discussions/9223${CL}"
       echo -e ""
       msg_custom "⚠️" "Update aborted. Please migrate your data first."
-      exit 1
+      exit 253
     fi
   fi
 

--- a/ct/vikunja.sh
+++ b/ct/vikunja.sh
@@ -34,14 +34,14 @@ function update_script() {
     msg_warn "This requires MANUAL config changes in /etc/vikunja/config.yml."
     msg_warn "See: https://vikunja.io/changelog/whats-new-in-vikunja-1.0.0/#config-changes"
 
-    read -rp "Continue with update? (y to proceed): " -t 30 CONFIRM1 || exit 1
+    read -rp "Continue with update? (y to proceed): " -t 30 CONFIRM1 || exit 254
     [[ "$CONFIRM1" =~ ^[yY]$ ]] || exit 0
 
     echo
     msg_warn "Vikunja may not start after the update until you manually adjust the config."
     msg_warn "Details: https://vikunja.io/changelog/whats-new-in-vikunja-1.0.0/#config-changes"
 
-    read -rp "Acknowledge and continue? (y): " -t 30 CONFIRM2 || exit 1
+    read -rp "Acknowledge and continue? (y): " -t 30 CONFIRM2 || exit 254
     [[ "$CONFIRM2" =~ ^[yY]$ ]] || exit 0
   fi
 

--- a/install/alpine-postgresql-install.sh
+++ b/install/alpine-postgresql-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 read -r -p "${TAB3}Enter PostgreSQL version (15/16/17): " ver
-[[ $ver =~ ^(15|16|17)$ ]] || { echo "Invalid version"; exit 1; }
+[[ $ver =~ ^(15|16|17)$ ]] || { echo "Invalid version"; exit 64; }
 
 msg_info "Installing PostgreSQL ${ver}"
 $STD apk add --no-cache postgresql${ver} postgresql${ver}-contrib postgresql${ver}-openrc sudo

--- a/install/apache-tomcat-install.sh
+++ b/install/apache-tomcat-install.sh
@@ -25,7 +25,7 @@ case $version in
     ;;
   *)
     msg_error "Invalid JDK version selected. Please enter 8, 11, 17 or 21."
-    exit 1
+    exit 64
     ;;
   esac
   ;;
@@ -39,7 +39,7 @@ case $version in
     ;;
   *)
     msg_error "Invalid JDK version selected. Please enter 11, 17 or 21."
-    exit 1
+    exit 64
     ;;
   esac
   ;;
@@ -53,13 +53,13 @@ case $version in
     ;;
   *)
     msg_error "Invalid JDK version selected. Please enter 17 or 21."
-    exit 1
+    exit 64
     ;;
   esac
   ;;
 *)
   msg_error "Invalid Tomcat version selected. Please enter 9, 10.1 or 11."
-  exit 1
+  exit 64
   ;;
 esac
 

--- a/install/booklore-install.sh
+++ b/install/booklore-install.sh
@@ -59,7 +59,7 @@ mkdir -p /opt/booklore/dist
 JAR_PATH=$(find /opt/booklore/booklore-api/build/libs -maxdepth 1 -type f -name "booklore-api-*.jar" ! -name "*plain*" | head -n1)
 if [[ -z "$JAR_PATH" ]]; then
   msg_error "Backend JAR not found"
-  exit 1
+  exit 153
 fi
 cp "$JAR_PATH" /opt/booklore/dist/app.jar
 msg_ok "Built Backend"

--- a/install/docker-install.sh
+++ b/install/docker-install.sh
@@ -86,7 +86,7 @@ EOF
     msg_ok "Docker TCP socket available on $socket"
   else
     msg_error "Docker failed to restart. Check journalctl -xeu docker.service"
-    exit 1
+    exit 150
   fi
 fi
 

--- a/install/emqx-install.sh
+++ b/install/emqx-install.sh
@@ -21,7 +21,7 @@ msg_info "Fetching latest EMQX Enterprise version"
 LATEST_VERSION=$(curl -fsSL https://www.emqx.com/en/downloads/enterprise | grep -oP '/en/downloads/enterprise/v\K[0-9]+\.[0-9]+\.[0-9]+' | sort -V | tail -n1)
 if [[ -z "$LATEST_VERSION" ]]; then
   msg_error "Failed to determine latest EMQX version"
-  exit 1
+  exit 250
 fi
 msg_ok "Latest version: v$LATEST_VERSION"
 

--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -17,7 +17,7 @@ update_os
 source /etc/os-release
 if [[ "$VERSION_ID" != "12" ]]; then
   msg_error "Frigate requires Debian 12 (Bookworm) due to Python 3.11 dependencies"
-  exit 1
+  exit 238
 fi
 
 msg_info "Converting APT sources to DEB822 format"

--- a/install/kasm-install.sh
+++ b/install/kasm-install.sh
@@ -31,7 +31,7 @@ fi
 
 if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
   msg_error "Unable to detect latest Kasm release URL."
-  exit 1
+  exit 250
 fi
 msg_ok "Detected Kasm Workspaces version $KASM_VERSION"
 

--- a/install/npmplus-install.sh
+++ b/install/npmplus-install.sh
@@ -51,7 +51,7 @@ while true; do
   attempts=$((attempts + 1))
   if [[ "$attempts" -ge 3 ]]; then
     msg_error "Maximum attempts reached. Exiting."
-    exit 1
+    exit 254
   fi
 done
 
@@ -76,11 +76,11 @@ for i in {1..60}; do
     elif [[ "$STATUS" == "unhealthy" ]]; then
       msg_error "NPMplus container is unhealthy! Check logs."
       docker logs "$CONTAINER_ID"
-      exit 1
+      exit 150
     fi
   fi
   sleep 2
-  [[ $i -eq 60 ]] && msg_error "NPMplus container did not become healthy within 120s." && docker logs "$CONTAINER_ID" && exit 1
+  [[ $i -eq 60 ]] && msg_error "NPMplus container did not become healthy within 120s." && docker logs "$CONTAINER_ID" && exit 150
 done
 msg_ok "Builded and started NPMplus"
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -78,11 +78,11 @@ if curl -fL# -C - -o "$TMP_TAR" "$OLLAMA_URL"; then
     msg_ok "Installed Ollama ${RELEASE}"
   else
     msg_error "Extraction failed – archive corrupt or incomplete"
-    exit 1
+    exit 251
   fi
 else
   msg_error "Download failed – $OLLAMA_URL not reachable"
-  exit 1
+  exit 250
 fi
 
 msg_info "Creating ollama User and Group"

--- a/install/onlyoffice-install.sh
+++ b/install/onlyoffice-install.sh
@@ -59,7 +59,7 @@ EOF
 else
   msg_error "Failed to download or verify GPG key from $KEY_URL"
   [[ -f "$TMP_KEY_CONTENT" ]] && rm -f "$TMP_KEY_CONTENT"
-  exit 1
+  exit 250
 fi
 rm -f "$TMP_KEY_CONTENT"
 

--- a/install/opencloud-install.sh
+++ b/install/opencloud-install.sh
@@ -34,7 +34,7 @@ for server in "${servers[@]}"; do
   done
   if ((attempt >= MAX_ATTEMPTS)); then
     msg_error "No more attempts - aborting script!"
-    exit 1
+    exit 254
   fi
 done
 

--- a/install/postgresql-install.sh
+++ b/install/postgresql-install.sh
@@ -16,7 +16,7 @@ update_os
 read -r -p "${TAB3}Enter PostgreSQL version (15/16/17/18): " ver
 [[ $ver =~ ^(15|16|17|18)$ ]] || {
   echo "Invalid version"
-  exit 1
+  exit 64
 }
 PG_VERSION=$ver setup_postgresql
 

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -25,7 +25,7 @@ if useradd -r -m -d /opt/pulse-home -s /usr/sbin/nologin pulse; then
   msg_ok "Created User"
 else
   msg_error "User creation failed"
-  exit 1
+  exit 71
 fi
 
 mkdir -p /etc/pulse

--- a/install/splunk-enterprise-install.sh
+++ b/install/splunk-enterprise-install.sh
@@ -34,7 +34,7 @@ while true; do
         [Nn]|[Nn][Oo]|"")
             msg_error "Terms not accepted. Installation cannot proceed."
             msg_error "Please review the terms and run the script again if you wish to proceed."
-            exit 1
+            exit 254
             ;;
         *)
             msg_error "Invalid response. Please enter 'y' for yes or 'n' for no."
@@ -47,7 +47,7 @@ DOWNLOAD_URL=$(curl -s "https://www.splunk.com/en_us/download/splunk-enterprise.
 RELEASE=$(echo "$DOWNLOAD_URL" | sed 's|.*/releases/\([^/]*\)/.*|\1|')
 $STD curl -fsSL -o "splunk-enterprise.tgz" "$DOWNLOAD_URL" || {
     msg_error "Failed to download Splunk Enterprise from the provided link."
-    exit 1
+    exit 250
 }
 $STD tar -xzf "splunk-enterprise.tgz" -C /opt
 rm -f "splunk-enterprise.tgz"

--- a/install/unifi-os-server-install.sh
+++ b/install/unifi-os-server-install.sh
@@ -16,13 +16,13 @@ update_os
 if [[ "${CTTYPE:-1}" != "0" ]]; then
   msg_error "UniFi OS Server requires a privileged LXC container."
   msg_error "Recreate the container with unprivileged=0."
-  exit 1
+  exit 10
 fi
 
 if [[ ! -e /dev/net/tun ]]; then
   msg_error "Missing /dev/net/tun in container."
   msg_error "Enable TUN/TAP (var_tun=yes) or add /dev/net/tun passthrough."
-  exit 1
+  exit 236
 fi
 
 msg_info "Installing dependencies"
@@ -48,7 +48,7 @@ TEMP_JSON="$(mktemp)"
 if ! curl -fsSL "$API_URL" -o "$TEMP_JSON"; then
   rm -f "$TEMP_JSON"
   msg_error "Failed to fetch data from Ubiquiti API"
-  exit 1
+  exit 250
 fi
 LATEST=$(jq -r '
   ._embedded.firmware
@@ -62,7 +62,7 @@ UOS_URL=$(echo "$LATEST" | jq -r '._links.data.href')
 rm -f "$TEMP_JSON"
 if [[ -z "$UOS_URL" || -z "$UOS_VERSION" || "$UOS_URL" == "null" ]]; then
   msg_error "Failed to parse UniFi OS Server version or download URL"
-  exit 1
+  exit 250
 fi
 msg_ok "Found UniFi OS Server ${UOS_VERSION}"
 

--- a/install/zerotier-one-install.sh
+++ b/install/zerotier-one-install.sh
@@ -31,7 +31,7 @@ if gpg --verify /tmp/zerotier-install.sh >/dev/null 2>&1; then
   $STD bash /tmp/zerotier-install.sh
 else
   msg_warn "Could not verify signature of Zerotier-One install script. Exiting..."
-  exit 1
+  exit 250
 fi
 msg_ok "Setup Zerotier-One"
 

--- a/misc/api.func
+++ b/misc/api.func
@@ -134,6 +134,7 @@ detect_repo_source
 #   * Proxmox custom codes (200-231)
 #   * Tools & Addon Scripts (232-238)
 #   * Node.js/npm errors (239, 243, 245-249)
+#   * Application Install/Update errors (250-254)
 # - Returns description string for given exit code
 # ------------------------------------------------------------------------------
 explain_exit_code() {
@@ -321,6 +322,13 @@ explain_exit_code() {
   247) echo "Node.js: Fatal internal error" ;;
   248) echo "Node.js: Invalid C++ addon / N-API failure" ;;
   249) echo "npm/pnpm/yarn: Unknown fatal error" ;;
+
+  # --- Application Install/Update Errors (250-254) ---
+  250) echo "App: Download failed or version not determined" ;;
+  251) echo "App: File extraction failed (corrupt or incomplete archive)" ;;
+  252) echo "App: Required file or resource not found" ;;
+  253) echo "App: Data migration required — update aborted" ;;
+  254) echo "App: User declined prompt or input timed out" ;;
 
   # --- DPKG ---
   255) echo "DPKG: Fatal internal error" ;;

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -195,6 +195,14 @@ if ! declare -f explain_exit_code &>/dev/null; then
     247) echo "Node.js: Fatal internal error" ;;
     248) echo "Node.js: Invalid C++ addon / N-API failure" ;;
     249) echo "npm/pnpm/yarn: Unknown fatal error" ;;
+
+    # --- Application Install/Update Errors (250-254) ---
+    250) echo "App: Download failed or version not determined" ;;
+    251) echo "App: File extraction failed (corrupt or incomplete archive)" ;;
+    252) echo "App: Required file or resource not found" ;;
+    253) echo "App: Data migration required — update aborted" ;;
+    254) echo "App: User declined prompt or input timed out" ;;
+
     255) echo "DPKG: Fatal internal error" ;;
     *) echo "Unknown error" ;;
     esac


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Part of #12467 — scripts only (no framework changes).

New exit codes 250-254 registered in api.func and error_handler.func:
- 250: App download failed or version not determined
- 251: App file extraction failed (corrupt/incomplete archive)
- 252: App required file or resource not found
- 253: App data migration required — update aborted
- 254: App user declined prompt or input timed out

Existing codes reused where applicable:
- 10: privileged/Docker required (unifi-os-server)
- 64: invalid user input (postgresql, tomcat)
- 71: system error (pulse useradd)
- 150: service failed to start (docker, npmplus)
- 153: build failed (booklore)
- 233: app not installed (evcc, endurain, grafana, loki, itsm-ng)
- 236: hardware not detected (unifi-os-server /dev/net/tun)
- 238: OS not supported (frigate)

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
