### PR TITLE
Grocy: bump PHP version from 8.3 to 8.5

### DIFF
--- a/ct/grocy.sh
+++ b/ct/grocy.sh
@@ -28,8 +28,8 @@ function update_script() {
     exit
   fi
   php_ver=$(php -v | head -n 1 | awk '{print $2}')
-  if [[ ! $php_ver == "8.3"* ]]; then
-    PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
+  if [[ ! $php_ver == "8.5"* ]]; then
+    PHP_VERSION="8.5" PHP_APACHE="YES" setup_php
   fi
   if check_for_gh_release "grocy" "grocy/grocy"; then
     msg_info "Updating grocy"

--- a/install/grocy-install.sh
+++ b/install/grocy-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y apt-transport-https
 msg_ok "Installed Dependencies"
 
-PHP_VERSION="8.3" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.5" PHP_APACHE="YES" setup_php
 fetch_and_deploy_gh_release "grocy" "grocy/grocy" "prebuild" "latest" "/var/www/html" "grocy*.zip"
 
 msg_info "Configuring grocy"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Grocy now requires PHP 8.5. Update both the install script and the update function to use PHP 8.5 instead of 8.3.

## 🔗 Related Issue

Fixes #12647

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
