### PR TITLE
fix(immich): correct LibRaw clone URL to official upstream

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -337,7 +337,7 @@ function compile_libraw() {
   if [[ "$LIBRAW_REVISION" != "$(grep 'libraw' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libraw"
     [[ -d "$SOURCE" ]] && rm -rf "$SOURCE"
-    $STD git clone https://github.com/libraw/libraw.git "$SOURCE"
+    $STD git clone https://github.com/LibRaw/LibRaw.git "$SOURCE"
     cd "$SOURCE"
     $STD git reset --hard "$LIBRAW_REVISION"
     $STD autoreconf --install

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -232,7 +232,7 @@ msg_ok "(2/5) Compiled libheif"
 msg_info "(3/5) Compiling libraw"
 SOURCE=${SOURCE_DIR}/libraw
 : "${LIBRAW_REVISION:=$(jq -cr '.revision' $BASE_DIR/server/sources/libraw.json)}"
-$STD git clone https://github.com/libraw/libraw.git "$SOURCE"
+$STD git clone https://github.com/LibRaw/LibRaw.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBRAW_REVISION"
 $STD autoreconf --install


### PR DESCRIPTION
## ✍️ Description

- Immich installation fails during the LibRaw compilation stage due to an incorrect clone URL: https://github.com/libraw/libraw.git

- GitHub returns HTTP 500 and git exits with code 128.

- The correct upstream repository is: https://github.com/LibRaw/LibRaw.git

- This PR updates the clone URL to the official LibRaw repository.

- Tested by reinstalling the Immich container from scratch.

## 🔗 Related Issue
N/A
Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
