### PR TITLE
Reactive-Resume: Upgrade Node to 24 and enable Corepack

### DIFF
--- a/ct/reactive-resume.sh
+++ b/ct/reactive-resume.sh
@@ -34,10 +34,14 @@ function update_script() {
     msg_ok "Stopped services"
 
     cp /opt/reactive-resume/.env /opt/reactive-resume.env.bak
+    NODE_VERSION="24" setup_nodejs
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball" "latest" "/opt/reactive-resume"
 
     msg_info "Updating Reactive Resume (Patience)"
     cd /opt/reactive-resume
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    corepack enable
+    corepack prepare --activate
     export CI="true"
     export NODE_ENV="production"
     $STD pnpm install --frozen-lockfile

--- a/install/reactive-resume-install.sh
+++ b/install/reactive-resume-install.sh
@@ -15,7 +15,7 @@ update_os
 
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="reactive_resume" PG_DB_USER="reactive_resume" setup_postgresql_db
-NODE_VERSION="22" NODE_MODULE="pnpm@latest" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 
 msg_info "Installing Dependencies"
 $STD apt install -y chromium
@@ -25,6 +25,9 @@ fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "ta
 
 msg_info "Building Reactive Resume (Patience)"
 cd /opt/reactive-resume
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable
+corepack prepare --activate
 export NODE_ENV="production"
 export CI="true"
 $STD pnpm install --frozen-lockfile


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Bump Node.js from 22 to 24. enable Corepack (with COREPACK_ENABLE_DOWNLOAD_PROMPT=0) and run corepack prepare --activate before running pnpm install

## 🔗 Related Issue

Fixes #13088 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
