### PR TITLE
fix: correct shell security bugs in core functions

### DIFF
--- a/install/shinobi-install.sh
+++ b/install/shinobi-install.sh
@@ -35,7 +35,7 @@ cd Shinobi
 gitVersionNumber=$(git rev-parse HEAD)
 theDateRightNow=$(date)
 touch version.json
-chmod 777 version.json
+chmod 644 version.json
 echo '{"Product" : "'"Shinobi"'" , "Branch" : "'"master"'" , "Version" : "'"$gitVersionNumber"'" , "Date" : "'"$theDateRightNow"'" , "Repository" : "'"https://gitlab.com/Shinobi-Systems/Shinobi.git"'"}' >version.json
 msg_ok "Cloned Shinobi"
 

--- a/install/tasmoadmin-install.sh
+++ b/install/tasmoadmin-install.sh
@@ -23,7 +23,7 @@ fetch_and_deploy_gh_release "tasmoadmin" "TasmoAdmin/TasmoAdmin" "prebuild" "lat
 msg_info "Configuring TasmoAdmin"
 rm -rf /etc/php/8.4/apache2/conf.d/10-opcache.ini
 chown -R www-data:www-data /var/www/tasmoadmin
-chmod 777 /var/www/tasmoadmin/tmp /var/www/tasmoadmin/data
+chmod 775 /var/www/tasmoadmin/tmp /var/www/tasmoadmin/data
 cat <<EOF >/etc/apache2/sites-available/tasmoadmin.conf
 <VirtualHost *:9999>
 	ServerName tasmoadmin

