### PR TITLE
tools.func: correct PATH escaping in ROCm profile script

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4653,8 +4653,8 @@ EOF
   # Environment (PATH + LD_LIBRARY_PATH)
   if [[ -d /opt/rocm ]]; then
     cat <<'ENVEOF' >/etc/profile.d/rocm.sh
-export PATH="\$PATH:/opt/rocm/bin"
-export LD_LIBRARY_PATH="\${LD_LIBRARY_PATH:+\$LD_LIBRARY_PATH:}/opt/rocm/lib"
+export PATH="$PATH:/opt/rocm/bin"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/opt/rocm/lib"
 ENVEOF
     chmod +x /etc/profile.d/rocm.sh
     # Also make available for current session / systemd services


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The heredoc uses a quoted delimiter (ENVEOF) which disables variable expansion, but the content had backslash-escaped dollar signs. This wrote literal backslashes into /etc/profile.d/rocm.sh, causing PATH corruption. Remove the unnecessary backslashes since the quoted heredoc already prevents expansion during write.

## 🔗 Related Issue

Fixes #12755

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
