### PR TITLE
Termix: add guacd build and systemd integration

### DIFF
--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -56,10 +56,7 @@ function update_script() {
       libavformat-dev
 
     msg_info "Updating Guacamole Server (guacd)"
-    mkdir -p /opt/guacamole-server
-    download_file "https://github.com/apache/guacamole-server/archive/refs/tags/${CHECK_UPDATE_RELEASE}.tar.gz" "/tmp/guacamole-server.tar.gz"
-    tar -xzf /tmp/guacamole-server.tar.gz --strip-components=1 -C /opt/guacamole-server
-    rm -f /tmp/guacamole-server.tar.gz
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "/opt/guacamole-server"
     cd /opt/guacamole-server
     export CPPFLAGS="-Wno-error=deprecated-declarations"
     $STD autoreconf -fi
@@ -67,7 +64,6 @@ function update_script() {
     $STD make
     $STD make install
     $STD ldconfig
-    echo "${CHECK_UPDATE_RELEASE}" >~/.guacd
     cd /opt
     rm -rf /opt/guacamole-server
     msg_ok "Updated Guacamole Server (guacd) to ${CHECK_UPDATE_RELEASE}"

--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -56,7 +56,7 @@ function update_script() {
       libavformat-dev
 
     msg_info "Updating Guacamole Server (guacd)"
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "/opt/guacamole-server"
+    fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "${CHECK_UPDATE_RELEASE}" "/opt/guacamole-server"
     cd /opt/guacamole-server
     export CPPFLAGS="-Wno-error=deprecated-declarations"
     $STD autoreconf -fi

--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -29,10 +29,91 @@ function update_script() {
     exit
   fi
 
+  if check_for_gh_tag "guacd" "apache/guacamole-server"; then
+    msg_info "Stopping guacd"
+    systemctl stop guacd 2>/dev/null || true
+    msg_ok "Stopped guacd"
+
+    ensure_dependencies \
+      libcairo2-dev \
+      libjpeg62-turbo-dev \
+      libpng-dev \
+      libtool-bin \
+      uuid-dev \
+      libvncserver-dev \
+      freerdp3-dev \
+      libssh2-1-dev \
+      libtelnet-dev \
+      libwebsockets-dev \
+      libpulse-dev \
+      libvorbis-dev \
+      libwebp-dev \
+      libssl-dev \
+      libpango1.0-dev \
+      libswscale-dev \
+      libavcodec-dev \
+      libavutil-dev \
+      libavformat-dev
+
+    msg_info "Updating Guacamole Server (guacd)"
+    mkdir -p /opt/guacamole-server
+    download_file "https://github.com/apache/guacamole-server/archive/refs/tags/${CHECK_UPDATE_RELEASE}.tar.gz" "/tmp/guacamole-server.tar.gz"
+    tar -xzf /tmp/guacamole-server.tar.gz --strip-components=1 -C /opt/guacamole-server
+    rm -f /tmp/guacamole-server.tar.gz
+    cd /opt/guacamole-server
+    export CPPFLAGS="-Wno-error=deprecated-declarations"
+    $STD autoreconf -fi
+    $STD ./configure --with-init-dir=/etc/init.d --enable-allow-freerdp-snapshots
+    $STD make
+    $STD make install
+    $STD ldconfig
+    echo "${CHECK_UPDATE_RELEASE}" >~/.guacd
+    cd /opt
+    rm -rf /opt/guacamole-server
+    msg_ok "Updated Guacamole Server (guacd) to ${CHECK_UPDATE_RELEASE}"
+
+    if [[ ! -f /etc/guacamole/guacd.conf ]]; then
+      mkdir -p /etc/guacamole
+      cat <<EOF >/etc/guacamole/guacd.conf
+[server]
+bind_host = 127.0.0.1
+bind_port = 4822
+EOF
+    fi
+
+    if [[ ! -f /etc/systemd/system/guacd.service ]]; then
+      cat <<EOF >/etc/systemd/system/guacd.service
+[Unit]
+Description=Guacamole Proxy Daemon (guacd)
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/guacd start
+ExecStop=/etc/init.d/guacd stop
+ExecReload=/etc/init.d/guacd restart
+PIDFile=/var/run/guacd.pid
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    fi
+
+    if ! grep -q "guacd.service" /etc/systemd/system/termix.service 2>/dev/null; then
+      sed -i '/^After=network.target/s/$/ guacd.service/' /etc/systemd/system/termix.service
+      sed -i '/^\[Unit\]/a Wants=guacd.service' /etc/systemd/system/termix.service
+    fi
+
+    systemctl daemon-reload
+    systemctl enable -q --now guacd
+  fi
+
   if check_for_gh_release "termix" "Termix-SSH/Termix"; then
-    msg_info "Stopping Service"
+    msg_info "Stopping Termix"
     systemctl stop termix
-    msg_ok "Stopped Service"
+    msg_ok "Stopped Termix"
 
     msg_info "Backing up Data"
     cp -r /opt/termix/data /opt/termix_data_backup
@@ -95,16 +176,16 @@ function update_script() {
       sed -i 's|/app/html|/opt/termix/html|g' /etc/nginx/nginx.conf
       sed -i 's|/app/nginx|/opt/termix/nginx|g' /etc/nginx/nginx.conf
       sed -i 's|listen ${PORT};|listen 80;|g' /etc/nginx/nginx.conf
-      
+
       nginx -t && systemctl reload nginx
       msg_ok "Updated Nginx Configuration"
     else
       msg_warn "Nginx configuration not updated. If Termix doesn't work, restore from backup or update manually."
     fi
 
-    msg_info "Starting Service"
+    msg_info "Starting Termix"
     systemctl start termix
-    msg_ok "Started Service"
+    msg_ok "Started Termix"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -43,10 +43,8 @@ msg_ok "Installed Dependencies"
 
 msg_info "Building Guacamole Server (guacd)"
 GUAC_SERVER_VERSION=$(get_latest_gh_tag "apache/guacamole-server")
-mkdir -p /opt/guacamole-server
-download_file "https://github.com/apache/guacamole-server/archive/refs/tags/${GUAC_SERVER_VERSION}.tar.gz" "/tmp/guacamole-server.tar.gz"
-tar -xzf /tmp/guacamole-server.tar.gz --strip-components=1 -C /opt/guacamole-server
-rm -f /tmp/guacamole-server.tar.gz
+CHECK_UPDATE_RELEASE="$GUAC_SERVER_VERSION"
+CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "/opt/guacamole-server"
 cd /opt/guacamole-server
 export CPPFLAGS="-Wno-error=deprecated-declarations"
 $STD autoreconf -fi
@@ -54,7 +52,6 @@ $STD ./configure --with-init-dir=/etc/init.d --enable-allow-freerdp-snapshots
 $STD make
 $STD make install
 $STD ldconfig
-echo "${GUAC_SERVER_VERSION}" >~/.guacd
 cd /opt
 rm -rf /opt/guacamole-server
 msg_ok "Built Guacamole Server (guacd) ${GUAC_SERVER_VERSION}"

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -19,8 +19,45 @@ $STD apt install -y \
   python3 \
   nginx \
   openssl \
-  gettext-base
+  gettext-base \
+  libcairo2-dev \
+  libjpeg62-turbo-dev \
+  libpng-dev \
+  libtool-bin \
+  uuid-dev \
+  libvncserver-dev \
+  freerdp3-dev \
+  libssh2-1-dev \
+  libtelnet-dev \
+  libwebsockets-dev \
+  libpulse-dev \
+  libvorbis-dev \
+  libwebp-dev \
+  libssl-dev \
+  libpango1.0-dev \
+  libswscale-dev \
+  libavcodec-dev \
+  libavutil-dev \
+  libavformat-dev
 msg_ok "Installed Dependencies"
+
+msg_info "Building Guacamole Server (guacd)"
+GUAC_SERVER_VERSION=$(get_latest_gh_tag "apache/guacamole-server")
+mkdir -p /opt/guacamole-server
+download_file "https://github.com/apache/guacamole-server/archive/refs/tags/${GUAC_SERVER_VERSION}.tar.gz" "/tmp/guacamole-server.tar.gz"
+tar -xzf /tmp/guacamole-server.tar.gz --strip-components=1 -C /opt/guacamole-server
+rm -f /tmp/guacamole-server.tar.gz
+cd /opt/guacamole-server
+export CPPFLAGS="-Wno-error=deprecated-declarations"
+$STD autoreconf -fi
+$STD ./configure --with-init-dir=/etc/init.d --enable-allow-freerdp-snapshots
+$STD make
+$STD make install
+$STD ldconfig
+echo "${GUAC_SERVER_VERSION}" >~/.guacd
+cd /opt
+rm -rf /opt/guacamole-server
+msg_ok "Built Guacamole Server (guacd) ${GUAC_SERVER_VERSION}"
 
 NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "termix" "Termix-SSH/Termix"
@@ -74,10 +111,36 @@ systemctl reload nginx
 msg_ok "Configured Nginx"
 
 msg_info "Creating Service"
+mkdir -p /etc/guacamole
+cat <<EOF >/etc/guacamole/guacd.conf
+[server]
+bind_host = 127.0.0.1
+bind_port = 4822
+EOF
+
+cat <<EOF >/etc/systemd/system/guacd.service
+[Unit]
+Description=Guacamole Proxy Daemon (guacd)
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/etc/init.d/guacd start
+ExecStop=/etc/init.d/guacd stop
+ExecReload=/etc/init.d/guacd restart
+PIDFile=/var/run/guacd.pid
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
 cat <<EOF >/etc/systemd/system/termix.service
 [Unit]
 Description=Termix Backend
-After=network.target
+After=network.target guacd.service
+Wants=guacd.service
 
 [Service]
 Type=simple
@@ -92,7 +155,7 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 EOF
-systemctl enable -q --now termix
+systemctl enable -q --now guacd termix
 msg_ok "Created Service"
 
 motd_ssh

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -42,9 +42,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Building Guacamole Server (guacd)"
-GUAC_SERVER_VERSION=$(get_latest_gh_tag "apache/guacamole-server")
-CHECK_UPDATE_RELEASE="$GUAC_SERVER_VERSION"
-CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "/opt/guacamole-server"
+fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "latest" "/opt/guacamole-server"
 cd /opt/guacamole-server
 export CPPFLAGS="-Wno-error=deprecated-declarations"
 $STD autoreconf -fi
@@ -54,7 +52,7 @@ $STD make install
 $STD ldconfig
 cd /opt
 rm -rf /opt/guacamole-server
-msg_ok "Built Guacamole Server (guacd) ${GUAC_SERVER_VERSION}"
+msg_ok "Built Guacamole Server (guacd)"
 
 NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "termix" "Termix-SSH/Termix"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Need #12998 and #13000 before merge

Install and build Apache Guacamole Server (guacd) and integrate it with Termix.

- Added required native dependencies to install/termix-install.sh and build steps to download, compile and install guacd, recording its tag in ~/.guacd.
- Created /etc/guacamole/guacd.conf and a systemd unit for guacd; enabled and started guacd alongside termix, and made termix.service depend on guacd.
- Extended ct/termix.sh update flow to detect guacd GitHub tags, stop guacd, rebuild/install the specified release, add default config/unit files if missing, and enable/start the service.
- Minor messaging tweaks: use "Termix" in stop/start logs.


This ensures guacd is available and managed automatically when installing or updating Termix.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
