### PR TITLE
Adventurelog: pin DRF <3.15 to fix coreapi module removal

### DIFF
--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -56,6 +56,7 @@ function update_script() {
     fi
     $STD .venv/bin/python -m pip install --upgrade pip
     $STD .venv/bin/python -m pip install -r requirements.txt
+    $STD .venv/bin/python -m pip install 'djangorestframework<3.15'
     $STD .venv/bin/python -m manage collectstatic --noinput
     $STD .venv/bin/python -m manage migrate
 

--- a/install/adventurelog-install.sh
+++ b/install/adventurelog-install.sh
@@ -62,6 +62,7 @@ $STD uv venv --clear /opt/adventurelog/backend/server/.venv
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m ensurepip --upgrade
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m pip install --upgrade pip
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m pip install -r requirements.txt
+$STD /opt/adventurelog/backend/server/.venv/bin/python -m pip install 'djangorestframework<3.15'
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m manage collectstatic --noinput
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m manage migrate
 $STD /opt/adventurelog/backend/server/.venv/bin/python -m manage download-countries


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
DRF 3.15 removed rest_framework.schemas.coreapi which AdventureLog still references. Pin to <3.15 until upstream fixes it. 

I create an issue tomorrow at adventurelog

## 🔗 Related Issue

Fixes #13190

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
