### PR TITLE
Patchmon: remove v prefix from pinned version 

### DIFF
--- a/ct/patchmon.sh
+++ b/ct/patchmon.sh
@@ -37,7 +37,7 @@ function update_script() {
   fi
 
   NODE_VERSION="24" setup_nodejs
-  if check_for_gh_release "PatchMon" "PatchMon/PatchMon" "v1.4.2"; then
+  if check_for_gh_release "PatchMon" "PatchMon/PatchMon" "1.4.2"; then
     msg_info "Stopping Service"
     systemctl stop patchmon-server
     msg_ok "Stopped Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
check_for_gh_release expects versions without v prefix (like Immich). fetch_and_deploy_gh_release keeps v1.4.2 as it maps to the git tag.

## 🔗 Related Issue

Fixes #12884

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
