### PR TITLE
core: reorder hwaccel setup and adjust GPU group usermod

### DIFF
--- a/ct/tdarr.sh
+++ b/ct/tdarr.sh
@@ -33,12 +33,16 @@ function update_script() {
   $STD apt upgrade -y
   rm -rf /opt/tdarr/Tdarr_Updater
   cd /opt/tdarr
-  RELEASE=$(curl -fsSL https://f000.backblazeb2.com/file/tdarrs/versions.json | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
-  curl -fsSL "$RELEASE" -o Tdarr_Updater.zip
+  RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.json" "-" | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
+  curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
   $STD unzip Tdarr_Updater.zip
   chmod +x Tdarr_Updater
   $STD ./Tdarr_Updater
   rm -rf /opt/tdarr/Tdarr_Updater.zip
+  [[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server ]] || {
+    msg_error "Tdarr_Updater failed — tdarr.io may be blocked by local DNS"
+    exit 250
+  }
   msg_ok "Updated Tdarr"
   msg_ok "Updated successfully!"
   exit

--- a/install/emby-install.sh
+++ b/install/emby-install.sh
@@ -13,9 +13,9 @@ setting_up_container
 network_check
 update_os
 
-setup_hwaccel "emby"
-
 fetch_and_deploy_gh_release "emby" "MediaBrowser/Emby.Releases" "binary"
+
+setup_hwaccel "emby"
 
 motd_ssh
 customize

--- a/install/jellyfin-install.sh
+++ b/install/jellyfin-install.sh
@@ -14,7 +14,6 @@ network_check
 update_os
 
 msg_custom "ℹ️" "${GN}" "If NVIDIA GPU passthrough is detected, you'll be asked whether to install drivers in the container"
-setup_hwaccel "jellyfin"
 
 msg_info "Installing Dependencies"
 ensure_dependencies libjemalloc2
@@ -36,6 +35,8 @@ $STD apt install -y jellyfin jellyfin-ffmpeg7
 ln -sf /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg
 ln -sf /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe
 msg_ok "Installed Jellyfin"
+
+setup_hwaccel "jellyfin"
 
 msg_info "Configuring Jellyfin"
 # Configure log rotation to prevent disk fill (keeps fail2ban compatibility) (PR: #1690 / Issue: #11224)

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -42,8 +42,6 @@ EOF
 $STD apt update
 msg_ok "Set up Intel® Repositories"
 
-setup_hwaccel "ollama"
-
 msg_info "Installing Intel® Level Zero"
 # Debian 13+ has newer Level Zero packages in system repos that conflict with Intel repo packages
 if is_debian && [[ "$(get_os_version_major)" -ge 13 ]]; then
@@ -91,6 +89,8 @@ if ! id ollama >/dev/null 2>&1; then
 fi
 $STD usermod -aG ollama $(id -u -n)
 msg_ok "Created ollama User and adjusted Groups"
+
+setup_hwaccel "ollama"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/ollama.service

--- a/install/plex-install.sh
+++ b/install/plex-install.sh
@@ -13,8 +13,6 @@ setting_up_container
 network_check
 update_os
 
-setup_hwaccel "plex"
-
 msg_info "Setting Up Plex Media Server Repository"
 setup_deb822_repo \
   "plexmediaserver" \
@@ -27,6 +25,8 @@ msg_ok "Set Up Plex Media Server Repository"
 msg_info "Installing Plex Media Server"
 $STD apt install -y plexmediaserver
 msg_ok "Installed Plex Media Server"
+
+setup_hwaccel "plex"
 
 motd_ssh
 customize

--- a/install/tdarr-install.sh
+++ b/install/tdarr-install.sh
@@ -20,12 +20,15 @@ msg_ok "Installed Dependencies"
 msg_info "Installing Tdarr"
 mkdir -p /opt/tdarr
 cd /opt/tdarr
-RELEASE=$(curl -fsSL https://f000.backblazeb2.com/file/tdarrs/versions.json | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
-curl -fsSL "$RELEASE" -o Tdarr_Updater.zip
+RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.json" "-" | grep -oP '(?<="Tdarr_Updater": ")[^"]+' | grep linux_x64 | head -n 1)
+curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
 $STD unzip Tdarr_Updater.zip
 chmod +x Tdarr_Updater
+msg_info "Running Tdarr_Updater (downloading server/node binaries from tdarr.io)"
 $STD ./Tdarr_Updater
 rm -rf /opt/tdarr/Tdarr_Updater.zip
+[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server && -f /opt/tdarr/Tdarr_Node/Tdarr_Node ]] \
+  || fatal "Tdarr_Updater did not download server binaries — tdarr.io may be blocked by local DNS"
 msg_ok "Installed Tdarr"
 
 setup_hwaccel

--- a/install/tdarr-install.sh
+++ b/install/tdarr-install.sh
@@ -24,11 +24,12 @@ RELEASE=$(curl_with_retry "https://f000.backblazeb2.com/file/tdarrs/versions.jso
 curl_with_retry "$RELEASE" "Tdarr_Updater.zip"
 $STD unzip Tdarr_Updater.zip
 chmod +x Tdarr_Updater
-msg_info "Running Tdarr_Updater (downloading server/node binaries from tdarr.io)"
 $STD ./Tdarr_Updater
 rm -rf /opt/tdarr/Tdarr_Updater.zip
-[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server && -f /opt/tdarr/Tdarr_Node/Tdarr_Node ]] \
-  || fatal "Tdarr_Updater did not download server binaries — tdarr.io may be blocked by local DNS"
+[[ -f /opt/tdarr/Tdarr_Server/Tdarr_Server ]] || {
+  msg_error "Tdarr_Updater failed — tdarr.io may be blocked by local DNS"
+  exit 250
+}
 msg_ok "Installed Tdarr"
 
 setup_hwaccel

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -5213,8 +5213,8 @@ _setup_gpu_permissions() {
 
   # Add service user to render and video groups for GPU hardware acceleration
   if [[ -n "$service_user" ]]; then
-    $STD usermod -aG render "$service_user" 2>/dev/null || true
-    $STD usermod -aG video "$service_user" 2>/dev/null || true
+    usermod -aG render "$service_user" 2>/dev/null || true
+    usermod -aG video "$service_user" 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Move setup_hwaccel invocations in emby, jellyfin, ollama, and plex installers to occur after package installation/configuration so GPU drivers/repos are present before enabling hardware acceleration. Update _setup_gpu_permissions to call usermod directly (remove $STD wrapper) when adding service users to render/video groups. Includes minor whitespace/ordering cleanups in the installer scripts.

## 🔗 Related Issue

Fixes #13071

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
