### PR TITLE
Komodo v2: migrate env vars to v2 and update source

### DIFF
--- a/ct/alpine-komodo.sh
+++ b/ct/alpine-komodo.sh
@@ -35,6 +35,8 @@ function update_script() {
   read -r -p "${TAB}Migrate update function now? [y/N]: " CONFIRM
   if [[ ! "${CONFIRM,,}" =~ ^(y|yes)$ ]]; then
     msg_warn "Migration skipped. The old update will continue to work for now."
+    msg_warn "⚠️  Komodo v2 uses :2 image tags. The :latest tag is deprecated and will not receive v2 updates."
+    msg_warn "Please migrate to the addon script to receive Komodo v2."
     msg_info "Updating ${APP} (legacy)"
     COMPOSE_FILE=$(find /opt/komodo -maxdepth 1 -type f -name '*.compose.yaml' ! -name 'compose.env' | head -n1)
     if [[ -z "$COMPOSE_FILE" ]]; then

--- a/ct/komodo.sh
+++ b/ct/komodo.sh
@@ -39,6 +39,8 @@ function update_script() {
   read -r -p "${TAB}Migrate update function now? [y/N]: " CONFIRM
   if [[ ! "${CONFIRM,,}" =~ ^(y|yes)$ ]]; then
     msg_warn "Migration skipped. The old update will continue to work for now."
+    msg_warn "⚠️  Komodo v2 uses :2 image tags. The :latest tag is deprecated and will not receive v2 updates."
+    msg_warn "Please migrate to the addon script to receive Komodo v2."
     msg_info "Updating ${APP} (legacy)"
     COMPOSE_FILE=$(find /opt/komodo -maxdepth 1 -type f -name '*.compose.yaml' ! -name 'compose.env' | head -n1)
     if [[ -z "$COMPOSE_FILE" ]]; then

--- a/tools/addon/komodo.sh
+++ b/tools/addon/komodo.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: MickLesk (CanbiZ)
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
-# Source: https://komo.do/ | Github: https://github.com/mbecker20/komodo
+# Source: https://komo.do/ | Github: https://github.com/moghtech/komodo
 if ! command -v curl &>/dev/null; then
   printf "\r\e[2K%b" '\033[93m Setup Source \033[m' >&2
   apt-get update >/dev/null 2>&1 || apk update >/dev/null 2>&1
@@ -82,6 +82,7 @@ function update() {
     msg_error "Failed to create backup of ${COMPOSE_BASENAME}!"
     exit 235
   }
+  cp "$COMPOSE_ENV" "${COMPOSE_ENV}.bak_$(date +%Y%m%d_%H%M%S)" 2>/dev/null || true
 
   GITHUB_URL="https://raw.githubusercontent.com/moghtech/komodo/main/compose/${COMPOSE_BASENAME}"
   if ! curl -fsSL "$GITHUB_URL" -o "$COMPOSE_FILE"; then
@@ -90,8 +91,29 @@ function update() {
     exit 115
   fi
 
-  if ! grep -qxF 'COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups' "$COMPOSE_ENV"; then
-    sed -i '/^COMPOSE_KOMODO_IMAGE_TAG=latest$/a COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups' "$COMPOSE_ENV"
+  # === v2 migration: image tag (latest is deprecated) ===
+  if grep -q '^COMPOSE_KOMODO_IMAGE_TAG=latest' "$COMPOSE_ENV"; then
+    msg_info "Migrating to Komodo v2 image tag"
+    sed -i 's/^COMPOSE_KOMODO_IMAGE_TAG=latest/COMPOSE_KOMODO_IMAGE_TAG=2/' "$COMPOSE_ENV"
+    msg_ok "Migrated image tag to :2"
+  fi
+
+  # === v2 migration: DB credential variable names ===
+  if grep -q '^KOMODO_DB_USERNAME=' "$COMPOSE_ENV"; then
+    msg_info "Migrating database credential variables"
+    sed -i 's/^KOMODO_DB_USERNAME=/KOMODO_DATABASE_USERNAME=/' "$COMPOSE_ENV"
+    sed -i 's/^KOMODO_DB_PASSWORD=/KOMODO_DATABASE_PASSWORD=/' "$COMPOSE_ENV"
+    msg_ok "Migrated DB credential variables"
+  fi
+
+  # === v2 migration: remove deprecated passkey (replaced by PKI) ===
+  if grep -q '^KOMODO_PASSKEY=' "$COMPOSE_ENV"; then
+    sed -i '/^KOMODO_PASSKEY=/d' "$COMPOSE_ENV"
+  fi
+
+  # === ensure backups path is set ===
+  if ! grep -q 'COMPOSE_KOMODO_BACKUPS_PATH=' "$COMPOSE_ENV"; then
+    echo 'COMPOSE_KOMODO_BACKUPS_PATH=/etc/komodo/backups' >>"$COMPOSE_ENV"
   fi
 
   $STD docker compose -p komodo -f "$COMPOSE_FILE" --env-file "$COMPOSE_ENV" pull
@@ -192,14 +214,12 @@ function install() {
 
   DB_PASSWORD=$(openssl rand -base64 16 | tr -d '/+=')
   ADMIN_PASSWORD=$(openssl rand -base64 8 | tr -d '/+=')
-  PASSKEY=$(openssl rand -base64 24 | tr -d '/+=')
   WEBHOOK_SECRET=$(openssl rand -base64 24 | tr -d '/+=')
   JWT_SECRET=$(openssl rand -base64 24 | tr -d '/+=')
 
-  sed -i "s/^KOMODO_DB_USERNAME=.*/KOMODO_DB_USERNAME=komodo_admin/" "$COMPOSE_ENV"
-  sed -i "s/^KOMODO_DB_PASSWORD=.*/KOMODO_DB_PASSWORD=${DB_PASSWORD}/" "$COMPOSE_ENV"
+  sed -i "s/^KOMODO_DATABASE_USERNAME=.*/KOMODO_DATABASE_USERNAME=komodo_admin/" "$COMPOSE_ENV"
+  sed -i "s/^KOMODO_DATABASE_PASSWORD=.*/KOMODO_DATABASE_PASSWORD=${DB_PASSWORD}/" "$COMPOSE_ENV"
   sed -i "s/^KOMODO_INIT_ADMIN_PASSWORD=changeme/KOMODO_INIT_ADMIN_PASSWORD=${ADMIN_PASSWORD}/" "$COMPOSE_ENV"
-  sed -i "s/^KOMODO_PASSKEY=.*/KOMODO_PASSKEY=${PASSKEY}/" "$COMPOSE_ENV"
   sed -i "s/^KOMODO_WEBHOOK_SECRET=.*/KOMODO_WEBHOOK_SECRET=${WEBHOOK_SECRET}/" "$COMPOSE_ENV"
   sed -i "s/^KOMODO_JWT_SECRET=.*/KOMODO_JWT_SECRET=${JWT_SECRET}/" "$COMPOSE_ENV"
   msg_ok "Configured environment"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update Komodo addon script:
- switch source GitHub URL to moghtech
- create a timestamped backup of the compose env before updating
- add migrations for Komodo v2
- Migrate image tag from 'latest' to ':2'
- rename DB credential variables (KOMODO_DB_* -> KOMODO_DATABASE_*)
- remove the deprecated KOMODO_PASSKEY
- ensure COMPOSE_KOMODO_BACKUPS_PATH is set
- Adjust install routine to stop generating/setting PASSKEY and to use the new DATABASE variable names

### User Action:
**Move to public key authentication**
If you want to reverse the agent connection, [skip this step and go to 2b](https://komo.do/docs/releases/v2.0.0#2b-reversing-the-agent-connection).

If you want to keep the Core to Periphery connection direction, you can increase the security by moving from passkey authentication to public key authentication.

Navigate to the Settings page, at the top you will find the Core Public Key (starting with MCow...). Copy this key and and redeploy Periphery agents with updated configuration:
```yaml
## Accepted public keys to allow Core(s) to connect.
## Periphery gains knowledge of the Core public key through the noise handshake.
## If neither these nor passkeys provided, inbound connections will not be authenticated.
## Accepts Spki base64 DER directly and PEM file. Use `file:/path/to/core.pub` to load from file.
## Env: PERIPHERY_CORE_PUBLIC_KEYS
## Optional, no default.
core_public_keys = "<YOUR_CORE_PUBLIC_KEY>"
```

After confirming the connection

https://komo.do/docs/releases/v2.0.0#2a-move-to-public-key-authentication


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
