### PR TITLE
Reactive Resume: rewrite for v5 using original repo amruthpilla/reactive-resume

### DIFF
--- a/ct/reactive-resume.sh
+++ b/ct/reactive-resume.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: vhsdream
+# Author: vhsdream | Rewrite: MickLesk (CanbiZ)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
-# Source: https://rxresume.org | Github: https://github.com/lazy-media/Reactive-Resume
+# Source: https://rxresume.org | Github: https://github.com/amruthpillai/reactive-resume
 
 APP="Reactive-Resume"
 var_tags="${var_tags:-documents}"
@@ -24,62 +24,29 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  if [[ ! -f /etc/systemd/system/Reactive-Resume.service ]]; then
+  if [[ ! -f /etc/systemd/system/reactive-resume.service ]]; then
     msg_error "No $APP Installation Found!"
     exit
   fi
-  if check_for_gh_release "Reactive-Resume" "lazy-media/Reactive-Resume"; then
+  if check_for_gh_release "reactive-resume" "amruthpillai/reactive-resume"; then
     msg_info "Stopping services"
-    systemctl stop Reactive-Resume
+    systemctl stop reactive-resume
     msg_ok "Stopped services"
 
-    cp /opt/Reactive-Resume/.env /opt/rxresume.env
-    fetch_and_deploy_gh_release "Reactive-Resume" "lazy-media/Reactive-Resume" "tarball" "latest" "/opt/Reactive-Resume"
+    cp /opt/reactive-resume/.env /opt/reactive-resume.env.bak
+    fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball" "latest" "/opt/reactive-resume"
 
-    msg_info "Updating Reactive-Resume"
-    cd /opt/Reactive-Resume
-    export PUPPETEER_SKIP_DOWNLOAD="true"
-    export NEXT_TELEMETRY_DISABLED=1
+    msg_info "Updating Reactive Resume (Patience)"
+    cd /opt/reactive-resume
     export CI="true"
     export NODE_ENV="production"
     $STD pnpm install --frozen-lockfile
     $STD pnpm run build
