### PR TITLE
Check for influxdb3 installation in update_script

### DIFF
--- a/ct/influxdb.sh
+++ b/ct/influxdb.sh
@@ -23,7 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /usr/bin/influxd ]]; then
+  if [[ ! -f /usr/bin/influxd && ! -f /usr/bin/influxdb3 ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi


### PR DESCRIPTION
Fix current check only working for influxdb 1.x and 2.x

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Calling `update` in influxdb lxc container returns 

```
    ____      ______           ____  ____ 
   /  _/___  / __/ /_  ___  __/ __ \/ __ )
   / // __ \/ /_/ / / / / |/_/ / / / __  |
 _/ // / / / __/ / /_/ />  </ /_/ / /_/ / 
/___/_/ /_/_/ /_/\__,_/_/|_/_____/_____/  
                                          

  ✖️   No InfluxDB Installation Found!
```

I installed influxdb version 3. Current check in update script only handled old cli path. This changed for v3.

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
