### PR TITLE
update-apps: fix restore path, add PBS support and improve restore messages

### DIFF
--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -426,16 +426,23 @@ for container in $CHOICE; do
   elif [ $exit_code -eq 75 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (requires interactive mode)"
   elif [ "$BACKUP_CHOICE" == "yes" ]; then
-    msg_info "Restoring LXC from backup"
+    msg_error "Update failed for container $container (exit code: $exit_code) — attempting restore"
+    msg_info "Restoring LXC $container from backup ($STORAGE_CHOICE)"
     pct stop $container
     LXC_STORAGE=$(pct config $container | awk -F '[:,]' '/rootfs/ {print $2}')
-    pct restore $container /var/lib/vz/dump/vzdump-lxc-${container}-*.tar.zst --storage $LXC_STORAGE --force >/dev/null 2>&1
-    pct start $container
+    BACKUP_ENTRY=$(pvesm list "$STORAGE_CHOICE" 2>/dev/null | awk -v ctid="$container" '$1 ~ "vzdump-lxc-"ctid"-" || $1 ~ "/ct/"ctid"/" {print $1}' | sort -r | head -n1)
+    if [ -z "$BACKUP_ENTRY" ]; then
+      msg_error "No backup found in storage $STORAGE_CHOICE for container $container"
+      exit 235
+    fi
+    msg_info "Restoring from: $BACKUP_ENTRY"
+    pct restore $container "$BACKUP_ENTRY" --storage $LXC_STORAGE --force >/dev/null 2>&1
     restorestatus=$?
     if [ $restorestatus -eq 0 ]; then
-      msg_ok "Restored LXC from backup"
+      pct start $container
+      msg_ok "Container $container successfully restored from backup"
     else
-      msg_error "Restored LXC from backup failed"
+      msg_error "Restore failed for container $container"
       exit 235
     fi
   else


### PR DESCRIPTION
 ✍️ Description

`update-apps.sh` restore step was hardcoded to `/var/lib/vz/dump/*.tar.zst`, which silently fails for PBS and any non-default storage.

**Changes:**
- Use `pvesm list` to dynamically resolve the latest backup from the selected storage — works for both PBS and traditional file-based storages with no extra plumbing
- Restore log messages now include container ID, exit code, storage name and resolved backup entry

 🔗 Related Issue

Fixes #

 ✅ Prerequisites
- [X] Self-review completed
- [X] Tested thoroughly
- [X] No security risks

 🛠️ Type of Change
- [X] 🐞 Bug fix
- [X] ✨ New feature
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.