### PR TITLE
Refactor: PartDB

### DIFF
--- a/ct/part-db.sh
+++ b/ct/part-db.sh
@@ -33,23 +33,21 @@ function update_script() {
     systemctl stop apache2
     msg_ok "Stopped Service"
 
-    msg_info "Updating $APP to v${CHECK_UPDATE_RELEASE}"
-    cd /opt
     mv /opt/partdb/ /opt/partdb-backup
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "partdb" "Part-DB/Part-DB-server" "prebuild" "latest" "/opt/partdb" "partdb_with_assets.zip"
 
+    msg_info "Updating Part-DB"
     cd /opt/partdb/
     cp -r /opt/partdb-backup/.env.local /opt/partdb/
     cp -r /opt/partdb-backup/public/media /opt/partdb/public/
     cp -r /opt/partdb-backup/config/banner.md /opt/partdb/config/
-
     export COMPOSER_ALLOW_SUPERUSER=1
     $STD composer install --no-dev -o --no-interaction
     $STD php bin/console cache:clear
     $STD php bin/console doctrine:migrations:migrate -n
     chown -R www-data:www-data /opt/partdb
     rm -r /opt/partdb-backup
-    msg_ok "Updated $APP to v${CHECK_UPDATE_RELEASE}"
+    msg_ok "Updated Part-DB"
 
     msg_info "Starting Service"
     systemctl start apache2

--- a/ct/part-db.sh
+++ b/ct/part-db.sh
@@ -27,36 +27,29 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  
-  RELEASE=$(get_latest_github_release "Part-DB/Part-DB-server")
+
   if check_for_gh_release "partdb" "Part-DB/Part-DB-server"; then
     msg_info "Stopping Service"
     systemctl stop apache2
     msg_ok "Stopped Service"
 
-    msg_info "Updating $APP to v${RELEASE}"
+    msg_info "Updating $APP to v${CHECK_UPDATE_RELEASE}"
     cd /opt
     mv /opt/partdb/ /opt/partdb-backup
-    curl -fsSL "https://github.com/Part-DB/Part-DB-server/archive/refs/tags/v${RELEASE}.zip" -o "/opt/v${RELEASE}.zip"
-    $STD unzip "v${RELEASE}.zip"
-    mv /opt/Part-DB-server-${RELEASE}/ /opt/partdb
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "partdb" "Part-DB/Part-DB-server" "prebuild" "latest" "/opt/partdb" "partdb_with_assets.zip"
 
     cd /opt/partdb/
-    cp -r "/opt/partdb-backup/.env.local" /opt/partdb/
-    cp -r "/opt/partdb-backup/public/media" /opt/partdb/public/
-    cp -r "/opt/partdb-backup/config/banner.md" /opt/partdb/config/
+    cp -r /opt/partdb-backup/.env.local /opt/partdb/
+    cp -r /opt/partdb-backup/public/media /opt/partdb/public/
+    cp -r /opt/partdb-backup/config/banner.md /opt/partdb/config/
 
     export COMPOSER_ALLOW_SUPERUSER=1
     $STD composer install --no-dev -o --no-interaction
-    $STD yarn install
-    $STD yarn build
     $STD php bin/console cache:clear
     $STD php bin/console doctrine:migrations:migrate -n
     chown -R www-data:www-data /opt/partdb
-    rm -r "/opt/v${RELEASE}.zip"
     rm -r /opt/partdb-backup
-    echo "${RELEASE}" >~/.partdb
-    msg_ok "Updated $APP to v${RELEASE}"
+    msg_ok "Updated $APP to v${CHECK_UPDATE_RELEASE}"
 
     msg_info "Starting Service"
     systemctl start apache2

--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -13,18 +13,13 @@ setting_up_container
 network_check
 update_os
 
-NODE_VERSION="22" NODE_MODULE="yarn@latest" setup_nodejs
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="partdb" PG_DB_USER="partdb" setup_postgresql_db
 PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="xsl" PHP_POST_MAX_SIZE="100M" PHP_UPLOAD_MAX_FILESIZE="100M" setup_php
 setup_composer
 
 msg_info "Installing Part-DB (Patience)"
-cd /opt
-RELEASE=$(get_latest_github_release "Part-DB/Part-DB-server")
-curl -fsSL "https://github.com/Part-DB/Part-DB-server/archive/refs/tags/v${RELEASE}.zip" -o "/opt/v${RELEASE}.zip"
-$STD unzip "v${RELEASE}.zip"
-mv /opt/Part-DB-server-${RELEASE}/ /opt/partdb
+fetch_and_deploy_gh_release "partdb" "Part-DB/Part-DB-server" "prebuild" "latest" "/opt/partdb" "partdb_with_assets.zip"
 
 cd /opt/partdb/
 cp .env .env.local
@@ -32,8 +27,6 @@ sed -i "s|DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/app.db\"|DATABASE_UR
 
 export COMPOSER_ALLOW_SUPERUSER=1
 $STD composer install --no-dev -o --no-interaction
-$STD yarn install
-$STD yarn build
 $STD php bin/console cache:clear
 php bin/console doctrine:migrations:migrate -n >~/database-migration-output
 chown -R www-data:www-data /opt/partdb
@@ -44,8 +37,6 @@ ADMIN_PASS=$(grep -oP 'The initial password for the "admin" user is: \K\w+' ~/da
   echo "Part-DB Admin Password: $ADMIN_PASS"
 } >>~/partdb.creds
 rm -rf ~/database-migration-output
-rm -rf "/opt/v${RELEASE}.zip"
-echo "${RELEASE}" >~/.partdb
 msg_ok "Installed Part-DB"
 
 msg_info "Creating Service"

--- a/install/part-db-install.sh
+++ b/install/part-db-install.sh
@@ -18,13 +18,12 @@ PG_DB_NAME="partdb" PG_DB_USER="partdb" setup_postgresql_db
 PHP_VERSION="8.4" PHP_APACHE="YES" PHP_MODULE="xsl" PHP_POST_MAX_SIZE="100M" PHP_UPLOAD_MAX_FILESIZE="100M" setup_php
 setup_composer
 
-msg_info "Installing Part-DB (Patience)"
 fetch_and_deploy_gh_release "partdb" "Part-DB/Part-DB-server" "prebuild" "latest" "/opt/partdb" "partdb_with_assets.zip"
 
+msg_info "Installing Part-DB"
 cd /opt/partdb/
 cp .env .env.local
 sed -i "s|DATABASE_URL=\"sqlite:///%kernel.project_dir%/var/app.db\"|DATABASE_URL=\"postgresql://${PG_DB_USER}:${PG_DB_PASS}@127.0.0.1:5432/${PG_DB_NAME}?serverVersion=12.19&charset=utf8\"|" .env.local
-
 export COMPOSER_ALLOW_SUPERUSER=1
 $STD composer install --no-dev -o --no-interaction
 $STD php bin/console cache:clear


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replace manual curl/unzip with fetch_and_deploy_gh_release using the partdb_with_assets.zip prebuild asset. This fixes the update error where get_latest_github_release captured apt output into the RELEASE variable, causing the download URL to be invalid.


Also removes Node.js/yarn dependency since the prebuild asset includes pre-compiled frontend assets.


## 🔗 Related Issue

Fixes #13226

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
