### PR TITLE
tools: centralize GPU group setup via setup_hwaccel

### DIFF
--- a/install/channels-install.sh
+++ b/install/channels-install.sh
@@ -35,7 +35,6 @@ setup_hwaccel
 msg_info "Installing Channels DVR Server (Patience)"
 cd /opt
 $STD bash <(curl -fsSL https://getchannels.com/dvr/setup.sh)
-sed -i -e 's/^sgx:x:104:$/render:x:104:root/' -e 's/^render:x:106:root$/sgx:x:106:/' /etc/group
 msg_ok "Installed Channels DVR Server"
 
 motd_ssh

--- a/install/emby-install.sh
+++ b/install/emby-install.sh
@@ -13,17 +13,9 @@ setting_up_container
 network_check
 update_os
 
-setup_hwaccel
+setup_hwaccel "emby"
 
 fetch_and_deploy_gh_release "emby" "MediaBrowser/Emby.Releases" "binary"
-
-msg_info "Configuring Emby"
-if [[ "$CTTYPE" == "0" ]]; then
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:root,emby/' -e 's/^render:x:108:root,emby$/ssl-cert:x:108:/' /etc/group
-else
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:emby/' -e 's/^render:x:108:emby$/ssl-cert:x:108:/' /etc/group
-fi
-msg_ok "Configured Emby"
 
 motd_ssh
 customize

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -42,7 +42,7 @@ EOF
 $STD apt update
 msg_ok "Set up Intel® Repositories"
 
-setup_hwaccel
+setup_hwaccel "ollama"
 
 msg_info "Installing Intel® Level Zero"
 # Debian 13+ has newer Level Zero packages in system repos that conflict with Intel repo packages
@@ -89,8 +89,6 @@ msg_info "Creating ollama User and Group"
 if ! id ollama >/dev/null 2>&1; then
   useradd -r -s /usr/sbin/nologin -U -m -d /usr/share/ollama ollama
 fi
-$STD usermod -aG render ollama || true
-$STD usermod -aG video ollama || true
 $STD usermod -aG ollama $(id -u -n)
 msg_ok "Created ollama User and adjusted Groups"
 

--- a/install/plex-install.sh
+++ b/install/plex-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-setup_hwaccel
+setup_hwaccel "plex"
 
 msg_info "Setting Up Plex Media Server Repository"
 setup_deb822_repo \
@@ -26,11 +26,6 @@ msg_ok "Set Up Plex Media Server Repository"
 
 msg_info "Installing Plex Media Server"
 $STD apt install -y plexmediaserver
-if [[ "$CTTYPE" == "0" ]]; then
-  sed -i -e 's/^ssl-cert:x:104:plex$/render:x:104:root,plex/' -e 's/^render:x:108:root$/ssl-cert:x:108:plex/' /etc/group
-else
-  sed -i -e 's/^ssl-cert:x:104:plex$/render:x:104:plex/' -e 's/^render:x:108:$/ssl-cert:x:108:/' /etc/group
-fi
 msg_ok "Installed Plex Media Server"
 
 motd_ssh

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4215,6 +4215,8 @@ function setup_gs() {
 #   - NVIDIA requires matching host driver version
 # ------------------------------------------------------------------------------
 function setup_hwaccel() {
+  local service_user="${1:-}"
+
   # Check if user explicitly disabled GPU in advanced settings
   # ENABLE_GPU is exported from build.func
   if [[ "${ENABLE_GPU:-no}" == "no" ]]; then
@@ -4466,7 +4468,7 @@ function setup_hwaccel() {
   # ═══════════════════════════════════════════════════════════════════════════
   # Device Permissions
   # ═══════════════════════════════════════════════════════════════════════════
-  _setup_gpu_permissions "$in_ct"
+  _setup_gpu_permissions "$in_ct" "$service_user"
 
   cache_installed_version "hwaccel" "1.0"
   msg_ok "Setup Hardware Acceleration"
@@ -5100,6 +5102,7 @@ EOF
 # ══════════════════════════════════════════════════════════════════════════════
 _setup_gpu_permissions() {
   local in_ct="$1"
+  local service_user="${2:-}"
 
   # /dev/dri permissions (Intel/AMD)
   if [[ "$in_ct" == "0" && -d /dev/dri ]]; then
@@ -5165,6 +5168,12 @@ _setup_gpu_permissions() {
   if [[ -e /dev/kfd ]]; then
     chmod 666 /dev/kfd 2>/dev/null || true
     msg_info "AMD ROCm compute device configured"
+  fi
+
+  # Add service user to render and video groups for GPU hardware acceleration
+  if [[ -n "$service_user" ]]; then
+    $STD usermod -aG render "$service_user" 2>/dev/null || true
+    $STD usermod -aG video "$service_user" 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
improve hardware-acceleration setup to centralize service user group management. Install scripts (emby, plex, ollama, channels) now pass a service user to setup_hwaccel (or no user for channels) and have had inline /etc/group sed/usermod tweaks removed. misc/tools.func updated: setup_hwaccel accepts an optional service_user and forwards it to _setup_gpu_permissions, which now adds the service user to render and video groups if provided. This consolidates GPU permission changes in one place and removes duplicated per-service group edits.


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
