### PR TITLE
hwaccel: remove ROCm install from AMD APU setup

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4629,9 +4629,6 @@ _setup_amd_apu() {
     $STD apt -y install firmware-amd-graphics 2>/dev/null || true
   fi
 
-  # ROCm compute stack (OpenCL + HIP) - also works for many APUs
-  _setup_rocm "$os_id" "$os_codename"
-
   msg_ok "AMD APU configured"
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
AMD APUs (Radeon 780M/760M/740M and similar "old" integrated graphics) do not benefit from the full ROCm compute stack in LXC containers. ROCm is a multi-GB GPGPU framework primarily designed for discrete AMD GPUs and ML/AI workloads, not for video transcoding with integrated graphics.

For APUs the Mesa VA-API drivers (mesa-va-drivers, mesa-opencl-icd) and firmware (firmware-amd-graphics) provide all the hardware acceleration needed for media tasks. Installing ROCm on top adds ~4GB of packages that frequently fail or time out for this class of hardware.

Discrete AMD GPUs (GPU_TYPE=AMD) are unaffected and still receive ROCm.

## 🔗 Related Issue

Fixes #12951

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
