### PR TITLE
feat: add CopycatWarningToast component for user warnings

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Inter } from "next/font/google";
 import Script from "next/script";
 import React from "react";
 
+import { CopycatWarningToast } from "@/components/copycat-warning-toast";
 import { ThemeProvider } from "@/components/theme-provider";
 import { analytics, basePath } from "@/config/site-config";
 import QueryProvider from "@/components/query-provider";
@@ -116,6 +117,7 @@ export default function RootLayout({
                     <div className="w-full max-w-[1440px] ">
                       {children}
                       <Toaster richColors />
+                      <CopycatWarningToast />
                     </div>
                   </div>
                   <Footer />

--- a/frontend/src/components/copycat-warning-toast.tsx
+++ b/frontend/src/components/copycat-warning-toast.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+const STORAGE_KEY = "copycat-warning-dismissed";
+
+export function CopycatWarningToast() {
+  useEffect(() => {
+    if (typeof window === "undefined")
+      return;
+    if (localStorage.getItem(STORAGE_KEY) === "true")
+      return;
+
+    toast.warning("Beware of copycat sites. Always verify the URL is correct before trusting or running scripts.", {
+      position: "top-center",
+      duration: Number.POSITIVE_INFINITY,
+      closeButton: true,
+      onDismiss: () => localStorage.setItem(STORAGE_KEY, "true"),
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Introduced a new CopycatWarningToast component that displays a warning about copycat sites. The toast appears at the top-center of the screen and can be dismissed, with the dismissal state stored in local storage to prevent reappearing. Integrated the component into the RootLayout for global visibility.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
