### PR TITLE
SparkyFitness: install pnpm dependencies from workspace root

### DIFF
--- a/ct/sparkyfitness.sh
+++ b/ct/sparkyfitness.sh
@@ -55,8 +55,9 @@ function update_script() {
     msg_ok "Updated Sparky Fitness Backend"
 
     msg_info "Updating Sparky Fitness Frontend (Patience)"
-    cd /opt/sparkyfitness/SparkyFitnessFrontend
+    cd /opt/sparkyfitness
     $STD pnpm install
+    cd /opt/sparkyfitness/SparkyFitnessFrontend
     $STD pnpm run build
     cp -a /opt/sparkyfitness/SparkyFitnessFrontend/dist/. /var/www/sparkyfitness/
     msg_ok "Updated Sparky Fitness Frontend"

--- a/install/sparkyfitness-install.sh
+++ b/install/sparkyfitness-install.sh
@@ -51,8 +51,9 @@ $STD npm install
 msg_ok "Built Backend"
 
 msg_info "Building Frontend (Patience)"
-cd /opt/sparkyfitness/SparkyFitnessFrontend
+cd /opt/sparkyfitness
 $STD pnpm install
+cd /opt/sparkyfitness/SparkyFitnessFrontend
 $STD pnpm run build
 cp -a /opt/sparkyfitness/SparkyFitnessFrontend/dist/. /var/www/sparkyfitness/
 msg_ok "Built Frontend"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The shared workspace package imports zod but pnpm install was only run in the SparkyFitnessFrontend subdirectory, leaving the shared packages dependencies unresolved. Run pnpm install from the monorepo root to install all workspace dependencies before building the frontend.

## 🔗 Related Issue

Fixes #12748

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
