### PR TITLE
Frigate: use correct CPU model fallback path

### DIFF
--- a/install/frigate-install.sh
+++ b/install/frigate-install.sh
@@ -310,7 +310,7 @@ else
 ffmpeg:
   hwaccel_args: auto
 model:
-  path: /cpu_model.tflite
+  path: /models/cpu_model.tflite
 EOF
 fi
 msg_ok "Configured Frigate"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When OpenVino build fails, the fallback config referenced /cpu_model.tflite but the model is downloaded to /models/cpu_model.tflite. This path mismatch caused: ValueError: Could not open '/cpu_model.tflite'

## 🔗 Related Issue

Fixes #13141

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
