### PR TITLE
fix(pve-privilege-converter): handle already stopped container in manage_states

### DIFF
--- a/tools/pve/pve-privilege-converter.sh
+++ b/tools/pve/pve-privilege-converter.sh
@@ -134,16 +134,20 @@ manage_states() {
   read -rp "Shutdown source and start new container? [Y/n]: " answer
   answer=${answer:-Y}
   if [[ $answer =~ ^[Yy] ]]; then
-    pct shutdown "$CONTAINER_ID"
-    for i in {1..36}; do
-      sleep 5
-      ! pct status "$CONTAINER_ID" | grep -q running && break
-    done
     if pct status "$CONTAINER_ID" | grep -q running; then
-      read -rp "Timeout reached. Force shutdown? [Y/n]: " force
-      if [[ ${force:-Y} =~ ^[Yy] ]]; then
-        pkill -9 -f "lxc-start -F -n $CONTAINER_ID"
+      pct shutdown "$CONTAINER_ID"
+      for i in {1..36}; do
+        sleep 5
+        ! pct status "$CONTAINER_ID" | grep -q running && break
+      done
+      if pct status "$CONTAINER_ID" | grep -q running; then
+        read -rp "Timeout reached. Force shutdown? [Y/n]: " force
+        if [[ ${force:-Y} =~ ^[Yy] ]]; then
+          pkill -9 -f "lxc-start -F -n $CONTAINER_ID"
+        fi
       fi
+    else
+      msg_custom "ℹ️" "\e[36m" "Source container $CONTAINER_ID is already stopped"
     fi
     pct start "$NEW_CONTAINER_ID"
     msg_ok "New container started"


### PR DESCRIPTION
## ✍️ Description

When the source container is already stopped before running the privilege converter script, `pct shutdown` fails with `CT <id> not running` (non-zero exit code). Since the script uses `set -euo pipefail`, this causes immediate termination — the new container is never started, and cleanup/summary steps are skipped.

This fix checks the container status with `pct status` before attempting shutdown. If the container is already stopped, the shutdown step is skipped and the script proceeds to start the new container normally.

### Steps to Reproduce

1. Stop a container (e.g. `pct stop 101`)
2. Run the privilege converter script
3. Complete all steps, choose "Y" when asked to shutdown source and start new container
4. Script exits immediately after `CT 101 not running` — new container is never started

## 🔗 Related Issue

N/A

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.