### PR TITLE
tools: add Alpine (apk) support to ensure_dependencies and is_package_installed

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -969,13 +969,43 @@ verify_repo_available() {
 }
 
 # ------------------------------------------------------------------------------
-# Ensure dependencies are installed (with apt update caching)
+# Ensure dependencies are installed (with apt/apk update caching)
+# Supports both Debian (apt/dpkg) and Alpine (apk) systems
 # ------------------------------------------------------------------------------
 ensure_dependencies() {
   local deps=("$@")
   local missing=()
 
-  # Fast batch check using dpkg-query (much faster than individual checks)
+  # Detect Alpine Linux
+  if [[ -f /etc/alpine-release ]]; then
+    for dep in "${deps[@]}"; do
+      if command -v "$dep" &>/dev/null; then
+        continue
+      fi
+      if apk info -e "$dep" &>/dev/null; then
+        continue
+      fi
+      missing+=("$dep")
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+      $STD apk add --no-cache "${missing[@]}" || {
+        local failed=()
+        for pkg in "${missing[@]}"; do
+          if ! $STD apk add --no-cache "$pkg" 2>/dev/null; then
+            failed+=("$pkg")
+          fi
+        done
+        if [[ ${#failed[@]} -gt 0 ]]; then
+          msg_error "Failed to install dependencies: ${failed[*]}"
+          return 1
+        fi
+      }
+    fi
+    return 0
+  fi
+
+  # Debian/Ubuntu: Fast batch check using dpkg-query
   local installed_pkgs
   installed_pkgs=$(dpkg-query -W -f='${Package}\n' 2>/dev/null | sort -u)
 
@@ -1072,11 +1102,15 @@ create_temp_dir() {
 }
 
 # ------------------------------------------------------------------------------
-# Check if package is installed (faster than dpkg -l | grep)
+# Check if package is installed (supports both Debian and Alpine)
 # ------------------------------------------------------------------------------
 is_package_installed() {
   local package="$1"
-  dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "^install ok installed$"
+  if [[ -f /etc/alpine-release ]]; then
+    apk info -e "$package" &>/dev/null
+  else
+    dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "^install ok installed$"
+  fi
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
ensure_dependencies() and is_package_installed() used dpkg-query and apt which don't exist on Alpine Linux. When alpine-install.func sources tools.func, these functions would fail with 'exit code 980' errors.
- ensure_dependencies: uses apk info/apk add on Alpine
- is_package_installed: uses apk info -e on Alpine

## 🔗 Related Issue

Fixes #12698

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
