### PR TITLE
jellyseer/overseer migration corrupting /usr/bin/update

### DIFF
--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -47,7 +47,6 @@ function update_script() {
     msg_info "Switching update script to Seerr"
     TMP_UPDATE=$(mktemp)
     cat <<'EOF' >"$TMP_UPDATE"
-#!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
     mv "$TMP_UPDATE" /usr/bin/update

--- a/ct/jellyseerr.sh
+++ b/ct/jellyseerr.sh
@@ -45,14 +45,16 @@ function update_script() {
     fi
 
     msg_info "Switching update script to Seerr"
-    cat <<'EOF' >/usr/bin/update
+    TMP_UPDATE=$(mktemp)
+    cat <<'EOF' >"$TMP_UPDATE"
 #!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
+    mv "$TMP_UPDATE" /usr/bin/update
     chmod +x /usr/bin/update
     msg_ok "Switched update script to Seerr"
     msg_warn "Please type 'update' again to complete the migration"
-    exit
+    exit 0
   fi
 
   msg_info "Updating Jellyseerr"

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -46,7 +46,6 @@ function update_script() {
     msg_info "Switching update script to Seerr"
     TMP_UPDATE=$(mktemp)
     cat <<'EOF' >"$TMP_UPDATE"
-#!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
     mv "$TMP_UPDATE" /usr/bin/update

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -44,10 +44,12 @@ function update_script() {
     fi
 
     msg_info "Switching update script to Seerr"
-    cat <<'EOF' >/usr/bin/update
+    TMP_UPDATE=$(mktemp)
+    cat <<'EOF' >"$TMP_UPDATE"
 #!/usr/bin/env bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/seerr.sh)"
 EOF
+    mv "$TMP_UPDATE" /usr/bin/update
     chmod +x /usr/bin/update
     msg_ok "Switched update script to Seerr"
     msg_warn "Please type 'update' again to complete the migration"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The migration wrote the new update script directly to /usr/bin/update while the parent shell still had the file open for reading. Since the new content (with shebang) is longer than the original single-line file, bash would read leftover bytes from the new content after the child process exited, causing:
  /usr/bin/update: line 2: syntax error near unexpected token )'

## 🔗 Related Issue
https://discord.com/channels/1302816934508630047/1478442094212284446/1478442094212284446
Fixes #12529

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
