### PR TITLE
Tdarr: use curl_with_retry and correct exit code

### DIFF
--- a/ct/tdarr.sh
+++ b/ct/tdarr.sh
@@ -33,12 +33,16 @@ function update_script() {
   $STD apt upgrade -y
   rm -rf /opt/tdarr/Tdarr_Updater
   cd /opt/tdarr
-  RELEASE=$(curl -fsSL https://f000.backblazeb2.com/file/tdarrs/versions.json | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
-  curl -fsSL "$RELEASE" -o Tdarr_Updater.zip
+  RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.json" "-" | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
+  curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
   $STD unzip Tdarr_Updater.zip
   chmod +x Tdarr_Updater
   $STD ./Tdarr_Updater
   rm -rf /opt/tdarr/Tdarr_Updater.zip
+  [[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server ]] || {
+    msg_error "Tdarr_Updater failed — tdarr.io may be blocked by local DNS"
+    exit 250
+  }
   msg_ok "Updated Tdarr"
   msg_ok "Updated successfully!"
   exit

--- a/install/tdarr-install.sh
+++ b/install/tdarr-install.sh
@@ -20,12 +20,15 @@ msg_ok "Installed Dependencies"
 msg_info "Installing Tdarr"
 mkdir -p /opt/tdarr
 cd /opt/tdarr
-RELEASE=$(curl -fsSL https://f000.backblazeb2.com/file/tdarrs/versions.json | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
-curl -fsSL "$RELEASE" -o Tdarr_Updater.zip
+RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.json" "-" | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
+curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
 $STD unzip Tdarr_Updater.zip
 chmod +x Tdarr_Updater
+msg_info "Running Tdarr_Updater (downloading server/node binaries from tdarr.io)"
 $STD ./Tdarr_Updater
 rm -rf /opt/tdarr/Tdarr_Updater.zip
+[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server && -f /opt/tdarr/Tdarr_Node/Tdarr_Node ]] \
+  || fatal "Tdarr_Updater did not download server binaries — tdarr.io may be blocked by local DNS"
 msg_ok "Installed Tdarr"
 
 setup_hwaccel

--- a/install/tdarr-install.sh
+++ b/install/tdarr-install.sh
@@ -24,11 +24,12 @@ RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.jso
 curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
 $STD unzip Tdarr_Updater.zip
 chmod +x Tdarr_Updater
-msg_info "Running Tdarr_Updater (downloading server/node binaries from tdarr.io)"
 $STD ./Tdarr_Updater
 rm -rf /opt/tdarr/Tdarr_Updater.zip
-[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server && -f /opt/tdarr/Tdarr_Node/Tdarr_Node ]] \
-  || fatal "Tdarr_Updater did not download server binaries — tdarr.io may be blocked by local DNS"
+[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server ]] || {
+  msg_error "Tdarr_Updater failed — tdarr.io may be blocked by local DNS"
+  exit 250
+}
 msg_ok "Installed Tdarr"
 
 setup_hwaccel


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Tdarr_Updater downloads the actual server/node binaries from tdarr.io at
runtime. If tdarr.io is blocked by local DNS (e.g. OPNsense OISD blocklists),
the updater exits silently with code 0, leaving no binaries on disk. The
subsequent systemctl enable then fails with 'Operation not permitted' (exit 1)
because the ExecStart paths don't exist.

## 🔗 Related Issue

Fixes #13030

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
