### PR TITLE
feat: add OpenClaw AI assistant container script

### DIFF
--- a/ct/openclaw.sh
+++ b/ct/openclaw.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: coe0718
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/openclaw/openclaw
+
+source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+
+APP="OpenClaw"
+var_tags="ai;assistant;automation"
+var_cpu="2"
+var_ram="2048"
+var_disk="10"
+var_os="debian"
+var_version="12"
+var_unprivileged="1"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if ! command -v openclaw &>/dev/null; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  INSTALLED=$(npm list -g openclaw --depth=0 2>/dev/null | grep openclaw | awk -F'@' '{print $2}')
+  LATEST=$(npm show openclaw version 2>/dev/null)
+
+  if [[ "${INSTALLED}" == "${LATEST}" ]]; then
+    msg_ok "Already on latest version (${LATEST})"
+    exit
+  fi
+
+  msg_info "Updating ${APP} from ${INSTALLED} to ${LATEST}"
+  $STD npm update -g openclaw
+  msg_ok "Updated ${APP} to ${LATEST}"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed Successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Before first use, run the onboarding wizard inside the container:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}openclaw onboard${CL}"
+echo -e "${INFO}${YW} Once onboarded, access the Control UI at:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:18789${CL}"

--- a/install/openclaw-install.sh
+++ b/install/openclaw-install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021-2025 community-scripts ORG
+# Author: coe0718
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/openclaw/openclaw
+
+source /dev/stdin <<< "$FUNCTIONS_FILE_PATH"
+
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  curl \
+  ca-certificates \
+  gnupg \
+  whiptail
+msg_ok "Installed Dependencies"
+
+msg_info "Setting up Node.js Repository"
+curl -fsSL https://deb.nodesource.com/setup_22.x | bash - &>/dev/null
+msg_ok "Set up Node.js Repository"
+
+msg_info "Installing Node.js"
+$STD apt-get install -y nodejs
+msg_ok "Installed Node.js $(node -v)"
+
+msg_info "Installing ${APP}"
+$STD npm install -g openclaw@latest
+msg_ok "Installed ${APP} $(npm list -g openclaw --depth=0 2>/dev/null | grep openclaw | awk -F'@' '{print $2}')"
+
+msg_info "Creating ${APP} systemd service"
+cat <<EOF >/etc/systemd/system/openclaw.service
+[Unit]
+Description=OpenClaw AI Assistant Gateway
+Documentation=https://docs.openclaw.ai
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/root
+ExecStart=/usr/bin/openclaw gateway start
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+# Service is enabled and started by the setup wizard on first SSH login
+msg_ok "Created ${APP} systemd service"
+
+msg_info "Installing setup wizard"
+curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/openclaw-wizard.sh \
+  -o /usr/local/bin/openclaw-wizard
+chmod +x /usr/local/bin/openclaw-wizard
+ln -sf /usr/local/bin/openclaw-wizard /usr/local/bin/openclaw-setup
+msg_ok "Installed setup wizard at /usr/local/bin/openclaw-wizard"
+
+msg_info "Configuring first-login trigger"
+cat <<'EOF' >>/root/.bashrc
+
+# OpenClaw first-run wizard
+if [[ -z "$OPENCLAW_WIZARD_SKIP" ]] && [[ ! -f /root/.openclaw/.configured ]]; then
+  /usr/local/bin/openclaw-wizard
+fi
+EOF
+msg_ok "Wizard will run automatically on first SSH login"
+
+motd_ssh
+customize

