### PR TITLE
[Quickfix] Opencloud: ensure correct case for binary

### DIFF
--- a/ct/opencloud.sh
+++ b/ct/opencloud.sh
@@ -41,7 +41,9 @@ function update_script() {
     ensure_dependencies "inotify-tools"
     msg_ok "Updated packages"
 
+    rm -f /usr/bin/{OpenCloud,opencloud}
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "${RELEASE}" "/usr/bin" "opencloud-*-linux-amd64"
+    mv /usr/bin/OpenCloud /usr/bin/opencloud
 
     if ! grep -q 'POSIX_WATCH' /etc/opencloud/opencloud.env; then
       sed -i '/^## External/i ## Uncomment below to enable PosixFS Collaborative Mode\

--- a/install/opencloud-install.sh
+++ b/install/opencloud-install.sh
@@ -64,7 +64,8 @@ $STD sudo -u cool coolconfig set-admin-password --user=admin --password="$COOLPA
 echo "$COOLPASS" >~/.coolpass
 msg_ok "Installed Collabora Online"
 
-fetch_and_deploy_gh_release "opencloud" "opencloud-eu/opencloud" "singlefile" "v5.2.0" "/usr/bin" "opencloud-*-linux-amd64"
+fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "v5.2.0" "/usr/bin" "opencloud-*-linux-amd64"
+mv /usr/bin/OpenCloud /usr/bin/opencloud
 
 msg_info "Configuring OpenCloud"
 DATA_DIR="/var/lib/opencloud"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Turns out I was wrong, and the last 2 versions of Opencloud were fine; the problem was that the binary was being updated as 'OpenCloud' when it should have been 'opencloud'. 🤦‍♂️

## 🔗 Related Issue

Fixes #12062

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