--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -67,6 +67,7 @@ EOF
 # This function sets up the Container OS by generating the locale, setting the timezone, and checking the network connection
 setting_up_container() {
   msg_info "Setting up Container OS"
+  i=$RETRY_NUM
   while [ $i -gt 0 ]; do
     if [ "$(ip addr show | grep 'inet ' | grep -v '127.0.0.1' | awk '{print $2}' | cut -d'/' -f1)" != "" ]; then
       break

--- a/misc/build.func
+++ b/misc/build.func
@@ -221,15 +221,21 @@ update_motd_ip() {
     local current_hostname="$(hostname)"
     local current_ip="$(hostname -I | awk '{print $1}')"
 
+    # Escape sed replacement special chars: \, &, and the | delimiter
+    local esc_os esc_hostname esc_ip
+    esc_os=$(printf '%s' "$current_os" | sed 's/[\\&|]/\\&/g')
+    esc_hostname=$(printf '%s' "$current_hostname" | sed 's/[\\&|]/\\&/g')
+    esc_ip=$(printf '%s' "$current_ip" | sed 's/[\\&|]/\\&/g')
+
     # Update only if values actually changed
     if ! grep -q "OS:.*$current_os" "$PROFILE_FILE" 2>/dev/null; then
-      sed -i "s|OS:.*|OS: \${GN}$current_os\${CL}\\\"|" "$PROFILE_FILE"
+      sed -i "s|OS:.*|OS: \${GN}${esc_os}\${CL}\\\"|" "$PROFILE_FILE"
     fi
     if ! grep -q "Hostname:.*$current_hostname" "$PROFILE_FILE" 2>/dev/null; then
-      sed -i "s|Hostname:.*|Hostname: \${GN}$current_hostname\${CL}\\\"|" "$PROFILE_FILE"
+      sed -i "s|Hostname:.*|Hostname: \${GN}${esc_hostname}\${CL}\\\"|" "$PROFILE_FILE"
     fi
     if ! grep -q "IP Address:.*$current_ip" "$PROFILE_FILE" 2>/dev/null; then
-      sed -i "s|IP Address:.*|IP Address: \${GN}$current_ip\${CL}\\\"|" "$PROFILE_FILE"
+      sed -i "s|IP Address:.*|IP Address: \${GN}${esc_ip}\${CL}\\\"|" "$PROFILE_FILE"
     fi
   fi
 }
@@ -4078,7 +4084,9 @@ EOF'
   else
     sleep 3
     LANG=${LANG:-en_US.UTF-8}
-    pct exec "$CTID" -- bash -c "sed -i \"/$LANG/ s/^# //\" /etc/locale.gen"
+    local esc_lang
+    esc_lang=$(printf '%s' "$LANG" | sed 's/[\\/.^$*[]/\\&/g')
+    pct exec "$CTID" -- bash -c "sed -i \"/${esc_lang}/ s/^# //\" /etc/locale.gen"
     pct exec "$CTID" -- bash -c "locale_line=\$(grep -v '^#' /etc/locale.gen | grep -E '^[a-zA-Z]' | awk '{print \$1}' | head -n 1) && \
     echo LANG=\$locale_line >/etc/default/locale && \
     locale-gen >/dev/null && \
@@ -4750,6 +4758,10 @@ fix_gpu_gids() {
   # Stop container to update config
   pct stop "$CTID" >/dev/null 2>&1
   sleep 1
+
+  # Validate GIDs are numeric before using in sed replacement
+  [[ "$render_gid" =~ ^[0-9]+$ ]] || { msg_error "Invalid render GID: $render_gid"; return 1; }
+  [[ "$video_gid" =~ ^[0-9]+$ ]] || { msg_error "Invalid video GID: $video_gid"; return 1; }
 
   # Update dev entries with correct GIDs
   sed -i.bak -E "s|(dev[0-9]+: /dev/dri/renderD[0-9]+),gid=[0-9]+|\1,gid=${render_gid}|g" "$LXC_CONFIG"

--- a/misc/install.func
+++ b/misc/install.func
@@ -309,14 +309,14 @@ customize() {
   if [[ "$PASSWORD" == "" ]]; then
     msg_info "Customizing Container"
     GETTY_OVERRIDE="/etc/systemd/system/container-getty@1.service.d/override.conf"
-    mkdir -p $(dirname $GETTY_OVERRIDE)
+    mkdir -p "$(dirname "$GETTY_OVERRIDE")"
     cat <<EOF >$GETTY_OVERRIDE
   [Service]
   ExecStart=
   ExecStart=-/sbin/agetty --autologin root --noclear --keep-baud tty%I 115200,38400,9600 \$TERM
 EOF
     systemctl daemon-reload
-    systemctl restart $(basename $(dirname $GETTY_OVERRIDE) | sed 's/\.d//')
+    systemctl restart "$(basename "$(dirname "$GETTY_OVERRIDE")" | sed 's/\.d//')"
     msg_ok "Customized Container"
   fi
   echo "bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/ct/${app}.sh)\"" >/usr/bin/update

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -5192,7 +5192,7 @@ _setup_gpu_permissions() {
     for nvidia_dev in /dev/nvidia*; do
       [[ -e "$nvidia_dev" ]] && {
         chgrp video "$nvidia_dev" 2>/dev/null || true
-        chmod 666 "$nvidia_dev" 2>/dev/null || true
+        chmod 660 "$nvidia_dev" 2>/dev/null || true
       }
     done
     if [[ -d /dev/nvidia-caps ]]; then
@@ -5200,7 +5200,7 @@ _setup_gpu_permissions() {
       for caps_dev in /dev/nvidia-caps/*; do
         [[ -e "$caps_dev" ]] && {
           chgrp video "$caps_dev" 2>/dev/null || true
-          chmod 666 "$caps_dev" 2>/dev/null || true
+          chmod 660 "$caps_dev" 2>/dev/null || true
         }
       done
     fi
@@ -5217,7 +5217,8 @@ _setup_gpu_permissions() {
 
   # /dev/kfd permissions (AMD ROCm)
   if [[ -e /dev/kfd ]]; then
-    chmod 666 /dev/kfd 2>/dev/null || true
+    chgrp render /dev/kfd 2>/dev/null || true
+    chmod 660 /dev/kfd 2>/dev/null || true
     msg_info "AMD ROCm compute device configured"
   fi
 


### PR DESCRIPTION
## Summary

This PR fixes several shell scripting security and correctness bugs found across the core function files:

- **`misc/alpine-install.func`**: Initialize `$i` to `$RETRY_NUM` before the retry while-loop — variable was previously unbound, causing the network check loop to never execute
- **`misc/install.func`**: Quote command substitutions in `mkdir -p` and `systemctl restart` calls to prevent word splitting on paths with spaces
- **`misc/build.func`**: Escape sed replacement strings for `$current_os`, `$current_hostname`, `$current_ip` (special chars like `&`, `\`, `|` would corrupt the profile file)
- **`misc/build.func`**: Escape `$LANG` before embedding it as a sed regex pattern (prevents regex injection)
- **`misc/build.func`**: Validate `render_gid` and `video_gid` are numeric before using them in sed replacements for LXC config
- **`misc/tools.func`**: Replace `chmod 666` with `chmod 660` on NVIDIA device files and AMD `/dev/kfd`; add `chgrp render` for `/dev/kfd` — GPU devices should not be world-writable
- **`install/shinobi-install.sh`**: Replace `chmod 777` with `chmod 644` on `version.json`
- **`install/tasmoadmin-install.sh`**: Replace `chmod 777` with `chmod 775` on web app `tmp`/`data` directories (already owned by `www-data`)

## Test plan

- [ ] Verify Alpine container setup completes the network retry loop correctly
- [ ] Verify container customization works when `PASSWORD` is unset
- [ ] Verify profile update works with OS names/hostnames containing special characters
- [ ] Verify GPU passthrough still works with `chmod 660` (service user must be in `video`/`render` groups — already handled at line ~5225)
- [ ] Verify Shinobi install completes successfully
- [ ] Verify TasmoAdmin install and web app write access work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)