### PR TITLE
Podman: replace deprecated commands with Quadlets

### DIFF
--- a/ct/podman-homeassistant.sh
+++ b/ct/podman-homeassistant.sh
@@ -23,7 +23,7 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /etc/systemd/system/homeassistant.service ]]; then
+  if [[ ! -f /etc/containers/systemd/homeassistant.container ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi

--- a/install/podman-homeassistant-install.sh
+++ b/install/podman-homeassistant-install.sh
@@ -45,32 +45,58 @@ systemctl enable -q --now podman.socket
 echo -e 'unqualified-search-registries=["docker.io"]' >>/etc/containers/registries.conf
 msg_ok "Installed Podman"
 
+mkdir -p /etc/containers/systemd
+
 read -r -p "${TAB3}Would you like to add Portainer? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   msg_info "Installing Portainer $PORTAINER_LATEST_VERSION"
   podman volume create portainer_data >/dev/null
-  $STD podman run -d \
-    -p 8000:8000 \
-    -p 9443:9443 \
-    --name=portainer \
-    --restart=always \
-    -v /run/podman/podman.sock:/var/run/docker.sock \
-    -v portainer_data:/data \
-    portainer/portainer-ce:latest
+  cat <<EOF >/etc/containers/systemd/portainer.container
+[Unit]
+Description=Portainer Container
+After=network-online.target
+
+[Container]
+Image=docker.io/portainer/portainer-ce:latest
+ContainerName=portainer
+PublishPort=8000:8000
+PublishPort=9443:9443
+Volume=/run/podman/podman.sock:/var/run/docker.sock
+Volume=portainer_data:/data
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable -q --now portainer
   msg_ok "Installed Portainer $PORTAINER_LATEST_VERSION"
 else
   read -r -p "${TAB3}Would you like to add the Portainer Agent? <y/N> " prompt
   if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
     msg_info "Installing Portainer agent $PORTAINER_AGENT_LATEST_VERSION"
-    podman volume create temp >/dev/null
-    podman volume remove temp >/dev/null
-    $STD podman run -d \
-      -p 9001:9001 \
-      --name portainer_agent \
-      --restart=always \
-      -v /run/podman/podman.sock:/var/run/docker.sock \
-      -v /var/lib/containers/storage/volumes:/var/lib/docker/volumes \
-      portainer/agent
+    cat <<EOF >/etc/containers/systemd/portainer-agent.container
+[Unit]
+Description=Portainer Agent Container
+After=network-online.target
+
+[Container]
+Image=docker.io/portainer/agent:latest
+ContainerName=portainer_agent
+PublishPort=9001:9001
+Volume=/run/podman/podman.sock:/var/run/docker.sock
+Volume=/var/lib/containers/storage/volumes:/var/lib/docker/volumes
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable -q --now portainer-agent
     msg_ok "Installed Portainer Agent $PORTAINER_AGENT_LATEST_VERSION"
   fi
 fi
@@ -81,18 +107,28 @@ msg_ok "Pulled Home Assistant Image"
 
 msg_info "Installing Home Assistant"
 $STD podman volume create hass_config
-$STD podman run -d \
-  --name homeassistant \
-  --restart unless-stopped \
-  -v /dev:/dev \
-  -v hass_config:/config \
-  -v /etc/localtime:/etc/localtime:ro \
-  -v /etc/timezone:/etc/timezone:ro \
-  --net=host \
-  homeassistant/home-assistant:stable
-podman generate systemd \
-  --new --name homeassistant \
-  >/etc/systemd/system/homeassistant.service
+cat <<EOF >/etc/containers/systemd/homeassistant.container
+[Unit]
+Description=Home Assistant Container
+After=network-online.target
+
+[Container]
+Image=docker.io/homeassistant/home-assistant:stable
+ContainerName=homeassistant
+Volume=/dev:/dev
+Volume=hass_config:/config
+Volume=/etc/localtime:/etc/localtime:ro
+Volume=/etc/timezone:/etc/timezone:ro
+Network=host
+
+[Service]
+Restart=always
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target multi-user.target
+EOF
+systemctl daemon-reload
 systemctl enable -q --now homeassistant
 msg_ok "Installed Home Assistant"
 

--- a/install/podman-install.sh
+++ b/install/podman-install.sh
@@ -45,32 +45,58 @@ systemctl enable -q --now podman.socket
 echo -e 'unqualified-search-registries=["docker.io"]' >>/etc/containers/registries.conf
 msg_ok "Installed Podman"
 
+mkdir -p /etc/containers/systemd
+
 read -r -p "${TAB3}Would you like to add Portainer? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
   msg_info "Installing Portainer $PORTAINER_LATEST_VERSION"
   podman volume create portainer_data >/dev/null
-  $STD podman run -d \
-    -p 8000:8000 \
-    -p 9443:9443 \
-    --name=portainer \
-    --restart=always \
-    -v /run/podman/podman.sock:/var/run/docker.sock \
-    -v portainer_data:/data \
-    portainer/portainer-ce:latest
+  cat <<EOF >/etc/containers/systemd/portainer.container
+[Unit]
+Description=Portainer Container
+After=network-online.target
+
+[Container]
+Image=docker.io/portainer/portainer-ce:latest
+ContainerName=portainer
+PublishPort=8000:8000
+PublishPort=9443:9443
+Volume=/run/podman/podman.sock:/var/run/docker.sock
+Volume=portainer_data:/data
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target multi-user.target
+EOF
+  systemctl daemon-reload
+  systemctl enable -q --now portainer
   msg_ok "Installed Portainer $PORTAINER_LATEST_VERSION"
 else
   read -r -p "${TAB3}Would you like to add the Portainer Agent? <y/N> " prompt
   if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
     msg_info "Installing Portainer agent $PORTAINER_AGENT_LATEST_VERSION"
-    podman volume create temp >/dev/null
-    podman volume remove temp >/dev/null
-    $STD podman run -d \
-      -p 9001:9001 \
-      --name portainer_agent \
-      --restart=always \
-      -v /run/podman/podman.sock:/var/run/docker.sock \
-      -v /var/lib/containers/storage/volumes:/var/lib/docker/volumes \
-      portainer/agent
+    cat <<EOF >/etc/containers/systemd/portainer-agent.container
+[Unit]
+Description=Portainer Agent Container
+After=network-online.target
+
+[Container]
+Image=docker.io/portainer/agent:latest
+ContainerName=portainer_agent
+PublishPort=9001:9001
+Volume=/run/podman/podman.sock:/var/run/docker.sock
+Volume=/var/lib/containers/storage/volumes:/var/lib/docker/volumes
+
+[Service]
+Restart=always
+
+[Install]
+WantedBy=default.target multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable -q --now portainer-agent
     msg_ok "Installed Portainer Agent $PORTAINER_AGENT_LATEST_VERSION"
   fi
 fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Replace podman run --restart + podman generate systemd with systemd Quadlet .container unit files in /etc/containers/systemd/
- Affects: Home Assistant, Portainer, Portainer Agent
- Remove workaround temp-volume create/remove for Portainer Agent
- Update install check in ct/podman-homeassistant.sh to reference the Quadlet file instead of the old generated .service file

podman generate systemd is deprecated since Podman 4.4 in favor of Quadlets (podman-systemd.unit(5)). Quadlets are natively integrated into systemd and do not require a running container to generate the unit file.

## 🔗 Related Issue

Closes #13050

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
