### PR TITLE
Change cronjob setup to use www-data user

### DIFF
--- a/install/glpi-install.sh
+++ b/install/glpi-install.sh
@@ -137,7 +137,7 @@ rm -rf /opt/glpi-${RELEASE}.tgz
 msg_ok "Setup Service"
 
 msg_info "Setup Cronjob"
-echo "* * * * * php /opt/glpi/front/cron.php" | crontab -
+echo "* * * * * php /opt/glpi/front/cron.php" | crontab -u www-data -
 msg_ok "Setup Cronjob"
 
 msg_info "Update PHP Params"


### PR DESCRIPTION
## ✍️ Description

This change fixes the cron configuration for GLPI during installation.

Previously the cron job was being added without specifying the user, which caused it to run under the root context when executed from the installation script. GLPI recommends running its cron tasks under the web server user (`www-data`) to ensure correct permissions for files, sessions, and cache directories.

The change explicitly sets the cron job to run as `www-data`:

```bash
echo "* * * * * php /opt/glpi/front/cron.php" | crontab -u www-data -
```

### Benefits

* Ensures GLPI cron runs under the correct user.
* Prevents permission issues with GLPI files and cache.
* Aligns with official GLPI deployment recommendations.
* Improves compatibility with systems where root cannot access web user runtime paths.

---

## 🔗 Related Issue

Fixes potential permission issues with GLPI cron execution when installed through the Proxmox script.

---

## ✅ Prerequisites

* [x] **Self-review completed** – Code follows project standards.
* [x] **Tested thoroughly** – Changes work as expected.
* [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

* [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
* [ ] ✨ **New feature** – Adds new, non-breaking functionality.
* [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
* [ ] 🆕 **New script** – A fully functional and tested script or script set.
* [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
* [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
* [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