--- a/install/openclaw-wizard.sh
+++ b/install/openclaw-wizard.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# OpenClaw First-Run Setup Wizard
+# Runs automatically on first SSH login, writes config, starts service.
+
+CONFIG_DIR="/root/.openclaw"
+CONFIG_FILE="${CONFIG_DIR}/openclaw.json"
+SENTINEL="${CONFIG_DIR}/.configured"
+SERVICE="openclaw"
+BACKTITLE="OpenClaw Setup Wizard"
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+die() {
+  whiptail --backtitle "$BACKTITLE" --title "Error" --msgbox "$1" 10 60
+  exit 1
+}
+
+check_deps() {
+  for cmd in whiptail openclaw systemctl; do
+    if ! command -v "$cmd" &>/dev/null; then
+      echo "ERROR: '$cmd' is not installed. Cannot run wizard." >&2
+      exit 1
+    fi
+  done
+}
+
+# ──────────────────────────────────────────────
+# Already configured?
+# ──────────────────────────────────────────────
+
+if [[ -f "$SENTINEL" ]]; then
+  echo "OpenClaw is already configured. Run 'openclaw-wizard --reconfigure' to redo setup."
+  exit 0
+fi
+
+if [[ "$1" == "--reconfigure" ]]; then
+  rm -f "$SENTINEL"
+fi
+
+check_deps
+mkdir -p "$CONFIG_DIR"
+
+# ──────────────────────────────────────────────
+# Welcome
+# ──────────────────────────────────────────────
+
+whiptail --backtitle "$BACKTITLE" \
+  --title "Welcome to OpenClaw" \
+  --msgbox "This wizard will configure your OpenClaw AI assistant.\n\nYou will be asked to:\n  • Choose an AI provider\n  • Enter your API key\n  • Connect a messaging platform\n\nPress OK to begin." 15 60
+
+# ──────────────────────────────────────────────
+# Step 1 — AI Provider
+# ──────────────────────────────────────────────
+
+AI_PROVIDER=$(whiptail --backtitle "$BACKTITLE" \
+  --title "Step 1 of 4 — AI Provider" \
+  --menu "Choose your AI provider:" 15 60 3 \
+  "anthropic"  "Anthropic Claude (recommended)" \
+  "openai"     "OpenAI (GPT-4o, o1, etc.)" \
+  "codex"      "OpenAI Codex CLI (ChatGPT subscription)" \
+  3>&1 1>&2 2>&3) || die "Setup cancelled."
+
+# ──────────────────────────────────────────────
+# Step 2 — API Key
+# ──────────────────────────────────────────────
+
+case "$AI_PROVIDER" in
+  anthropic)
+    KEY_LABEL="Anthropic API Key"
+    KEY_HINT="Starts with sk-ant-  •  console.anthropic.com → API Keys"
+    KEY_ENV="ANTHROPIC_API_KEY"
+    ;;
+  openai)
+    KEY_LABEL="OpenAI API Key"
+    KEY_HINT="Starts with sk-  •  platform.openai.com → API Keys"
+    KEY_ENV="OPENAI_API_KEY"
+    ;;
+  codex)
+    KEY_LABEL="OpenAI API Key (for Codex)"
+    KEY_HINT="Starts with sk-  •  platform.openai.com → API Keys"
+    KEY_ENV="OPENAI_API_KEY"
+    ;;
+esac
+
+API_KEY=$(whiptail --backtitle "$BACKTITLE" \
+  --title "Step 2 of 4 — API Key" \
+  --passwordbox "${KEY_LABEL}\n\n${KEY_HINT}" 12 60 \
+  3>&1 1>&2 2>&3) || die "Setup cancelled."
+
+[[ -z "$API_KEY" ]] && die "API key cannot be empty."
+
+# Basic format check
+if [[ "$AI_PROVIDER" == "anthropic" && "$API_KEY" != sk-ant-* ]]; then
+  whiptail --backtitle "$BACKTITLE" --title "Warning" \
+    --yesno "That key doesn't look like an Anthropic key (expected sk-ant-...).\n\nContinue anyway?" 10 60 \
+    || die "Setup cancelled."
+fi
+
+if [[ "$AI_PROVIDER" =~ ^(openai|codex)$ && "$API_KEY" != sk-* ]]; then
+  whiptail --backtitle "$BACKTITLE" --title "Warning" \
+    --yesno "That key doesn't look like an OpenAI key (expected sk-...).\n\nContinue anyway?" 10 60 \
+    || die "Setup cancelled."
+fi
+
+# ──────────────────────────────────────────────
+# Step 3 — Messaging Platform
+# ──────────────────────────────────────────────
+
+PLATFORM=$(whiptail --backtitle "$BACKTITLE" \
+  --title "Step 3 of 4 — Messaging Platform" \
+  --menu "Choose how you'll talk to your assistant:" 15 65 4 \
+  "telegram"  "Telegram (easiest — create a bot via @BotFather)" \
+  "discord"   "Discord (requires a Discord Application & Bot token)" \
+  "whatsapp"  "WhatsApp (requires phone scan on first connect)" \
+  "skip"      "Skip for now — configure manually later" \
+  3>&1 1>&2 2>&3) || die "Setup cancelled."
+
+BOT_TOKEN=""
+PLATFORM_NOTE=""
+
+case "$PLATFORM" in
+  telegram)
+    whiptail --backtitle "$BACKTITLE" --title "Telegram Setup" \
+      --msgbox "To get a Telegram bot token:\n\n  1. Open Telegram and search for @BotFather\n  2. Send /newbot and follow the prompts\n  3. Copy the token it gives you\n\nPress OK when ready." 14 60
+
+    BOT_TOKEN=$(whiptail --backtitle "$BACKTITLE" \
+      --title "Telegram Bot Token" \
+      --passwordbox "Paste your Telegram bot token below:\n\nFormat: 123456789:AABBccDDeeFFgg..." 11 65 \
+      3>&1 1>&2 2>&3) || die "Setup cancelled."
+
+    [[ -z "$BOT_TOKEN" ]] && die "Bot token cannot be empty."
+    PLATFORM_NOTE="Pair your Telegram account by running:\n  openclaw pairing request telegram"
+    ;;
+
+  discord)
+    whiptail --backtitle "$BACKTITLE" --title "Discord Setup" \
+      --msgbox "To get a Discord bot token:\n\n  1. Go to discord.com/developers/applications\n  2. Create a new Application → Bot → Reset Token\n  3. Enable 'Message Content Intent' under Privileged Intents\n  4. Copy the token\n\nPress OK when ready." 16 65
+
+    BOT_TOKEN=$(whiptail --backtitle "$BACKTITLE" \
+      --title "Discord Bot Token" \
+      --passwordbox "Paste your Discord bot token below:" 10 65 \
+      3>&1 1>&2 2>&3) || die "Setup cancelled."
+
+    [[ -z "$BOT_TOKEN" ]] && die "Bot token cannot be empty."
+    PLATFORM_NOTE="Invite your bot to a server, then pair with:\n  openclaw pairing request discord"
+    ;;
+
+  whatsapp)
+    whiptail --backtitle "$BACKTITLE" --title "WhatsApp Setup" \
+      --msgbox "WhatsApp requires a phone scan to link.\n\nAfter the wizard finishes and the service starts,\na QR code will appear in the container logs.\n\nScan it with WhatsApp:\n  Settings → Linked Devices → Link a Device\n\nTo view logs:\n  journalctl -u openclaw -f\n\nPress OK to continue." 16 65
+
+    PLATFORM_NOTE="Check logs for the WhatsApp QR code:\n  journalctl -u openclaw -f"
+    ;;
+
+  skip)
+    whiptail --backtitle "$BACKTITLE" --title "Skipping Messaging" \
+      --msgbox "No messaging platform configured.\n\nYou can add one later by editing:\n  ${CONFIG_FILE}\n\nOr by re-running:\n  openclaw-wizard --reconfigure" 12 60
+    PLATFORM_NOTE="No messaging platform configured yet."
+    ;;
+esac
+
+# ──────────────────────────────────────────────
+# Step 4 — Review & Confirm
+# ──────────────────────────────────────────────
+
+SUMMARY="AI Provider : ${AI_PROVIDER}\nAPI Key     : ${API_KEY:0:8}••••••••••••\nPlatform    : ${PLATFORM}"
+
+whiptail --backtitle "$BACKTITLE" \
+  --title "Step 4 of 4 — Review" \
+  --yesno "Ready to apply the following configuration?\n\n${SUMMARY}\n\nThis will:\n  • Write ${CONFIG_FILE}\n  • Set environment variables\n  • Enable and start the openclaw service" 18 65 \
+  || die "Setup cancelled."
+
+# ──────────────────────────────────────────────
+# Write environment variables
+# ──────────────────────────────────────────────
+
+ENV_FILE="${CONFIG_DIR}/.env"
+cat > "$ENV_FILE" <<EOF
+# OpenClaw environment — sourced by systemd service
+${KEY_ENV}=${API_KEY}
+EOF
+
+if [[ -n "$BOT_TOKEN" ]]; then
+  case "$PLATFORM" in
+    telegram) echo "TELEGRAM_BOT_TOKEN=${BOT_TOKEN}" >> "$ENV_FILE" ;;
+    discord)  echo "DISCORD_BOT_TOKEN=${BOT_TOKEN}" >> "$ENV_FILE" ;;
+  esac
+fi
+
+chmod 600 "$ENV_FILE"
+
+# ──────────────────────────────────────────────
+# Write openclaw.json config
+# ──────────────────────────────────────────────
+
+INTEGRATIONS="{}"
+
+case "$PLATFORM" in
+  telegram)
+    INTEGRATIONS=$(cat <<EOFJSON
+{
+  "telegram": {
+    "enabled": true,
+    "botToken": "${BOT_TOKEN}"
+  }
+}
+EOFJSON
+    )
+    ;;
+  discord)
+    INTEGRATIONS=$(cat <<EOFJSON
+{
+  "discord": {
+    "enabled": true,
+    "botToken": "${BOT_TOKEN}"
+  }
+}
+EOFJSON
+    )
+    ;;
+  whatsapp)
+    INTEGRATIONS=$(cat <<EOFJSON
+{
+  "whatsapp": {
+    "enabled": true
+  }
+}
+EOFJSON
+    )
+    ;;
+esac
+
+cat > "$CONFIG_FILE" <<EOFJSON
+{
+  "provider": "${AI_PROVIDER}",
+  "integrations": ${INTEGRATIONS},
+  "gateway": {
+    "bind": "lan",
+    "port": 18789
+  }
+}
+EOFJSON
+
+chmod 600 "$CONFIG_FILE"
+
+# ──────────────────────────────────────────────
+# Patch systemd service to load the .env file
+# ──────────────────────────────────────────────
+
+SERVICE_FILE="/etc/systemd/system/${SERVICE}.service"
+
+if grep -q "EnvironmentFile" "$SERVICE_FILE" 2>/dev/null; then
+  # Already has EnvironmentFile line — update it
+  sed -i "s|^EnvironmentFile=.*|EnvironmentFile=${ENV_FILE}|" "$SERVICE_FILE"
+else
+  # Insert after [Service]
+  sed -i "/^\[Service\]/a EnvironmentFile=${ENV_FILE}" "$SERVICE_FILE"
+fi
+
+systemctl daemon-reload
+
+# ──────────────────────────────────────────────
+# Enable and start the service
+# ──────────────────────────────────────────────
+
+systemctl enable "$SERVICE" &>/dev/null
+systemctl restart "$SERVICE"
+
+sleep 2
+STATUS=$(systemctl is-active "$SERVICE")
+
+# ──────────────────────────────────────────────
+# Mark as configured
+# ──────────────────────────────────────────────
+
+touch "$SENTINEL"
+
+# ──────────────────────────────────────────────
+# Done!
+# ──────────────────────────────────────────────
+
+IP=$(hostname -I | awk '{print $1}')
+
+if [[ "$STATUS" == "active" ]]; then
+  MSG="✔  OpenClaw is running!\n\nControl UI : http://${IP}:18789\nConfig     : ${CONFIG_FILE}\nLogs       : journalctl -u openclaw -f\n\n"
+else
+  MSG="⚠  OpenClaw service did not start cleanly.\nCheck logs with: journalctl -u openclaw -f\n\n"
+fi
+
+[[ -n "$PLATFORM_NOTE" ]] && MSG="${MSG}Next step:\n  ${PLATFORM_NOTE}\n\n"
+MSG="${MSG}To re-run this wizard: openclaw-wizard --reconfigure"
+
+whiptail --backtitle "$BACKTITLE" \
+  --title "Setup Complete" \
+  --msgbox "$MSG" 20 65


### PR DESCRIPTION
## Description
Adds an LXC container script for OpenClaw — a free, open-source, self-hosted AI assistant gateway that connects to Telegram, Discord, WhatsApp and more, using Anthropic Claude or OpenAI as the AI backend.

Includes a whiptail-based first-run setup wizard that auto-launches on first SSH login and walks the user through AI provider, API key, and messaging platform setup.

## Type of Change
- [x] New application (ct/openclaw.sh + install/openclaw-install.sh)

## Application Details
- **App Name**: OpenClaw
- **Source**: https://github.com/openclaw/openclaw
- **Default OS**: Debian 12
- **Recommended Resources**: 2 CPU, 2GB RAM, 10GB Disk
- **Tags**: ai;assistant;automation
- **Access URL**: http://IP:18789

## Testing
- [ ] Tested on Proxmox VE 8.x
- [ ] Container creation successful
- [ ] Application installation successful
- [ ] Wizard runs on first SSH login
- [ ] Service starts and Control UI is accessible at http://IP:18789

## Checklist
- [x] Script follows repo style guidelines
- [x] ShellCheck reviewed
- [x] No temporary files left after installation
- [x] update_script() function included