### PR TITLE
feat: add NPM-to-PiHole LXC helper script

### DIFF
--- a/ct/npm-to-pihole.sh
+++ b/ct/npm-to-pihole.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/lazarh/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: lazarh
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/CypriotUnknown/npm-to-pihole
+
+APP="NPM-to-PiHole"
+var_tags="${var_tags:-dns;networking}"
+var_cpu="${var_cpu:-1}"
+var_ram="${var_ram:-256}"
+var_disk="${var_disk:-2}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -f /opt/npm-to-pihole/npm-to-pihole.sh ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/npm-to-pihole-install.sh \
+    | bash -s -- --update-only
+  msg_ok "Updated ${APP}"
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Configure the sync settings:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}nano /opt/npm-to-pihole/config${CL}"
+echo -e "${INFO}${YW} Then restart the service:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}systemctl restart npm-to-pihole${CL}"

--- a/frontend/public/json/npm-to-pihole.json
+++ b/frontend/public/json/npm-to-pihole.json
@@ -1,0 +1,52 @@
+{
+  "name": "NPM to Pi-Hole",
+  "slug": "npm-to-pihole",
+  "categories": [
+    5
+  ],
+  "date_created": "2026-03-10",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": null,
+  "documentation": "https://github.com/CypriotUnknown/npm-to-pihole",
+  "website": "https://github.com/community-scripts/ProxmoxVE",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/nginx-proxy-manager.webp",
+  "config_path": "/opt/npm-to-pihole/config",
+  "description": "NPM-to-PiHole is a lightweight sync daemon that automatically keeps Pi-hole local DNS records in sync with Nginx Proxy Manager (NPM) proxy hosts. It reads NPM's proxy host configuration files, extracts server_name entries, and adds or removes the corresponding DNS A records in Pi-hole. This eliminates the need to manually create Pi-hole DNS entries every time a new reverse proxy host is added in NPM. Supports Pi-hole v6 (REST API) and v5 (custom.list).",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/npm-to-pihole.sh",
+      "resources": {
+        "cpu": 1,
+        "ram": 256,
+        "hdd": 2,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": null,
+    "password": null
+  },
+  "notes": [
+    {
+      "text": "After installation, edit `/opt/npm-to-pihole/config` with your NPM proxy host path, Pi-hole URL, Pi-hole password, and target IP, then run `systemctl restart npm-to-pihole`.",
+      "type": "info"
+    },
+    {
+      "text": "The NPM proxy_host directory must be accessible inside this LXC. For NPM in another LXC on the same Proxmox host, add a bind mount in the LXC config: `mp0: /path/to/npm/data/nginx/proxy_host,mp=/mnt/npm/proxy_host`.",
+      "type": "info"
+    },
+    {
+      "text": "For Pi-hole v5, set `PIHOLE_VERSION=5` in the config and bind-mount Pi-hole's `/etc/pihole/custom.list` into this LXC.",
+      "type": "info"
+    },
+    {
+      "text": "The service communicates with Pi-hole over HTTP/HTTPS and accepts self-signed certificates. Only deploy on a trusted internal network.",
+      "type": "warning"
+    }
+  ]
+}

