### PR TITLE
core: validate storage availability when loading defaults

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1185,6 +1185,18 @@ load_vars_file() {
             continue
           fi
           ;;
+        var_container_storage | var_template_storage)
+          # Validate that the storage exists and is active on the current node
+          local _storage_status
+          _storage_status=$(pvesm status 2>/dev/null | awk -v s="$var_val" '$1 == s { print $3 }')
+          if [[ -z "$_storage_status" ]]; then
+            msg_warn "Storage '$var_val' from $file not found on this node, ignoring"
+            continue
+          elif [[ "$_storage_status" == "disabled" ]]; then
+            msg_warn "Storage '$var_val' from $file is disabled on this node, ignoring"
+            continue
+          fi
+          ;;
         esac
       fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When loading var_container_storage / var_template_storage from default.vars or app defaults, validate that the storage actually exists and is active on the current node. In mixed clusters (e.g. LVM-Thin + ZFS hosts), saved defaults from one node type would fail on another because the referenced storage doesn't exist. Now invalid storage values are skipped with a warning, allowing the normal storage selection prompt to appear.

## 🔗 Related Issue

Fixes #12766

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