-    $STD pnpm run prisma:generate
-    mv /opt/rxresume.env /opt/Reactive-Resume/.env
-    msg_ok "Updated Reactive-Resume"
-
-    msg_info "Updating Minio"
-    systemctl stop minio
-    cd /tmp
-    curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio.deb -o minio.deb
-    $STD dpkg -i minio.deb
-    rm -f /tmp/minio.deb
-    msg_ok "Updated Minio"
-
-    msg_info "Updating Browserless (Patience)"
-    systemctl stop browserless
-    cp /opt/browserless/.env /opt/browserless.env
-    rm -rf /opt/browserless
-    brwsr_tmp=$(mktemp)
-    TAG=$(curl -fsSL https://api.github.com/repos/browserless/browserless/tags?per_page=1 | grep "name" | awk '{print substr($2, 3, length($2)-4) }')
-    curl -fsSL https://github.com/browserless/browserless/archive/refs/tags/v"$TAG".zip -o "$brwsr_tmp"
-    $STD unzip "$brwsr_tmp"
-    mv browserless-"$TAG"/ /opt/browserless
-    cd /opt/browserless
-    $STD npm install typescript
-    $STD npm install esbuild
-    $STD npm install
-    rm -rf src/routes/{chrome,edge,firefox,webkit}
-    $STD node_modules/playwright-core/cli.js install --with-deps chromium
-    $STD npm run build
-    $STD npm run build:function
-    $STD npm prune production
-    mv /opt/browserless.env /opt/browserless/.env
-    rm -f "$brwsr_tmp"
-    msg_ok "Updated Browserless"
+    mv /opt/reactive-resume.env.bak /opt/reactive-resume/.env
+    msg_ok "Updated Reactive Resume"
 
     msg_info "Restarting services"
-    systemctl start minio Reactive-Resume browserless
+    systemctl start chromium-printer reactive-resume
     msg_ok "Restarted services"
     msg_ok "Updated successfully!"
   fi

--- a/ct/reactive-resume.sh
+++ b/ct/reactive-resume.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: vhsdream | Rewrite: MickLesk (CanbiZ)
+# Author: vhsdream | MickLesk (CanbiZ)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://rxresume.org | Github: https://github.com/amruthpillai/reactive-resume
 
@@ -34,7 +34,7 @@ function update_script() {
     msg_ok "Stopped services"
 
     cp /opt/reactive-resume/.env /opt/reactive-resume.env.bak
-    fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball" "latest" "/opt/reactive-resume"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball" "latest" "/opt/reactive-resume"
 
     msg_info "Updating Reactive Resume (Patience)"
     cd /opt/reactive-resume

--- a/frontend/public/json/reactive-resume.json
+++ b/frontend/public/json/reactive-resume.json
@@ -12,7 +12,7 @@
   "documentation": "https://docs.rxresume.org/",
   "website": "https://rxresume.org",
   "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/reactive-resume.webp",
-  "config_path": "/opt/Reactive-Resume/.env",
+  "config_path": "/opt/reactive-resume/.env",
   "description": "A one-of-a-kind resume builder that keeps your privacy in mind. Completely secure, customizable, portable, open-source and free forever.",
   "install_methods": [
     {

--- a/install/reactive-resume-install.sh
+++ b/install/reactive-resume-install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Copyright (c) 2021-2026 community-scripts ORG
-# Author: vhsdream
+# Author: vhsdream | Rewrite: MickLesk (CanbiZ)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
-# Source: https://rxresume.org | Github: https://github.com/lazy-media/Reactive-Resume
+# Source: https://rxresume.org | Github: https://github.com/amruthpillai/reactive-resume
 
 source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
 color
@@ -13,149 +13,106 @@ setting_up_container
 network_check
 update_os
 
+PG_VERSION="16" setup_postgresql
+PG_DB_NAME="reactive_resume" PG_DB_USER="reactive_resume" setup_postgresql_db
+NODE_VERSION="24" NODE_MODULE="pnpm@latest" setup_nodejs
+
 msg_info "Installing Dependencies"
-cd /tmp
-curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio.deb -o minio.deb
-$STD dpkg -i minio.deb
+$STD apt install -y chromium
 msg_ok "Installed Dependencies"
 
-PG_VERSION="16" setup_postgresql
-PG_DB_NAME="rxresume" PG_DB_USER="rxresume" PG_DB_GRANT_SUPERUSER="true" setup_postgresql_db
-NODE_VERSION="24" NODE_MODULE="pnpm@latest" setup_nodejs
-fetch_and_deploy_gh_release "Reactive-Resume" "lazy-media/Reactive-Resume" "tarball"
+fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball"
 
-msg_info "Setting up Reactive-Resume"
-MINIO_PASS=$(openssl rand -base64 48)
-ACCESS_TOKEN=$(openssl rand -base64 48)
-REFRESH_TOKEN=$(openssl rand -base64 48)
-CHROME_TOKEN=$(openssl rand -hex 32)
-TAG=$(curl -fsSL https://api.github.com/repos/browserless/browserless/tags?per_page=1 | grep "name" | awk '{print substr($2, 3, length($2)-4) }')
-cd /opt/Reactive-Resume
-export CI="true"
-export PUPPETEER_SKIP_DOWNLOAD="true"
+msg_info "Building Reactive Resume (Patience)"
+cd /opt/reactive-resume
 export NODE_ENV="production"
-export NEXT_TELEMETRY_DISABLED=1
+export CI="true"
 $STD pnpm install --frozen-lockfile
 $STD pnpm run build
-$STD pnpm run prisma:generate
-msg_ok "Setup Reactive-Resume"
+mkdir -p /opt/reactive-resume/data
+msg_ok "Built Reactive Resume"
 
-msg_info "Installing Browserless (Patience)"
-cd /tmp
-curl -fsSL https://github.com/browserless/browserless/archive/refs/tags/v"$TAG".zip -o v"$TAG".zip
-$STD unzip v"$TAG".zip
-mv browserless-"$TAG" /opt/browserless
-cd /opt/browserless
-$STD npm install
-rm -rf src/routes/{chrome,edge,firefox,webkit}
-$STD node_modules/playwright-core/cli.js install --with-deps chromium
-$STD npm install typescript --save-dev
-$STD npm install esbuild --save-dev
-$STD npm run build
-$STD npm run build:function
-$STD npm prune production
-msg_ok "Installed Browserless"
+msg_info "Configuring Reactive Resume"
+AUTH_SECRET=$(openssl rand -hex 32)
 
-msg_info "Configuring applications"
-mkdir -p /opt/minio
-cat <<EOF >/opt/minio/.env
-MINIO_ROOT_USER="storageadmin"
-MINIO_ROOT_PASSWORD="${MINIO_PASS}"
-MINIO_VOLUMES=/opt/minio
-MINIO_OPTS="--address :9000 --console-address 127.0.0.1:9001"
-EOF
-
-cat <<EOF >/opt/Reactive-Resume/.env
+cat <<EOF >/opt/reactive-resume/.env
+# Reactive Resume v5 Configuration
 NODE_ENV=production
 PORT=3000
-# for use behind a reverse proxy, use your FQDN for PUBLIC_URL and STORAGE_URL
-# To avoid issues when behind a reverse proxy with downloading PDFs, ensure that the 
-# storage path is accessible via a subdomain (i.e storage.yourapp.xyz) or you set your 
-# reverse proxy to properly rewrite the subpath (/rxresume) to point to the service
-# running on port 9000 (minio).
-PUBLIC_URL=http://${LOCAL_IP}:3000
-STORAGE_URL=http://${LOCAL_IP}:9000/rxresume
-DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}?schema=public
-ACCESS_TOKEN_SECRET=${ACCESS_TOKEN}
-REFRESH_TOKEN_SECRET=${REFRESH_TOKEN}
-CHROME_PORT=8080
-CHROME_TOKEN=${CHROME_TOKEN}
-CHROME_URL=ws://localhost:8080
-CHROME_IGNORE_HTTPS_ERRORS=true
-MAIL_FROM=noreply@locahost
-# SMTP_URL=smtp://username:password@smtp.server.mail:587 #
-STORAGE_ENDPOINT=localhost
-STORAGE_PORT=9000
-STORAGE_REGION=us-east-1
-STORAGE_BUCKET=rxresume
-STORAGE_ACCESS_KEY=storageadmin
-STORAGE_SECRET_KEY=${MINIO_PASS}
-STORAGE_USE_SSL=false
-STORAGE_SKIP_BUCKET_CHECK=false
 
-# GitHub (OAuth, Optional)
+# Public URL (change to your FQDN when using a reverse proxy)
+APP_URL=http://${LOCAL_IP}:3000
+
+# Database
+DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}
+
+# Authentication Secret (do not change after initial setup)
+AUTH_SECRET=${AUTH_SECRET}
+
+# Printer (headless Chromium for PDF generation)
+PRINTER_ENDPOINT=http://localhost:9222
+
+# Storage: uses local filesystem (/opt/reactive-resume/data) when S3 is not configured
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+# S3_REGION=us-east-1
+# S3_ENDPOINT=
+# S3_BUCKET=
+# S3_FORCE_PATH_STYLE=false
+
+# Email (optional, logs to console if not configured)
+# SMTP_HOST=
+# SMTP_PORT=465
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=Reactive Resume <noreply@localhost>
+
+# OAuth (optional)
 # GITHUB_CLIENT_ID=
 # GITHUB_CLIENT_SECRET=
-# GITHUB_CALLBACK_URL=http://localhost:5173/api/auth/github/callback
-
-# Google (OAuth, Optional)
 # GOOGLE_CLIENT_ID=
 # GOOGLE_CLIENT_SECRET=
-# GOOGLE_CALLBACK_URL=http://localhost:5173/api/auth/google/callback
-EOF
 
-cat <<EOF >/opt/browserless/.env
-DEBUG=browserless*,-**:verbose
-HOST=localhost
-PORT=8080
-TOKEN=${CHROME_TOKEN}
+# Feature Flags
+# FLAG_DISABLE_SIGNUPS=false
+# FLAG_DISABLE_EMAIL_AUTH=false
 EOF
-rm -f /tmp/v"$TAG".zip
-rm -f /tmp/minio.deb
-msg_ok "Configured applications"
+msg_ok "Configured Reactive Resume"
 
 msg_info "Creating Services"
-mkdir -p /etc/systemd/system/minio.service.d/
-cat <<EOF >/etc/systemd/system/minio.service.d/override.conf
-[Service]
-User=root
-Group=root
-WorkingDirectory=/usr/local/bin
-EnvironmentFile=/opt/minio/.env
-EOF
-
-cat <<EOF >/etc/systemd/system/Reactive-Resume.service
+cat <<EOF >/etc/systemd/system/chromium-printer.service
 [Unit]
-Description=Reactive-Resume Service
-After=network.target postgresql.service minio.service
-Wants=postgresql.service minio.service
+Description=Headless Chromium for Reactive Resume PDF generation
+After=network.target
 
 [Service]
-WorkingDirectory=/opt/Reactive-Resume
-EnvironmentFile=/opt/Reactive-Resume/.env
-ExecStart=/usr/bin/pnpm run start
+Type=simple
+ExecStart=/usr/bin/chromium --headless --disable-gpu --no-sandbox --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
-cat <<EOF >/etc/systemd/system/browserless.service
+cat <<EOF >/etc/systemd/system/reactive-resume.service
 [Unit]
-Description=Browserless service
-After=network.target Reactive-Resume.service
+Description=Reactive Resume
+After=network.target postgresql.service chromium-printer.service
+Wants=postgresql.service chromium-printer.service
 
 [Service]
-WorkingDirectory=/opt/browserless
-EnvironmentFile=/opt/browserless/.env
-ExecStart=/usr/bin/npm run start
-Restart=unless-stopped
+WorkingDirectory=/opt/reactive-resume
+EnvironmentFile=/opt/reactive-resume/.env
+ExecStart=/usr/bin/node .output/server/index.mjs
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
 EOF
 systemctl daemon-reload
-systemctl enable -q --now minio.service Reactive-Resume.service browserless.service
+systemctl enable -q --now chromium-printer.service reactive-resume.service
 msg_ok "Created Services"
 
 motd_ssh


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replaces lazy-media fork with original upstream repo (amruthpillai/reactive-resume). Rewrites install script for v5 architecture:
- TanStack Start / Drizzle ORM single-package build
- Headless Chromium for PDF generation (replaces Browserless)
- Local filesystem storage (removes MinIO dependency)
- Node 24 + pnpm
- Runtime: node .output/server/index.mjs


### _=> Reinstall is needed!_

## 🔗 Related Issue

Fixes #12672, Fixes #11651

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
