### PR TITLE
fix(nginxproxymanager): cd to /root before certbot pip update to avoid deleted cwd

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -102,6 +102,7 @@ EOF
     msg_ok "Built OpenResty"
   fi
 
+  cd /root
   if [ -d /opt/certbot ]; then
     msg_info "Updating Certbot"
     $STD /opt/certbot/bin/pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
## Summary

- Fixes `OSError: [Errno 2] No such file or directory` when running the NPM update script on Debian Trixie (Python 3.13)
- Adds `cd /root` before the certbot pip update block to ensure a valid working directory

## Root Cause

The OpenResty build step does `cd /opt/openresty` then immediately `rm -rf /opt/openresty`, leaving the shell's `$PWD` pointing to a now-deleted directory. When the certbot block runs next, the `silent()` wrapper forks a subprocess to execute pip — that subprocess inherits the deleted `$PWD` and fails to resolve it, producing `OSError: [Errno 2] No such file or directory` before pip even starts. This is unrelated to the certbot venv itself, which is healthy.

## Fix

One line: `cd /root` before the certbot block resets `$PWD` to a guaranteed-valid directory.

```bash
  cd /root
  if [ -d /opt/certbot ]; then
    msg_info "Updating Certbot"
    ...
```

## Reproduction

Reproduced on Debian Trixie (Python 3.13.5) with an NPM container upgraded from Debian Bookworm. The update script consistently fails at line 107 with the above error.