### PR TITLE
Plex: restart service after update to apply new version

### DIFF
--- a/ct/plex.sh
+++ b/ct/plex.sh
@@ -79,6 +79,11 @@ function update_script() {
   $STD apt update
   $STD apt install -y plexmediaserver
   msg_ok "Updated Plex Media Server"
+
+  msg_info "Restarting Plex Media Server"
+  systemctl restart plexmediaserver
+  msg_ok "Restarted Plex Media Server"
+
   msg_ok "Updated successfully!"
   exit
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
After apt install updates the plexmediaserver package, the running service needs an explicit restart so the new version is loaded. Without this, users see the update succeed but Plex still shows the old version in the web interface.

## 🔗 Related Issue

Fixes #12993

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
