### PR TITLE
core: unify RELEASE variable for check_for_gh_release and fetch_and_deploy

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -109,7 +109,7 @@ EOF
     msg_ok "Image-processing libraries up to date"
   fi
 
-  RELEASE="2.5.6"
+  RELEASE="v2.5.6"
   if check_for_gh_release "Immich" "immich-app/immich" "${RELEASE}"; then
     if [[ $(cat ~/.immich) > "2.5.1" ]]; then
       msg_info "Enabling Maintenance Mode"
@@ -165,7 +165,7 @@ EOF
     )
 
     setup_uv
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v${RELEASE}" "$SRC_DIR"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "${RELEASE}" "$SRC_DIR"
     PNPM_VERSION="$(jq -r '.packageManager | split("@")[1]' ${SRC_DIR}/package.json)"
     NODE_VERSION="24" NODE_MODULE="pnpm@${PNPM_VERSION}" setup_nodejs
 

--- a/ct/nocodb.sh
+++ b/ct/nocodb.sh
@@ -23,16 +23,17 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
+  RELEASE="0.301.1"
   if [[ ! -f /etc/systemd/system/nocodb.service ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if check_for_gh_release "nocodb" "nocodb/nocodb" "0.301.1"; then
+  if check_for_gh_release "nocodb" "nocodb/nocodb" "${RELEASE}"; then
     msg_info "Stopping Service"
     systemctl stop nocodb
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "0.301.1" "/opt/nocodb/" "Noco-linux-x64"
+    fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "${RELEASE}" "/opt/nocodb/" "Noco-linux-x64"
 
     msg_info "Starting Service"
     systemctl start nocodb

--- a/ct/patchmon.sh
+++ b/ct/patchmon.sh
@@ -36,8 +36,9 @@ function update_script() {
     read -r
   fi
 
+  RELEASE="v1.4.2"
   NODE_VERSION="24" setup_nodejs
-  if check_for_gh_release "PatchMon" "PatchMon/PatchMon" "1.4.2"; then
+  if check_for_gh_release "PatchMon" "PatchMon/PatchMon" "${RELEASE}"; then
     msg_info "Stopping Service"
     systemctl stop patchmon-server
     msg_ok "Stopped Service"
@@ -47,7 +48,7 @@ function update_script() {
     cp /opt/patchmon/frontend/.env /opt/frontend.env
     msg_ok "Backup Created"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "PatchMon" "PatchMon/PatchMon" "tarball" "v1.4.2" "/opt/patchmon"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "PatchMon" "PatchMon/PatchMon" "tarball" "${RELEASE}" "/opt/patchmon"
 
     msg_info "Updating PatchMon"
     VERSION=$(get_latest_github_release "PatchMon/PatchMon")

--- a/ct/plant-it.sh
+++ b/ct/plant-it.sh
@@ -23,18 +23,19 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
+  RELEASE="0.10.0"
   if [[ ! -d /opt/plant-it ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
   setup_mariadb
-  if check_for_gh_release "plant-it" "MDeLuise/plant-it"; then
+  if check_for_gh_release "plant-it" "MDeLuise/plant-it" "${RELEASE}"; then
     msg_info "Stopping Service"
     systemctl stop plant-it
     msg_info "Stopped Service"
 
-    USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "plant-it" "MDeLuise/plant-it" "singlefile" "0.10.0" "/opt/plant-it/backend" "server.jar"
-    fetch_and_deploy_gh_release "plant-it-front" "MDeLuise/plant-it" "prebuild" "0.10.0" "/opt/plant-it/frontend" "client.tar.gz"
+    USE_ORIGINAL_FILENAME="true" fetch_and_deploy_gh_release "plant-it" "MDeLuise/plant-it" "singlefile" "${RELEASE}" "/opt/plant-it/backend" "server.jar"
+    fetch_and_deploy_gh_release "plant-it-front" "MDeLuise/plant-it" "prebuild" "${RELEASE}" "/opt/plant-it/frontend" "client.tar.gz"
     msg_warn "Application is updated to latest Web version (v0.10.0). There will be no more updates available."
     msg_warn "Please read: https://github.com/MDeLuise/plant-it/releases/tag/1.0.0"
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2223,6 +2223,35 @@ check_for_gh_release() {
   # Try /latest endpoint for non-pinned versions (most efficient)
   local releases_json="" http_code=""
 
+  # For pinned versions, query the specific release tag directly
+  if [[ -n "$pinned_version_in" ]]; then
+    http_code=$(curl -sSL --max-time 20 -w "%{http_code}" -o /tmp/gh_check.json \
+      -H 'Accept: application/vnd.github+json' \
+      -H 'X-GitHub-Api-Version: 2022-11-28' \
+      "${header_args[@]}" \
+      "https://api.github.com/repos/${source}/releases/tags/${pinned_version_in}" 2>/dev/null) || true
+
+    if [[ "$http_code" == "200" ]] && [[ -s /tmp/gh_check.json ]]; then
+      releases_json="[$(</tmp/gh_check.json)]"
+    elif [[ "$http_code" == "401" ]]; then
+      msg_error "GitHub API authentication failed (HTTP 401)."
+      if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        msg_error "Your GITHUB_TOKEN appears to be invalid or expired."
+      else
+        msg_error "The repository may require authentication. Try: export GITHUB_TOKEN=\"ghp_your_token\""
+      fi
+      rm -f /tmp/gh_check.json
+      return 1
+    elif [[ "$http_code" == "403" ]]; then
+      msg_error "GitHub API rate limit exceeded (HTTP 403)."
+      msg_error "To increase the limit, export a GitHub token before running the script:"
+      msg_error "  export GITHUB_TOKEN=\"ghp_your_token_here\""
+      rm -f /tmp/gh_check.json
+      return 1
+    fi
+    rm -f /tmp/gh_check.json
+  fi
+
   if [[ -z "$pinned_version_in" ]]; then
     http_code=$(curl -sSL --max-time 20 -w "%{http_code}" -o /tmp/gh_check.json \
       -H 'Accept: application/vnd.github+json' \
@@ -2752,7 +2781,7 @@ function fetch_and_deploy_codeberg_release() {
     resp=$(curl --connect-timeout 10 --max-time "${api_timeouts[$attempt]}" -fsSL -w "%{http_code}" -o /tmp/codeberg_rel.json "$api_url") && success=true && break
     ((attempt++))
     if ((attempt < ${#api_timeouts[@]})); then
-      msg_warn "API request timed out after ${api_timeouts[$((attempt-1))]}s, retrying... (attempt $((attempt + 1))/${#api_timeouts[@]})"
+      msg_warn "API request timed out after ${api_timeouts[$((attempt - 1))]}s, retrying... (attempt $((attempt + 1))/${#api_timeouts[@]})"
     fi
   done
 
@@ -3234,7 +3263,7 @@ function fetch_and_deploy_gh_release() {
   local max_retries=${#api_timeouts[@]} retry_delay=2 attempt=1 success=false http_code
 
   while ((attempt <= max_retries)); do
-    http_code=$(curl --connect-timeout 10 --max-time "${api_timeouts[$((attempt-1))]:-240}" -sSL -w "%{http_code}" -o /tmp/gh_rel.json "${header[@]}" "$api_url" 2>/dev/null) || true
+    http_code=$(curl --connect-timeout 10 --max-time "${api_timeouts[$((attempt - 1))]:-240}" -sSL -w "%{http_code}" -o /tmp/gh_rel.json "${header[@]}" "$api_url" 2>/dev/null) || true
     if [[ "$http_code" == "200" ]]; then
       success=true
       break


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Simplify pinned version check: query exact tag directly instead of candidate loop
- Use same RELEASE variable in both check and deploy calls
- immich: use RELEASE='v2.5.6' consistently (remove RELEASE_TAG indirection)
- nocodb/patchmon/plant-it: extract shared RELEASE variable for both functions

## 🔗 Related Issue

Closes #12916

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
