### PR TITLE
Refactor: nginxproxymanager update and OpenResty flow

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -34,6 +34,7 @@ function update_script() {
     exit
   fi
 
+  # ── Node.js upgrade if needed ──────────────────────────────────────────
   if command -v node &>/dev/null; then
     CURRENT_NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
     if [[ "$CURRENT_NODE_VERSION" != "22" ]]; then
@@ -49,41 +50,28 @@ function update_script() {
 
   NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
 
-  RELEASE=$(get_latest_github_release "NginxProxyManager/nginx-proxy-manager")
-
-  CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nginxproxymanager" "NginxProxyManager/nginx-proxy-manager" "tarball" "v${RELEASE}" "/opt/nginxproxymanager"
-
-  msg_info "Stopping Services"
-  systemctl stop openresty
-  systemctl stop npm
-  msg_ok "Stopped Services"
-
-  msg_info "Cleaning old files"
-  $STD rm -rf /app \
-    /var/www/html \
-    /etc/nginx \
-    /var/log/nginx \
-    /var/lib/nginx \
-    /var/cache/nginx
-  msg_ok "Cleaned old files"
-
-  msg_info "Migrating to OpenResty from source"
-  rm -f /etc/apt/trusted.gpg.d/openresty-archive-keyring.gpg /etc/apt/trusted.gpg.d/openresty.gpg
-  rm -f /etc/apt/sources.list.d/openresty.list /etc/apt/sources.list.d/openresty.sources
-  if dpkg -l openresty &>/dev/null; then
+  # ── Migrate from deb-packaged OpenResty to source-compiled ─────────────
+  if dpkg -s openresty &>/dev/null 2>&1; then
+    msg_info "Migrating from packaged OpenResty to source"
+    rm -f /etc/apt/trusted.gpg.d/openresty-archive-keyring.gpg /etc/apt/trusted.gpg.d/openresty.gpg
+    rm -f /etc/apt/sources.list.d/openresty.list /etc/apt/sources.list.d/openresty.sources
     $STD apt remove -y openresty
     $STD apt autoremove -y
+    rm -f ~/.openresty
+    msg_ok "Migrated from packaged OpenResty to source"
   fi
+
+  # ── OpenResty: build dependencies (Debian 13+ needs libpcre2-dev) ──────
   local pcre_pkg="libpcre3-dev"
   if grep -qE 'VERSION_ID="1[3-9]"' /etc/os-release 2>/dev/null; then
     pcre_pkg="libpcre2-dev"
   fi
   $STD apt install -y build-essential "$pcre_pkg" libssl-dev zlib1g-dev
-  msg_ok "Migrated to OpenResty from source"
 
-  CLEAN_INSTALL=1 fetch_and_deploy_gh_release "openresty" "openresty/openresty" "prebuild" "latest" "/opt/openresty" "openresty-*.tar.gz"
+  # ── OpenResty: check & update ──────────────────────────────────────────
+  if check_for_gh_release "openresty" "openresty/openresty"; then
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "openresty" "openresty/openresty" "prebuild" "${CHECK_UPDATE_RELEASE}" "/opt/openresty" "openresty-*.tar.gz"
 
-  if [[ -d /opt/openresty ]]; then
     msg_info "Building OpenResty"
     cd /opt/openresty
     $STD ./configure \
@@ -114,75 +102,102 @@ ExecStart=/usr/local/openresty/nginx/sbin/nginx -g 'daemon off;'
 WantedBy=multi-user.target
 EOF
     systemctl daemon-reload
+    systemctl restart openresty
     msg_ok "Built OpenResty"
   fi
 
-  msg_info "Setting up Environment"
-  ln -sf /usr/bin/python3 /usr/bin/python
-  ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx
-  ln -sf /usr/local/openresty/nginx/ /etc/nginx
-  sed -i "0,/\"version\": \"[^\"]*\"/s|\"version\": \"[^\"]*\"|\"version\": \"$RELEASE\"|" /opt/nginxproxymanager/backend/package.json
-  sed -i "0,/\"version\": \"[^\"]*\"/s|\"version\": \"[^\"]*\"|\"version\": \"$RELEASE\"|" /opt/nginxproxymanager/frontend/package.json
-  sed -i 's+^daemon+#daemon+g' /opt/nginxproxymanager/docker/rootfs/etc/nginx/nginx.conf
-  NGINX_CONFS=$(find /opt/nginxproxymanager -type f -name "*.conf")
-  for NGINX_CONF in $NGINX_CONFS; do
-    sed -i 's+include conf.d+include /etc/nginx/conf.d+g' "$NGINX_CONF"
-  done
-
-  mkdir -p /var/www/html /etc/nginx/logs
-  cp -r /opt/nginxproxymanager/docker/rootfs/var/www/html/* /var/www/html/
-  cp -r /opt/nginxproxymanager/docker/rootfs/etc/nginx/* /etc/nginx/
-  cp /opt/nginxproxymanager/docker/rootfs/etc/letsencrypt.ini /etc/letsencrypt.ini
-  cp /opt/nginxproxymanager/docker/rootfs/etc/logrotate.d/nginx-proxy-manager /etc/logrotate.d/nginx-proxy-manager
-  ln -sf /etc/nginx/nginx.conf /etc/nginx/conf/nginx.conf
-  rm -f /etc/nginx/conf.d/dev.conf
-
-  mkdir -p /tmp/nginx/body \
-    /run/nginx \
-    /data/nginx \
-    /data/custom_ssl \
-    /data/logs \
-    /data/access \
-    /data/nginx/default_host \
-    /data/nginx/default_www \
-    /data/nginx/proxy_host \
-    /data/nginx/redirection_host \
-    /data/nginx/stream \
-    /data/nginx/dead_host \
-    /data/nginx/temp \
-    /var/lib/nginx/cache/public \
-    /var/lib/nginx/cache/private \
-    /var/cache/nginx/proxy_temp
-
-  chmod -R 777 /var/cache/nginx
-  chown root /tmp/nginx
-
-  echo resolver "$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf);" >/etc/nginx/conf.d/include/resolvers.conf
-
-  if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]; then
-    $STD openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/O=Nginx Proxy Manager/OU=Dummy Certificate/CN=localhost" -keyout /data/nginx/dummykey.pem -out /data/nginx/dummycert.pem
+  # ── Certbot: always update ─────────────────────────────────────────────
+  if [ -d /opt/certbot ]; then
+    msg_info "Updating Certbot"
+    $STD /opt/certbot/bin/pip install --upgrade pip setuptools wheel
+    $STD /opt/certbot/bin/pip install --upgrade certbot certbot-dns-cloudflare
+    msg_ok "Updated Certbot"
   fi
 
-  mkdir -p /app/frontend/images
-  cp -r /opt/nginxproxymanager/backend/* /app
-  msg_ok "Set up Environment"
+  # ── NPM: check & update ───────────────────────────────────────────────
+  if check_for_gh_release "nginxproxymanager" "NginxProxyManager/nginx-proxy-manager"; then
+    msg_info "Stopping Services"
+    systemctl stop openresty
+    systemctl stop npm
+    msg_ok "Stopped Services"
 
-  msg_info "Building Frontend"
-  export NODE_OPTIONS="--max_old_space_size=2048 --openssl-legacy-provider"
-  cd /opt/nginxproxymanager/frontend
-  # Replace node-sass with sass in package.json before installation
-  sed -E -i 's/"node-sass" *: *"([^"]*)"/"sass": "\1"/g' package.json
-  $STD yarn install --network-timeout 600000
-  $STD yarn locale-compile
-  $STD yarn build
-  cp -r /opt/nginxproxymanager/frontend/dist/* /app/frontend
-  cp -r /opt/nginxproxymanager/frontend/public/images/* /app/frontend/images
-  msg_ok "Built Frontend"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nginxproxymanager" "NginxProxyManager/nginx-proxy-manager" "tarball" "${CHECK_UPDATE_RELEASE}" "/opt/nginxproxymanager"
 
-  msg_info "Initializing Backend"
-  rm -rf /app/config/default.json
-  if [ ! -f /app/config/production.json ]; then
-    cat <<'EOF' >/app/config/production.json
+    msg_info "Cleaning old files"
+    $STD rm -rf /app \
+      /var/www/html \
+      /etc/nginx \
+      /var/log/nginx \
+      /var/lib/nginx \
+      /var/cache/nginx
+    msg_ok "Cleaned old files"
+
+    local RELEASE="${CHECK_UPDATE_RELEASE#v}"
+    msg_info "Setting up Environment"
+    ln -sf /usr/bin/python3 /usr/bin/python
+    ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/sbin/nginx
+    ln -sf /usr/local/openresty/nginx/ /etc/nginx
+    sed -i "0,/\"version\": \"[^\"]*\"/s|\"version\": \"[^\"]*\"|\"version\": \"$RELEASE\"|" /opt/nginxproxymanager/backend/package.json
+    sed -i "0,/\"version\": \"[^\"]*\"/s|\"version\": \"[^\"]*\"|\"version\": \"$RELEASE\"|" /opt/nginxproxymanager/frontend/package.json
+    sed -i 's+^daemon+#daemon+g' /opt/nginxproxymanager/docker/rootfs/etc/nginx/nginx.conf
+    NGINX_CONFS=$(find /opt/nginxproxymanager -type f -name "*.conf")
+    for NGINX_CONF in $NGINX_CONFS; do
+      sed -i 's+include conf.d+include /etc/nginx/conf.d+g' "$NGINX_CONF"
+    done
+
+    mkdir -p /var/www/html /etc/nginx/logs
+    cp -r /opt/nginxproxymanager/docker/rootfs/var/www/html/* /var/www/html/
+    cp -r /opt/nginxproxymanager/docker/rootfs/etc/nginx/* /etc/nginx/
+    cp /opt/nginxproxymanager/docker/rootfs/etc/letsencrypt.ini /etc/letsencrypt.ini
+    cp /opt/nginxproxymanager/docker/rootfs/etc/logrotate.d/nginx-proxy-manager /etc/logrotate.d/nginx-proxy-manager
+    ln -sf /etc/nginx/nginx.conf /etc/nginx/conf/nginx.conf
+    rm -f /etc/nginx/conf.d/dev.conf
+
+    mkdir -p /tmp/nginx/body \
+      /run/nginx \
+      /data/nginx \
+      /data/custom_ssl \
+      /data/logs \
+      /data/access \
+      /data/nginx/default_host \
+      /data/nginx/default_www \
+      /data/nginx/proxy_host \
+      /data/nginx/redirection_host \
+      /data/nginx/stream \
+      /data/nginx/dead_host \
+      /data/nginx/temp \
+      /var/lib/nginx/cache/public \
+      /var/lib/nginx/cache/private \
+      /var/cache/nginx/proxy_temp
+
+    chmod -R 777 /var/cache/nginx
+    chown root /tmp/nginx
+
+    echo resolver "$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print ($2 ~ ":")? "["$2"]": $2}' /etc/resolv.conf);" >/etc/nginx/conf.d/include/resolvers.conf
+
+    if [ ! -f /data/nginx/dummycert.pem ] || [ ! -f /data/nginx/dummykey.pem ]; then
+      $STD openssl req -new -newkey rsa:2048 -days 3650 -nodes -x509 -subj "/O=Nginx Proxy Manager/OU=Dummy Certificate/CN=localhost" -keyout /data/nginx/dummykey.pem -out /data/nginx/dummycert.pem
+    fi
+
+    mkdir -p /app/frontend/images
+    cp -r /opt/nginxproxymanager/backend/* /app
+    msg_ok "Set up Environment"
+
+    msg_info "Building Frontend"
+    export NODE_OPTIONS="--max_old_space_size=2048 --openssl-legacy-provider"
+    cd /opt/nginxproxymanager/frontend
+    sed -E -i 's/"node-sass" *: *"([^"]*)"/"sass": "\1"/g' package.json
+    $STD yarn install --network-timeout 600000
+    $STD yarn locale-compile
+    $STD yarn build
+    cp -r /opt/nginxproxymanager/frontend/dist/* /app/frontend
+    cp -r /opt/nginxproxymanager/frontend/public/images/* /app/frontend/images
+    msg_ok "Built Frontend"
+
+    msg_info "Initializing Backend"
+    rm -rf /app/config/default.json
+    if [ ! -f /app/config/production.json ]; then
+      cat <<'EOF' >/app/config/production.json
 {
   "database": {
     "engine": "knex-native",
@@ -196,28 +211,22 @@ EOF
   }
 }
 EOF
+    fi
+    sed -i 's/"client": "sqlite3"/"client": "better-sqlite3"/' /app/config/production.json
+    cd /app
+    $STD yarn install --network-timeout 600000
+    msg_ok "Initialized Backend"
+
+    msg_info "Starting Services"
+    sed -i 's/user npm/user root/g; s/^pid/#pid/g' /usr/local/openresty/nginx/conf/nginx.conf
+    systemctl daemon-reload
+    systemctl enable -q --now openresty
+    systemctl enable -q --now npm
+    msg_ok "Started Services"
+
+    msg_ok "Updated successfully!"
   fi
-  sed -i 's/"client": "sqlite3"/"client": "better-sqlite3"/' /app/config/production.json
-  cd /app
-  $STD yarn install --network-timeout 600000
-  msg_ok "Initialized Backend"
 
-  msg_info "Updating Certbot"
-  if [ -d /opt/certbot ]; then
-    $STD /opt/certbot/bin/pip install --upgrade pip setuptools wheel
-    $STD /opt/certbot/bin/pip install --upgrade certbot certbot-dns-cloudflare
-  fi
-  msg_ok "Updated Certbot"
-
-  msg_info "Starting Services"
-  sed -i 's/user npm/user root/g; s/^pid/#pid/g' /usr/local/openresty/nginx/conf/nginx.conf
-  sed -r -i 's/^([[:space:]]*)su npm npm/\1#su npm npm/g;' /etc/logrotate.d/nginx-proxy-manager
-  systemctl daemon-reload
-  systemctl enable -q --now openresty
-  systemctl enable -q --now npm
-  msg_ok "Started Services"
-
-  msg_ok "Updated successfully!"
   exit
 }
 

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -34,7 +34,6 @@ function update_script() {
     exit
   fi
 
-  # ── Node.js upgrade if needed ──────────────────────────────────────────
   if command -v node &>/dev/null; then
     CURRENT_NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
     if [[ "$CURRENT_NODE_VERSION" != "22" ]]; then
@@ -50,7 +49,6 @@ function update_script() {
 
   NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
 
-  # ── Migrate from deb-packaged OpenResty to source-compiled ─────────────
   if dpkg -s openresty &>/dev/null 2>&1; then
     msg_info "Migrating from packaged OpenResty to source"
     rm -f /etc/apt/trusted.gpg.d/openresty-archive-keyring.gpg /etc/apt/trusted.gpg.d/openresty.gpg
@@ -61,14 +59,12 @@ function update_script() {
     msg_ok "Migrated from packaged OpenResty to source"
   fi
 
-  # ── OpenResty: build dependencies (Debian 13+ needs libpcre2-dev) ──────
   local pcre_pkg="libpcre3-dev"
   if grep -qE 'VERSION_ID="1[3-9]"' /etc/os-release 2>/dev/null; then
     pcre_pkg="libpcre2-dev"
   fi
   $STD apt install -y build-essential "$pcre_pkg" libssl-dev zlib1g-dev
 
-  # ── OpenResty: check & update ──────────────────────────────────────────
   if check_for_gh_release "openresty" "openresty/openresty"; then
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "openresty" "openresty/openresty" "prebuild" "${CHECK_UPDATE_RELEASE}" "/opt/openresty" "openresty-*.tar.gz"
 
@@ -106,7 +102,6 @@ EOF
     msg_ok "Built OpenResty"
   fi
 
-  # ── Certbot: always update ─────────────────────────────────────────────
   if [ -d /opt/certbot ]; then
     msg_info "Updating Certbot"
     $STD /opt/certbot/bin/pip install --upgrade pip setuptools wheel
@@ -114,7 +109,6 @@ EOF
     msg_ok "Updated Certbot"
   fi
 
-  # ── NPM: check & update ───────────────────────────────────────────────
   if check_for_gh_release "nginxproxymanager" "NginxProxyManager/nginx-proxy-manager"; then
     msg_info "Stopping Services"
     systemctl stop openresty
@@ -224,7 +218,6 @@ EOF
     systemctl enable -q --now openresty
     systemctl enable -q --now npm
     msg_ok "Started Services"
-
     msg_ok "Updated successfully!"
   fi
 

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -219,6 +219,7 @@ EOF
 
     msg_info "Starting Services"
     sed -i 's/user npm/user root/g; s/^pid/#pid/g' /usr/local/openresty/nginx/conf/nginx.conf
+    sed -r -i 's/^([[:space:]]*)su npm npm/\1#su npm npm/g;' /etc/logrotate.d/nginx-proxy-manager
     systemctl daemon-reload
     systemctl enable -q --now openresty
     systemctl enable -q --now npm

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -220,7 +220,6 @@ EOF
     msg_ok "Started Services"
     msg_ok "Updated successfully!"
   fi
-
   exit
 }
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add Node.js auto-upgrade check and ensure Node v22 + yarn setup.
- Use check_for_gh_release/CHECK_UPDATE_RELEASE to conditionally update OpenResty and Nginx Proxy Manager instead of always fetching latest.
- Migrate packaged OpenResty to source-built when detected (use dpkg -s), remove package artifacts, install build deps (switch to libpcre2-dev on Debian 13+), build OpenResty and restart service.
- Consolidate NPM deployment: stop services, clean old files, deploy release tarball, adjust file layout, update package.json versions, build frontend, initialize backend, and install dependencies.
- Move Certbot upgrades into a dedicated step and run pip upgrades when /opt/certbot exists.
- Minor fixes: safer dpkg detection, ensure daemon-reload and service restarts, create required directories, and general cleanup/ordering improvements.
- 
## 🔗 Related Issue

Fixes #13118

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
