### PR TITLE
fix: remove extra backslash to match single quoted here-doc

### DIFF
--- a/install/prometheus-install.sh
+++ b/install/prometheus-install.sh
@@ -36,7 +36,7 @@ ExecStart=/usr/local/bin/prometheus \
     --config.file=/etc/prometheus/prometheus.yml \
     --storage.tsdb.path=/var/lib/prometheus/ \
     --web.listen-address=0.0.0.0:9090
-ExecReload=/bin/kill -HUP \$MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Reloading prometheus fails with the following error
```
Mar 19 22:38:49 prometheus systemd[1]: Reloading prometheus.service - Prometheus...
Mar 19 22:38:49 prometheus kill[5187]: /bin/kill: failed to parse argument: '\$MAINPID'
Mar 19 22:38:49 prometheus systemd[1]: prometheus.service: Control process exited, code=exited, status=1/FAILURE
Mar 19 22:38:49 prometheus systemd[1]: Reload failed for prometheus.service - Prometheus.
```

This comes from this [PR](https://github.com/community-scripts/ProxmoxVE/pull/7093), and especially because of the here-doc change
```diff
- cat <<EOF >/etc/systemd/system/prometheus.service
+ cat <<'EOF' >/etc/systemd/system/prometheus.service
```

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 ~**Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.~
