### PR TITLE
Docmost: register NoopAuditService globally when EE submodule is missing

### DIFF
--- a/ct/docmost.sh
+++ b/ct/docmost.sh
@@ -48,6 +48,17 @@ function update_script() {
     cd /opt/docmost
     mv /opt/.env /opt/docmost/.env
     mv /opt/data /opt/docmost/data
+
+    # Fix: Docmost EE (audit logs etc.) lives in a git submodule that is NOT
+    # included in GitHub tarballs.  The community NoopAuditService exists but
+    # is only exported by CoreModule – child modules such as UserModule cannot
+    # resolve it.  Making CoreModule @Global() exposes the token app-wide.
+    if [[ ! -f /opt/docmost/apps/server/src/ee/ee.module.ts ]] \
+      && ! grep -q '@Global()' /opt/docmost/apps/server/src/core/core.module.ts 2>/dev/null; then
+      sed -i '/^  Module,$/a\  Global,' /opt/docmost/apps/server/src/core/core.module.ts
+      sed -i '/^@Module({$/i @Global()' /opt/docmost/apps/server/src/core/core.module.ts
+    fi
+
     $STD pnpm install --force
     $STD pnpm build
     msg_ok "Updated ${APP}"

--- a/install/docmost-install.sh
+++ b/install/docmost-install.sh
@@ -26,6 +26,17 @@ fetch_and_deploy_gh_release "docmost" "docmost/docmost" "tarball"
 
 msg_info "Configuring Docmost (Patience)"
 cd /opt/docmost
+
+# Fix: Docmost EE (audit logs etc.) lives in a git submodule that is NOT
+# included in GitHub tarballs.  The community NoopAuditService exists but
+# is only exported by CoreModule – child modules such as UserModule cannot
+# resolve it.  Making CoreModule @Global() exposes the token app-wide.
+if [[ ! -f /opt/docmost/apps/server/src/ee/ee.module.ts ]] \
+  && ! grep -q '@Global()' /opt/docmost/apps/server/src/core/core.module.ts 2>/dev/null; then
+  sed -i '/^  Module,$/a\  Global,' /opt/docmost/apps/server/src/core/core.module.ts
+  sed -i '/^@Module({$/i @Global()' /opt/docmost/apps/server/src/core/core.module.ts
+fi
+
 mv .env.example .env
 mkdir data
 sed -i -e "s|APP_SECRET=.*|APP_SECRET=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | cut -c1-32)|" \


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Docmost v0.70.0 added audit logging (enterprise feature). The EE code lives in a private git submodule (apps/server/src/ee) which is NOT included in GitHub tarballs used by fetch_and_deploy_gh_release.

Its very dirty, but the workaround should work. 

Without the submodule, AUDIT_SERVICE (Symbol) is provided by CoreModule via NoopAuditService but only exported – child modules like UserModule cannot resolve it because NestJS DI is scope-based. The EE module would normally register the real service as @Global(), making it available everywhere.

Fix: when the EE submodule is absent, patch CoreModule to be @Global() before building, so NoopAuditService is available to all modules.

## 🔗 Related Issue

Fixes #12548

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
