### PR TITLE
Anytype-server: wait for MongoDB readiness before rs.initiate()

### DIFF
--- a/install/anytype-server-install.sh
+++ b/install/anytype-server-install.sh
@@ -22,7 +22,12 @@ replication:
   replSetName: "rs0"
 EOF
 systemctl restart mongod
-sleep 3
+for i in $(seq 1 30); do
+  if mongosh --quiet --eval "db.adminCommand('ping')" &>/dev/null; then
+    break
+  fi
+  sleep 2
+done
 $STD mongosh --eval 'rs.initiate({_id: "rs0", members: [{_id: 0, host: "127.0.0.1:27017"}]})'
 msg_ok "Configured MongoDB Replica Set"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replace fixed 3-second sleep with a proper readiness loop (up to 60s) that polls MongoDB via ping before attempting replica set initiation. The previous sleep was insufficient on slower systems, causing 'MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017'.

## 🔗 Related Issue

Fixes #13136

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
