### PR TITLE
PowerDNS: use 'launch=' instead of 'launch+=' for gsqlite3 backend

### DIFF
--- a/install/powerdns-install.sh
+++ b/install/powerdns-install.sh
@@ -41,7 +41,7 @@ $STD apt install -y \
 sed -i 's/^launch=$/# launch=/' /etc/powerdns/pdns.conf
 rm -f /etc/powerdns/pdns.d/bind.conf
 cat <<EOF >/etc/powerdns/pdns.d/gsqlite3.conf
-launch+=gsqlite3
+launch=gsqlite3
 gsqlite3-database=/opt/poweradmin/powerdns.db
 EOF
 msg_ok "Setup PowerDNS"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
PowerDNS 5.x requires a parent 'launch=' directive before any incremental 'launch+=' can be used. Since the install script comments out the default 'launch=' in pdns.conf, the 'launch+=' in gsqlite3.conf fails with:
```Mar 05 09:40:03 Fatal error: Incremental setting 'launch' without a parent```

Use 'launch=gsqlite3' (non-incremental) since gsqlite3 is the only backend needed.

## 🔗 Related Issue

Fixes #12578

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
