### PR TITLE
Harden code-server addon install script

### DIFF
--- a/tools/addon/coder-code-server.sh
+++ b/tools/addon/coder-code-server.sh
@@ -89,26 +89,31 @@ VERSION=$(curl -fsSL https://api.github.com/repos/coder/code-server/releases/lat
   awk '{print substr($2, 3, length($2)-4) }')
 
 msg_info "Installing Code-Server v${VERSION}"
+config_path="${HOME}/.config/code-server/config.yaml"
+preexisting_config=false
 
-if [ -f ~/.config/code-server/config.yaml ]; then
-  existing_config=true
+if [ -f "$config_path" ]; then
+  preexisting_config=true
 fi
 
 curl -fOL https://github.com/coder/code-server/releases/download/v"$VERSION"/code-server_"${VERSION}"_amd64.deb &>/dev/null
 dpkg -i code-server_"${VERSION}"_amd64.deb &>/dev/null
 rm -rf code-server_"${VERSION}"_amd64.deb
-mkdir -p ~/.config/code-server/
-systemctl enable -q --now code-server@"$USER"
+mkdir -p "${HOME}/.config/code-server/"
 
-if [ $existing_config = false ]; then
-cat <<EOF >~/.config/code-server/config.yaml
+if [ "$preexisting_config" = false ]; then
+cat <<EOF >"$config_path"
 bind-addr: 0.0.0.0:8680
 auth: none
 password: 
 cert: false
 EOF
 fi
+systemctl enable -q --now code-server@"$USER"
 systemctl restart code-server@"$USER"
+if ! systemctl is-active --quiet code-server@"$USER"; then
+  error_exit "code-server service failed to start."
+fi
 msg_ok "Installed Code-Server v${VERSION} on $hostname"
 
 echo -e "${APP} should be reachable by going to the following URL.


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Refactor the code-server installer to be more robust: introduce a config_path variable and preexisting_config flag, use quoted ${HOME} paths, and only write a default config.yaml when none exists. Move systemctl enable after config creation and add an active check that errors out if the code-server service fails to start. Also tidy up variable quoting and cleanup steps for safer execution.


## 🔗 Related Issue

Fixes #13115 
Fixes #13056

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
