### PR TITLE
Tautulli: add setuptools<81 constraint to update script

### DIFF
--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -51,6 +51,7 @@ function update_script() {
     $STD source /opt/Tautulli/.venv/bin/activate
     $STD uv pip install -r requirements.txt
     $STD uv pip install pyopenssl
+    $STD uv pip install "setuptools<81"
     msg_ok "Updated Tautulli"
 
     msg_info "Restoring config and database"


### PR DESCRIPTION




<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The update function was missing the setuptools version pin that exists in the install script. Without it, setuptools 82+ gets installed which breaks Tautulli's startup (exit code 1/FAILURE).

## 🔗 Related Issue

Fixes #12950

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
