### PR TITLE
PowerDNS: use gsqlite3 backend instead of BIND

### DIFF
--- a/install/powerdns-install.sh
+++ b/install/powerdns-install.sh
@@ -38,6 +38,12 @@ msg_info "Setting up PowerDNS"
 $STD apt install -y \
   pdns-server \
   pdns-backend-sqlite3
+sed -i 's/^launch=$/# launch=/' /etc/powerdns/pdns.conf
+rm -f /etc/powerdns/pdns.d/bind.conf
+cat <<EOF >/etc/powerdns/pdns.d/gsqlite3.conf
+launch+=gsqlite3
+gsqlite3-database=/opt/poweradmin/powerdns.db
+EOF
 msg_ok "Setup PowerDNS"
 
 fetch_and_deploy_gh_release "poweradmin" "poweradmin/poweradmin" "tarball"
@@ -126,7 +132,10 @@ cat <<EOF >/etc/apache2/sites-enabled/poweradmin.conf
 EOF
 $STD a2enmod rewrite headers
 chown -R www-data:www-data /opt/poweradmin
-$STD systemctl restart apache2
+chown pdns:pdns /opt/poweradmin/powerdns.db
+chmod 664 /opt/poweradmin/powerdns.db
+usermod -aG pdns www-data
+$STD systemctl restart pdns apache2
 msg_info "Created Service"
 
 motd_ssh


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Comment out empty 'launch=' in pdns.conf that overrides launch+= directives
- Remove default bind.conf and create gsqlite3.conf pointing to the Poweradmin SQLite database (/opt/poweradmin/powerdns.db)
- Set correct ownership (pdns:pdns) and permissions (664) on the database file so pdns_server can read/write it
- Add www-data to pdns group for shared database access
- Restart pdns service alongside apache2

## 🔗 Related Issue

Fixes #12533

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
