### PR TITLE
Standardize NSAPP names across VM scripts

### DIFF
--- a/vm/archlinux-vm.sh
+++ b/vm/archlinux-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="arch-linux-vm"
+NSAPP="archlinux-vm"
 var_os="arch-linux"
 var_version="n.d."
 

--- a/vm/debian-13-vm.sh
+++ b/vm/debian-13-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="debian13vm"
+NSAPP="debian-13-vm"
 var_os="debian"
 var_version="13"
 

--- a/vm/debian-vm.sh
+++ b/vm/debian-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="debian12vm"
+NSAPP="debian-vm"
 var_os="debian"
 var_version="12"
 

--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -23,7 +23,7 @@ GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 VERSIONS=(stable beta dev)
 METHOD=""
-NSAPP="homeassistant-os"
+NSAPP="haos-vm"
 var_os="homeassistant"
 DISK_SIZE="32G"
 

--- a/vm/mikrotik-routeros.sh
+++ b/vm/mikrotik-routeros.sh
@@ -23,7 +23,7 @@ echo -e "Loading..."
 GEN_MAC=$(echo '00 60 2f'$(od -An -N3 -t xC /dev/urandom) | sed -e 's/ /:/g' | tr '[:lower:]' '[:upper:]')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="mikrotik-router-os"
+NSAPP="mikrotik-routeros"
 var_os="mikrotik"
 var_version=" "
 DISK_SIZE="1G"

--- a/vm/nextcloud-vm.sh
+++ b/vm/nextcloud-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="turnkey-nextcloud"
+NSAPP="nextcloud-vm"
 var_os="turnkey-nextcloud"
 var_version="n.d."
 

--- a/vm/owncloud-vm.sh
+++ b/vm/owncloud-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="turnkey-owncloud-vm"
+NSAPP="owncloud-vm"
 var_os="owncloud"
 var_version="18.0"
 APP="TurnKey ownCloud VM"

--- a/vm/truenas-vm.sh
+++ b/vm/truenas-vm.sh
@@ -23,6 +23,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
+NSAPP="truenas-vm"
 
 YW=$(echo "\033[33m")
 BL=$(echo "\033[36m")

--- a/vm/ubuntu2204-vm.sh
+++ b/vm/ubuntu2204-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="ubuntu-2204-vm"
+NSAPP="ubuntu2204-vm"
 var_os="ubuntu"
 var_version="2204"
 

--- a/vm/ubuntu2404-vm.sh
+++ b/vm/ubuntu2404-vm.sh
@@ -23,7 +23,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="ubuntu-2404-vm"
+NSAPP="ubuntu2404-vm"
 var_os="ubuntu"
 var_version="2404"
 

--- a/vm/ubuntu2504-vm.sh
+++ b/vm/ubuntu2504-vm.sh
@@ -22,7 +22,7 @@ echo -e "\n Loading..."
 GEN_MAC=02:$(openssl rand -hex 5 | awk '{print toupper($0)}' | sed 's/\(..\)/\1:/g; s/.$//')
 RANDOM_UUID="$(cat /proc/sys/kernel/random/uuid)"
 METHOD=""
-NSAPP="ubuntu-2504-vm"
+NSAPP="ubuntu2504-vm"
 var_os="ubuntu"
 var_version="2504"
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Normalize the NSAPP variable values in multiple vm/*.sh scripts for consistent naming (archlinux-vm, debian-13-vm, debian-vm, haos-vm, mikrotik-routeros, nextcloud-vm, owncloud-vm, ubuntu2204-vm, ubuntu2404-vm, ubuntu2504-vm) and add the missing NSAPP entry for truenas-vm. These changes are purely renames to standardize identifiers used by tooling or downstream logic and do not alter other behavior.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
