### PR TITLE
feat: add Bitfocus Companion LXC installer

### DIFF
--- a/ct/companion.sh
+++ b/ct/companion.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/glabutis/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: glabutis
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/bitfocus/companion
+
+APP="Companion"
+var_tags="${var_tags:-automation;media}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-8}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+var_keyctl="${var_keyctl:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/companion ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  CURRENT=""
+  [[ -f /opt/companion-config/version.txt ]] && CURRENT=$(cat /opt/companion-config/version.txt)
+
+  RELEASE_JSON=$(curl -fsSL "https://api.bitfocus.io/v1/product/companion/packages?limit=20")
+  LATEST=$(echo "$RELEASE_JSON" | grep -o '"version":"[^"]*","target":"linux-tgz"' | head -1 | awk -F'"' '{print $4}')
+
+  if [[ "$CURRENT" == "$LATEST" ]]; then
+    msg_ok "Already running Bitfocus Companion ${LATEST} — no update needed."
+    exit
+  fi
+
+  ASSET_URL=$(echo "$RELEASE_JSON" | grep -o '"uri":"[^"]*linux-x64[^"]*"' | head -1 | awk -F'"' '{print $4}')
+
+  msg_info "Updating ${APP} to ${LATEST}"
+  systemctl stop companion
+  rm -rf /opt/companion
+  mkdir -p /opt/companion
+  curl -fsSL "$ASSET_URL" -o /tmp/companion.tar.gz
+  tar -xzf /tmp/companion.tar.gz -C /opt/companion --strip-components=1
+  rm -f /tmp/companion.tar.gz
+  chown -R companion:companion /opt/companion
+  systemctl start companion
+  echo "${LATEST}" >/opt/companion-config/version.txt
+  msg_ok "Updated ${APP} to ${LATEST}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8000${CL}"

--- a/install/companion-install.sh
+++ b/install/companion-install.sh
@@ -27,7 +27,7 @@ if [[ -z "$ASSET_URL" ]]; then
   msg_error "Could not locate a Linux x64 release from the Bitfocus API."
   exit 1
 fi
-msg_ok "Found ${APP} ${RELEASE}"
+msg_ok "Found Companion ${RELEASE}"
 
 msg_info "Downloading Bitfocus Companion ${RELEASE}"
 mkdir -p /opt/companion

--- a/install/companion-install.sh
+++ b/install/companion-install.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: glabutis
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/bitfocus/companion
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  libusb-1.0-0
+msg_ok "Installed Dependencies"
+
+msg_info "Fetching Latest Bitfocus Companion Release"
+RELEASE_JSON=$(curl -fsSL "https://api.bitfocus.io/v1/product/companion/packages?limit=20")
+RELEASE=$(echo "$RELEASE_JSON" | grep -o '"version":"[^"]*","target":"linux-tgz"' | head -1 | awk -F'"' '{print $4}')
+ASSET_URL=$(echo "$RELEASE_JSON" | grep -o '"uri":"[^"]*linux-x64[^"]*"' | head -1 | awk -F'"' '{print $4}')
+
+if [[ -z "$ASSET_URL" ]]; then
+  msg_error "Could not locate a Linux x64 release from the Bitfocus API."
+  exit 1
+fi
+msg_ok "Found ${APP} ${RELEASE}"
+
+msg_info "Downloading Bitfocus Companion ${RELEASE}"
+mkdir -p /opt/companion
+curl -fsSL "$ASSET_URL" -o /tmp/companion.tar.gz
+$STD tar -xzf /tmp/companion.tar.gz -C /opt/companion --strip-components=1
+rm -f /tmp/companion.tar.gz
+msg_ok "Downloaded and Extracted Bitfocus Companion ${RELEASE}"
+
+msg_info "Installing udev Rules"
+[[ -f /opt/companion/50-companion-headless.rules ]] && cp /opt/companion/50-companion-headless.rules /etc/udev/rules.d/
+msg_ok "Installed udev Rules"
+
+msg_info "Creating companion User"
+useradd --system --no-create-home --shell /usr/sbin/nologin companion 2>/dev/null || true
+mkdir -p /opt/companion-config
+chown -R companion:companion /opt/companion-config
+chown -R companion:companion /opt/companion
+msg_ok "Created companion User"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/companion.service
+[Unit]
+Description=Bitfocus Companion
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=companion
+ExecStart=/opt/companion/companion_headless.sh --config-dir /opt/companion-config
+WorkingDirectory=/opt/companion
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=companion
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now companion
+msg_ok "Created Service"
+
+echo "${RELEASE}" >/opt/companion-config/version.txt
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## ✍️ Description

Adds a Proxmox VE LXC helper script for [Bitfocus Companion](https://github.com/bitfocus/companion), a powerful broadcast automation and Stream Deck controller used widely in live production environments.

**Notable implementation detail:** Companion v4.x no longer ships Linux binaries via GitHub Releases — downloads are served through the Bitfocus API (`https://api.bitfocus.io/v1/product/companion/packages`). The install and update scripts use this API to fetch the latest `linux-tgz` release.

- Installs headless via `companion_headless.sh` with a dedicated `companion` system user
- Requires `libusb-1.0-0` for USB device (Stream Deck) bindings
- Configures a systemd service with auto-restart
- Supports in-place updates via `update_script()`
- Tested on Proxmox VE 9.1.5 with Debian 12, unprivileged LXC

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Tested on real hardware (PVE 9.1.5) via curl from fork.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [X] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.