### PR TITLE
tools: fall back to distro packages for psql

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -6500,14 +6500,13 @@ function setup_postgresql() {
   local SUITE
   case "$DISTRO_CODENAME" in
   trixie | forky | sid)
-
     if verify_repo_available "https://apt.postgresql.org/pub/repos/apt" "trixie-pgdg"; then
       SUITE="trixie-pgdg"
-
     else
-      SUITE="bookworm-pgdg"
+      msg_warn "PGDG repo not available for ${DISTRO_CODENAME}, falling back to distro packages"
+      USE_PGDG_REPO=false setup_postgresql
+      return $?
     fi
-
     ;;
   *)
     SUITE=$(get_fallback_suite "$DISTRO_ID" "$DISTRO_CODENAME" "https://apt.postgresql.org/pub/repos/apt")


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When the PGDG repo is unreachable for trixie the previous code fell back to bookworm-pgdg. 
Instead of falling back to an incompatible suite, recursively call setup_postgresql with USE_PGDG_REPO=false to use Debians native PostgreSQL packages (Trixie ships PG 17 natively).

Its not the "solution" for 12524, but its an better workaround. The Script should work now for the User, because his network block "https://apt.postgresql.org/pub/repos/apt"

## 🔗 Related Issue

Closes #12524

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