--- a/install/npm-to-pihole-install.sh
+++ b/install/npm-to-pihole-install.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: lazarh
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/CypriotUnknown/npm-to-pihole
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  curl \
+  jq \
+  inotify-tools
+msg_ok "Installed Dependencies"
+
+# Skip full install if called with --update-only (from update_script)
+if [[ "${1}" == "--update-only" ]]; then
+  msg_info "Updating sync script"
+  curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/npm-to-pihole-install.sh \
+    | grep -A9999 '# --- BEGIN SYNC SCRIPT ---' \
+    | grep -B9999 '# --- END SYNC SCRIPT ---' \
+    | grep -v '# --- ' \
+    > /opt/npm-to-pihole/npm-to-pihole.sh
+  chmod +x /opt/npm-to-pihole/npm-to-pihole.sh
+  systemctl restart npm-to-pihole
+  msg_ok "Updated sync script"
+  exit 0
+fi
+
+msg_info "Setting up NPM-to-PiHole"
+mkdir -p /opt/npm-to-pihole
+
+# Write default config (user must edit this)
+cat <<'CONFIGEOF' >/opt/npm-to-pihole/config
+# NPM-to-PiHole Configuration
+# Edit these values before starting the service.
+
+# Path to Nginx Proxy Manager's proxy_host directory.
+# When running NPM in an LXC, set up a Proxmox bind mount:
+#   e.g., mp0: /path/on/host/npm/data/nginx/proxy_host,mp=/mnt/npm/proxy_host
+# For NPM on another host, use NFS or SFTP.
+NPM_PROXY_HOST_DIR="/mnt/npm/proxy_host"
+
+# Pi-hole URL (no trailing slash)
+PIHOLE_URL="http://192.168.1.x"
+
+# Pi-hole admin password (used to authenticate with the API)
+PIHOLE_PASSWORD=""
+
+# IP address that all synced DNS records should point to (typically NPM's IP)
+TARGET_IP="192.168.1.x"
+
+# How often to check for changes, in seconds (default: 300 = 5 minutes)
+SYNC_INTERVAL=300
+
+# Pi-hole API version: 6 (default, uses REST API) or 5 (uses custom.list file via local bind mount)
+PIHOLE_VERSION=6
+CONFIGEOF
+
+msg_ok "Created default config at /opt/npm-to-pihole/config"
+
+# Write the main sync script
+# --- BEGIN SYNC SCRIPT ---
+cat <<'SYNCEOF' >/opt/npm-to-pihole/npm-to-pihole.sh
+#!/usr/bin/env bash
+# NPM-to-PiHole sync daemon
+# Reads Nginx Proxy Manager proxy_host config files and syncs server_name
+# entries to Pi-hole local DNS records.
+
+set -euo pipefail
+
+CONFIG_FILE="/opt/npm-to-pihole/config"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "ERROR: Config file not found at $CONFIG_FILE"
+  exit 1
+fi
+
+# shellcheck source=/opt/npm-to-pihole/config
+source "$CONFIG_FILE"
+
+###############################################################################
+# Pi-hole v6 API helpers (REST API with session token)
+###############################################################################
+
+PIHOLE_TOKEN=""
+
+pihole6_authenticate() {
+  local response
+  response=$(curl -fsSL -X POST \
+    --insecure \
+    -H "Content-Type: application/json" \
+    -d "{\"password\":\"${PIHOLE_PASSWORD}\"}" \
+    "${PIHOLE_URL}/api/auth" 2>/dev/null) || {
+      echo "ERROR: Failed to authenticate with Pi-hole at ${PIHOLE_URL}"
+      return 1
+    }
+  PIHOLE_TOKEN=$(echo "$response" | jq -r '.session.sid // empty')
+  if [[ -z "$PIHOLE_TOKEN" ]]; then
+    echo "ERROR: Authentication failed - check PIHOLE_URL and PIHOLE_PASSWORD"
+    return 1
+  fi
+}
+
+pihole6_get_records() {
+  curl -fsSL --insecure \
+    -H "X-FTL-SID: ${PIHOLE_TOKEN}" \
+    "${PIHOLE_URL}/api/dns/records" 2>/dev/null \
+    | jq -r '.records[] | select(.type == "A" or .type == "CNAME") | .name' 2>/dev/null \
+    || true
+}
+
+pihole6_add_record() {
+  local domain="$1"
+  curl -fsSL --insecure -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-FTL-SID: ${PIHOLE_TOKEN}" \
+    -d "{\"domain\":\"${domain}\",\"ip\":\"${TARGET_IP}\"}" \
+    "${PIHOLE_URL}/api/dns/records" >/dev/null 2>&1
+}
+
+pihole6_remove_record() {
+  local domain="$1"
+  curl -fsSL --insecure -X DELETE \
+    -H "Content-Type: application/json" \
+    -H "X-FTL-SID: ${PIHOLE_TOKEN}" \
+    -d "{\"domain\":\"${domain}\",\"ip\":\"${TARGET_IP}\"}" \
+    "${PIHOLE_URL}/api/dns/records" >/dev/null 2>&1
+}
+
+pihole6_logout() {
+  [[ -z "$PIHOLE_TOKEN" ]] && return
+  curl -fsSL --insecure -X DELETE \
+    -H "X-FTL-SID: ${PIHOLE_TOKEN}" \
+    "${PIHOLE_URL}/api/auth" >/dev/null 2>&1
+  PIHOLE_TOKEN=""
+}
+
+###############################################################################
+# Pi-hole v5 helpers (direct custom.list file manipulation)
+# Requires Pi-hole's /etc/pihole/custom.list to be bind-mounted or local.
+###############################################################################
+
+PIHOLE_CUSTOM_LIST="${PIHOLE_CUSTOM_LIST:-/etc/pihole/custom.list}"
+
+pihole5_get_records() {
+  if [[ ! -f "$PIHOLE_CUSTOM_LIST" ]]; then
+    echo "ERROR: Pi-hole custom.list not found at $PIHOLE_CUSTOM_LIST" >&2
+    return 1
+  fi
+  grep -oP '(?<=\s)\S+$' "$PIHOLE_CUSTOM_LIST" 2>/dev/null || true
+}
+
+pihole5_add_record() {
+  local domain="$1"
+  if ! grep -qF "$domain" "$PIHOLE_CUSTOM_LIST" 2>/dev/null; then
+    echo "${TARGET_IP} ${domain}" >> "$PIHOLE_CUSTOM_LIST"
+    pihole restartdns reload 2>/dev/null || true
+  fi
+}
+
+pihole5_remove_record() {
+  local domain="$1"
+  sed -i "/ ${domain}$/d" "$PIHOLE_CUSTOM_LIST"
+  pihole restartdns reload 2>/dev/null || true
+}
+
+###############################################################################
+# NPM proxy host parsing
+###############################################################################
+
+get_npm_domains() {
+  # Extract server_name entries from all proxy_host .conf files
+  # Returns one domain per line (skips localhost, *.wildcard entries)
+  if [[ ! -d "$NPM_PROXY_HOST_DIR" ]]; then
+    echo "ERROR: NPM proxy host directory not found: $NPM_PROXY_HOST_DIR" >&2
+    return 1
+  fi
+  grep -rh 'server_name' "${NPM_PROXY_HOST_DIR}"/*.conf 2>/dev/null \
+    | grep -oP 'server_name\s+\K[^;]+' \
+    | tr ' ' '\n' \
+    | sed 's/;//g' \
+    | grep -v '^\*\.' \
+    | grep -v '^localhost$' \
+    | grep -v '^_$' \
+    | grep -v '^$' \
+    | sort -u \
+    || true
+}
+
+###############################################################################
+# Sync logic
+###############################################################################
+
+do_sync() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting sync..."
+
+  # Get current NPM domains
+  local npm_domains
+  npm_domains=$(get_npm_domains) || { echo "Failed to read NPM domains"; return 1; }
+
+  if [[ -z "$npm_domains" ]]; then
+    echo "No domains found in NPM proxy hosts (check NPM_PROXY_HOST_DIR)"
+    return 0
+  fi
+
+  # Get current Pi-hole records and compute diff
+  local pihole_domains added=0 removed=0
+
+  if [[ "$PIHOLE_VERSION" == "6" ]]; then
+    pihole6_authenticate || return 1
+    pihole_domains=$(pihole6_get_records)
+
+    # Add missing records
+    while IFS= read -r domain; do
+      if ! echo "$pihole_domains" | grep -qxF "$domain"; then
+        pihole6_add_record "$domain" && echo "  + Added: $domain" && ((added++)) || true
+      fi
+    done <<< "$npm_domains"
+
+    # Remove stale records (only those pointing to TARGET_IP, to avoid touching unrelated records)
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+      if ! echo "$npm_domains" | grep -qxF "$domain"; then
+        pihole6_remove_record "$domain" && echo "  - Removed: $domain" && ((removed++)) || true
+      fi
+    done <<< "$pihole_domains"
+
+    pihole6_logout
+
+  else
+    pihole_domains=$(pihole5_get_records) || return 1
+
+    while IFS= read -r domain; do
+      if ! echo "$pihole_domains" | grep -qxF "$domain"; then
+        pihole5_add_record "$domain" && echo "  + Added: $domain" && ((added++)) || true
+      fi
+    done <<< "$npm_domains"
+
+    while IFS= read -r domain; do
+      [[ -z "$domain" ]] && continue
+      if ! echo "$npm_domains" | grep -qxF "$domain"; then
+        pihole5_remove_record "$domain" && echo "  - Removed: $domain" && ((removed++)) || true
+      fi
+    done <<< "$pihole_domains"
+  fi
+
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] Sync complete. Added: ${added}, Removed: ${removed}"
+}
+
+###############################################################################
+# Main loop
+###############################################################################
+
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] NPM-to-PiHole sync daemon starting..."
+echo "  NPM dir:        $NPM_PROXY_HOST_DIR"
+echo "  Pi-hole URL:    $PIHOLE_URL"
+echo "  Target IP:      $TARGET_IP"
+echo "  Sync interval:  ${SYNC_INTERVAL}s"
+echo "  Pi-hole ver:    v${PIHOLE_VERSION}"
+
+# Run once on start
+do_sync || echo "Initial sync failed - will retry on next interval"
+
+# Then loop on interval
+while true; do
+  sleep "$SYNC_INTERVAL"
+  do_sync || echo "Sync failed - will retry on next interval"
+done
+SYNCEOF
+# --- END SYNC SCRIPT ---
+
+chmod +x /opt/npm-to-pihole/npm-to-pihole.sh
+msg_ok "Created sync script at /opt/npm-to-pihole/npm-to-pihole.sh"
+
+msg_info "Creating Service"
+cat <<'EOF' >/etc/systemd/system/npm-to-pihole.service
+[Unit]
+Description=NPM-to-PiHole DNS Sync Service
+Documentation=https://github.com/community-scripts/ProxmoxVE
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/opt/npm-to-pihole/npm-to-pihole.sh
+Restart=on-failure
+RestartSec=30
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q npm-to-pihole
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## Description

Adds a lightweight LXC container that automatically syncs **Nginx Proxy Manager (NPM)** proxy host entries to **Pi-hole local DNS records**.

This fills a gap: Docker-based solutions exist ([CypriotUnknown/npm-to-pihole](https://github.com/CypriotUnknown/npm-to-pihole), [c00ldude1oo/npm2pihole](https://github.com/c00ldude1oo/npm2pihole)) but there is no Proxmox LXC-native version.

## How it works

1. Reads NPM's `proxy_host/*.conf` nginx config files (via Proxmox bind mount, NFS, etc.)
2. Extracts `server_name` entries from each config
3. Adds/removes matching DNS A records in Pi-hole via API
4. Runs as a systemd service on a configurable interval (default 5 min)

## Pi-hole support

- **v6** (default): REST API with session token (`/api/dns/records`)
- **v5**: direct `custom.list` file manipulation (bind mount required)

## Files changed

- `ct/npm-to-pihole.sh` — container creation script
- `install/npm-to-pihole-install.sh` — installs `curl`, `jq`, `inotify-tools`; writes sync daemon; creates systemd service
- `frontend/public/json/npm-to-pihole.json` — frontend metadata

## Resources

| | |
|---|---|
| CPU | 1 core |
| RAM | 256 MB |
| Disk | 2 GB |
| OS | Debian 13 |

## Configuration

After installation, user edits `/opt/npm-to-pihole/config`:

```bash
NPM_PROXY_HOST_DIR="/mnt/npm/proxy_host"  # bind mount from NPM LXC
PIHOLE_URL="http://192.168.1.x"
PIHOLE_PASSWORD="your-pihole-password"
TARGET_IP="192.168.1.x"                   # NPM's IP
SYNC_INTERVAL=300
PIHOLE_VERSION=6
```

## Checklist

- [x] Follows template structure (`ct/` and `install/` templates used)
- [x] Copyright header with author
- [x] Error handling with `msg_error`, `msg_ok`, `msg_info`
- [x] Uses helper functions from `tools.func` only
- [x] No Docker — bare-metal bash service
- [x] 3 files only (no setup-fork.sh changes included)
- [x] JSON metadata with correct category (5 = DNS/networking, same as Pi-hole)