### PR TITLE
manyfold: fix incorrect port in upstream requests by forwarding original host

### DIFF
--- a/install/manyfold-install.sh
+++ b/install/manyfold-install.sh
@@ -101,11 +101,14 @@ server {
 
     location /cable {
         proxy_pass http://127.0.0.1:5000;
-        proxy_set_header Host \$host;
+        
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Forwarded-Host \$http_host;
+        proxy_set_header X-Forwarded-Port \$server_port;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade \$http_upgrade;
-        proxy_set_header Connection "Upgrade";
+        proxy_set_header Connection "upgrade";
 
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
@@ -118,7 +121,11 @@ server {
 
     location @rails {
         proxy_pass http://127.0.0.1:5000;
-        proxy_set_header Host \$host;
+        
+        proxy_set_header Host \$http_host;
+        proxy_set_header X-Forwarded-Host \$http_host;
+        proxy_set_header X-Forwarded-Port \$server_port;
+        
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto \$scheme;


### PR DESCRIPTION
## ✍️ Description

Fixes an issue in the Manyfold helper script for Proxmox VE CT containers where the application generates incorrect links when running on a non-default HTTP port.

Manyfold defaults to port `80`, but when the port is changed (e.g. `8081`), nginx forwarded requests without including the port in the `Host` header. As a result, the Rails application generated absolute URLs without the correct port, causing some links to redirect to port `80`. This also prevented certain functionality such as model uploads from working correctly.

The fix ensures nginx forwards the original host and port to the upstream application by using:

* `Host $http_host`
* `X-Forwarded-Host`
* `X-Forwarded-Port`

This allows the application to correctly generate URLs when running behind nginx on a non-standard port.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

* [x] **Self-review completed** – Code follows project standards.
* [x] **Tested thoroughly** – Changes work as expected.
* [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

* [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
* [ ] ✨ **New feature** – Adds new, non-breaking functionality.
* [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
* [ ] 🆕 **New script** – A fully functional and tested script or script set.
* [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
* [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
* [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
