### PR TITLE
🐞 **Bug fix** Frigate LXC Installer OpenVino Labelmap Fix

### DIFF
--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -218,6 +218,25 @@ else
   msg_warn "OpenVino build failed (CPU may not support required instructions). Frigate will use CPU model."
 fi
 
+msg_info "Building OpenVino Model"
+cd /models
+wget -q http://download.tensorflow.org/models/object_detection/ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz
+$STD tar -zxf ssdlite_mobilenet_v2_coco_2018_05_09.tar.gz --no-same-owner
+if python3 /opt/frigate/docker/main/build_ov_model.py &>/dev/null; then
+  mkdir -p /openvino-model
+  cp /models/ssdlite_mobilenet_v2.xml /openvino-model/
+  cp /models/ssdlite_mobilenet_v2.bin /openvino-model/
+  
+  # Project Standard Fix: Link the labelmap from the python site-packages to /openvino-model
+  # We use a direct python call to avoid hardcoding version-specific paths (3.11 vs 3.12)
+  $STD ln -sf $(python3 -c "import omz_tools; import os; print(os.path.join(omz_tools.__path__[0], 'data/dataset_classes/coco_91cl_bkgr.txt'))") /openvino-model/coco_91cl_bkgr.txt
+  
+  sed -i 's/truck/car/g' /openvino-model/coco_91cl_bkgr.txt
+  msg_ok "Built OpenVino Model"
+else
+  msg_warn "OpenVino build failed (CPU may not support required instructions). Frigate will use CPU model."
+fi
+
 msg_info "Building Frigate Application (Patience)"
 cd /opt/frigate
 $STD pip3 install -r /opt/frigate/docker/main/requirements-dev.txt


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Problem:
On bare-metal (non-Docker) installs using OpenVINO, Frigate fails to initialize the detector because it expects the COCO labelmap to exist at /openvino-model/coco_91cl_bkgr.txt. In this environment, omz_tools installs the labelmap deep within the Python site-packages directory, causing a FileNotFoundError and a permanent 4-second service restart loop.

Changes:

Dynamically locates the omz_tools installation path using Python.

Creates a symbolic link from the library's data folder to the expected /openvino-model/ path.

Ensures the Frigate service can initialize hardware acceleration on the first boot without manual user intervention.

Testing:
Verified on a Debian 12 LXC with Intel iGPU pass-through. Before this change, the service would fail with an Errno 2. After the change, the service initializes the OpenVINO detector successfully and the web UI is accessible.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
