### PR TITLE
NZBGet: Fixes for RAR5 handling

### DIFF
--- a/ct/nzbget.sh
+++ b/ct/nzbget.sh
@@ -27,6 +27,16 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+
+  if ! command -v unrar &>/dev/null; then
+    setup_nonfree
+    $STD apt install -y unrar
+
+    if grep -q "UnrarCmd=unrar-free" /var/lib/nzbget/nzbget.conf; then
+      sed -i "s|UnrarCmd=unrar-free|UnrarCmd=unrar|g" /var/lib/nzbget/nzbget.conf
+    fi
+  fi
+
   msg_info "Updating NZBGet"
   $STD apt update
   $STD apt upgrade -y

--- a/install/nzbget-install.sh
+++ b/install/nzbget-install.sh
@@ -14,10 +14,12 @@ setting_up_container
 network_check
 update_os
 
+setup_nonfree
+
 msg_info "Installing Dependencies"
 $STD apt install -y \
   par2 \
-  unrar-free
+  unrar
 msg_ok "Installed Dependencies"
 
 msg_info "Installing NZBGet"
@@ -27,7 +29,6 @@ setup_deb822_repo \
   "https://nzbgetcom.github.io/deb" \
   "stable"
 $STD apt install -y nzbget
-sed -i "s|UnrarCmd=unrar|UnrarCmd=unrar-free|g" /var/lib/nzbget/nzbget.conf
 sed -i "s|SevenZipCmd=7zz|SevenZipCmd=7z|g" /var/lib/nzbget/nzbget.conf
 systemctl restart nzbget
 msg_ok "Installed NZBGet"

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8192,3 +8192,23 @@ function fetch_and_deploy_from_url() {
   msg_ok "Successfully deployed archive to $directory"
   return 0
 }
+
+setup_nonfree() {
+  local sources_file="/etc/apt/sources.list.d/debian-nonfree.sources"
+
+  if [ ! -f "$sources_file" ]; then
+    cat <<EOF >$sources_file
+Types: deb
+URIs: http://deb.debian.org/debian
+Suites: trixie trixie-updates
+Components: main contrib non-free non-free-firmware
+
+Types: deb
+URIs: http://security.debian.org/debian-security
+Suites: trixie-security
+Components: main contrib non-free non-free-firmware
+EOF
+  fi
+  $STD apt update
+  return 0
+}


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- The script used `unrar-free` from official Debian repo but its not 100% compatible with RAR5 archives, hence failing to extract them. Added a helper function to `misc/tools.func` that will set up `non-free` Debian repo for scripts that need packages from it

## 🔗 Related Issue

Fixes #12667 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
