### PR TITLE
iSponsorblockTV: add AVX CPU check before installation

### DIFF
--- a/install/isponsorblocktv-install.sh
+++ b/install/isponsorblocktv-install.sh
@@ -13,6 +13,11 @@ setting_up_container
 network_check
 update_os
 
+if ! grep -q ' avx ' /proc/cpuinfo 2>/dev/null; then
+  msg_error "CPU does not support AVX instructions (required by iSponsorBlockTV/PyApp)"
+  exit 106
+fi
+
 fetch_and_deploy_gh_release "isponsorblocktv" "dmunozv04/iSponsorBlockTV" "singlefile" "latest" "/opt/isponsorblocktv" "iSponsorBlockTV-x86_64-linux"
 
 msg_info "Setting up iSponsorBlockTV"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
PyApp requires AVX support. CPUs without AVX (e.g. Intel N3160) crash with SIGILL. Exit early with clear error message. 


## 🔗 Related Issue

Fixes #13191

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
