### PR TITLE
update: stirling-pdf: java 25

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -35,7 +35,7 @@ function update_script() {
     fi
 
     PYTHON_VERSION="3.12" setup_uv
-    JAVA_VERSION="21" setup_java
+    JAVA_VERSION="25" setup_java
 
     msg_info "Stopping Services"
     systemctl stop stirlingpdf libreoffice-listener unoserver

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -31,7 +31,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.12" setup_uv
-JAVA_VERSION="21" setup_java
+JAVA_VERSION="25" setup_java
 
 read -r -p "${TAB3}Do you want to use Stirling-PDF with Login? (no/n = without Login) [Y/n] " response
 response=${response,,} # Convert to lowercase


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
update: stirling-pdf: java 25 as release 2.6.0 bumped from 17-25 to dropping 17 and recommending 25

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
