### PR TITLE
Refactor: Jellyfin repo, ffmpeg package and symlinks

### DIFF
--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -39,13 +39,13 @@ function update_script() {
     msg_ok "Updated Intel Dependencies"
   fi
 
-  msg_info "Ensuring Jellyfin Repository"
+  msg_info "Setting up Jellyfin Repository"
   setup_deb822_repo \
     "jellyfin" \
     "https://repo.jellyfin.org/jellyfin_team.gpg.key" \
     "https://repo.jellyfin.org/$(get_os_info id)" \
     "$(get_os_info codename)"
-  msg_ok "Ensured Jellyfin Repository"
+  msg_ok "Set up Jellyfin Repository"
 
   msg_info "Updating Jellyfin"
   ensure_dependencies libjemalloc2

--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -39,14 +39,23 @@ function update_script() {
     msg_ok "Updated Intel Dependencies"
   fi
 
+  msg_info "Ensuring Jellyfin Repository"
+  setup_deb822_repo \
+    "jellyfin" \
+    "https://repo.jellyfin.org/jellyfin_team.gpg.key" \
+    "https://repo.jellyfin.org/$(get_os_info id)" \
+    "$(get_os_info codename)"
+  msg_ok "Ensured Jellyfin Repository"
+
   msg_info "Updating Jellyfin"
   ensure_dependencies libjemalloc2
   if [[ ! -f /usr/lib/libjemalloc.so ]]; then
     ln -sf /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so
   fi
-  $STD apt update
   $STD apt -y upgrade
-  $STD apt -y --with-new-pkgs upgrade jellyfin jellyfin-server
+  $STD apt -y --with-new-pkgs upgrade jellyfin jellyfin-server jellyfin-ffmpeg7
+  ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
+  ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
   msg_ok "Updated Jellyfin"
   msg_ok "Updated successfully!"
   exit

--- a/install/jellyfin-install.sh
+++ b/install/jellyfin-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2021-2026 tteck
-# Author: tteck (tteckster)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: MickLesk (CanbiZ)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 # Source: https://jellyfin.org/
 
@@ -14,31 +14,30 @@ network_check
 update_os
 
 msg_custom "ℹ️" "${GN}" "If NVIDIA GPU passthrough is detected, you'll be asked whether to install drivers in the container"
-setup_hwaccel
+setup_hwaccel "jellyfin"
 
-msg_info "Installing Jellyfin"
-VERSION="$(awk -F'=' '/^VERSION_CODENAME=/{ print $NF }' /etc/os-release)"
-if ! dpkg -s libjemalloc2 >/dev/null 2>&1; then
-  $STD apt install -y libjemalloc2
-fi
+msg_info "Installing Dependencies"
+ensure_dependencies libjemalloc2
 if [[ ! -f /usr/lib/libjemalloc.so ]]; then
   ln -sf /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so
 fi
-if [[ ! -d /etc/apt/keyrings ]]; then
-  mkdir -p /etc/apt/keyrings
-fi
-curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key | gpg --dearmor --yes --output /etc/apt/keyrings/jellyfin.gpg
-cat <<EOF >/etc/apt/sources.list.d/jellyfin.sources
-Types: deb
-URIs: https://repo.jellyfin.org/${PCT_OSTYPE}
-Suites: ${VERSION}
-Components: main
-Architectures: amd64
-Signed-By: /etc/apt/keyrings/jellyfin.gpg
-EOF
+msg_ok "Installed Dependencies"
 
-$STD apt update
-$STD apt install -y jellyfin
+msg_info "Setting up Jellyfin Repository"
+setup_deb822_repo \
+  "jellyfin" \
+  "https://repo.jellyfin.org/jellyfin_team.gpg.key" \
+  "https://repo.jellyfin.org/$(get_os_info id)" \
+  "$(get_os_info codename)"
+msg_ok "Set up Jellyfin Repository"
+
+msg_info "Installing Jellyfin"
+$STD apt install -y jellyfin jellyfin-ffmpeg7
+ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
+ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
+msg_ok "Installed Jellyfin"
+
+msg_info "Configuring Jellyfin"
 # Configure log rotation to prevent disk fill (keeps fail2ban compatibility) (PR: #1690 / Issue: #11224)
 cat <<EOF >/etc/logrotate.d/jellyfin
 /var/log/jellyfin/*.log {
@@ -55,12 +54,7 @@ EOF
 chown -R jellyfin:adm /etc/jellyfin
 sleep 10
 systemctl restart jellyfin
-if [[ "$CTTYPE" == "0" ]]; then
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:root,jellyfin/' -e 's/^render:x:108:root,jellyfin$/ssl-cert:x:108:/' /etc/group
-else
-  sed -i -e 's/^ssl-cert:x:104:$/render:x:104:jellyfin/' -e 's/^render:x:108:jellyfin$/ssl-cert:x:108:/' /etc/group
-fi
-msg_ok "Installed Jellyfin"
+msg_ok "Configured Jellyfin"
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Use setup_deb822_repo to add the Jellyfin APT repo (replacing manual keyring/sources handling) and ensure libjemalloc2 in both ct and install scripts. Install jellyfin-ffmpeg7 alongside Jellyfin, create /usr/bin symlinks for ffmpeg and ffprobe, and call setup_hwaccel with "jellyfin".

Waiting for: #13044

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
