### PR TITLE
tools.func: pin npm to 11.11.0 to work around Node.js 22.22.2 regression

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -6233,8 +6233,8 @@ function setup_nodejs() {
 
     ensure_apt_working || return 1
 
-    # Just update npm to latest
-    $STD npm install -g npm@latest 2>/dev/null || true
+    # Pin npm to 11.11.0 to work around Node.js 22.22.2 regression (nodejs/node#62425)
+    $STD npm install -g npm@11.11.0 2>/dev/null || true
 
     cache_installed_version "nodejs" "$NODE_VERSION"
     msg_ok "Update Node.js $NODE_VERSION"
@@ -6298,12 +6298,12 @@ function setup_nodejs() {
       return 1
     fi
 
-    # Update to latest npm (with version check to avoid incompatibility)
+    # Pin npm to 11.11.0 to work around Node.js 22.22.2 regression (nodejs/node#62425)
     local NPM_VERSION
     NPM_VERSION=$(npm -v 2>/dev/null || echo "0")
     if [[ "$NPM_VERSION" != "0" ]]; then
-      $STD npm install -g npm@latest 2>/dev/null || {
-        msg_warn "Failed to update npm to latest version (continuing with bundled npm $NPM_VERSION)"
+      $STD npm install -g npm@11.11.0 2>/dev/null || {
+        msg_warn "Failed to update npm to 11.11.0 (continuing with bundled npm $NPM_VERSION)"
       }
     fi
 


### PR DESCRIPTION



<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Node.js 22.22.2 ships with a broken npm self-upgrade path where 'npm install -g npm@latest' fails with MODULE_NOT_FOUND for promise-retry. Pin to npm@11.11.0 as a known-good version until the upstream issue is resolved. Ref: nodejs/node#62425, npm/cli#9151

## 🔗 Related Issue

Related to #13290

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
