### PR TITLE
core: use /usr/bin/install to prevent function shadowing

### DIFF
--- a/misc/alpine-tools.func
+++ b/misc/alpine-tools.func
@@ -304,7 +304,7 @@ setup_yq() {
   url="https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${arch}"
   tmp="$(mktemp)"
   download_with_progress "$url" "$tmp" || return 1
-  install -m 0755 "$tmp" /usr/local/bin/yq
+  /usr/bin/install -m 0755 "$tmp" /usr/local/bin/yq
   rm -f "$tmp"
   msg_ok "Setup yq ($(yq --version 2>/dev/null))"
 }
@@ -376,10 +376,10 @@ setup_uv() {
 
   # tar contains ./uv
   if [ -x "$tmpd/uv" ]; then
-    install -m 0755 "$tmpd/uv" "$UV_BIN"
+    /usr/bin/install -m 0755 "$tmpd/uv" "$UV_BIN"
   else
     # fallback: in subfolder
-    install -m 0755 "$tmpd"/*/uv "$UV_BIN" 2>/dev/null || {
+    /usr/bin/install -m 0755 "$tmpd"/*/uv "$UV_BIN" 2>/dev/null || {
       msg_error "uv binary not found in tar"
       rm -rf "$tmpd"
       return 1

--- a/misc/build.func
+++ b/misc/build.func
@@ -1642,7 +1642,7 @@ maybe_offer_save_app_defaults() {
     if whiptail --backtitle "Proxmox VE Helper Scripts" \
       --yesno "Save these advanced settings as defaults for ${APP}?\n\nThis will create:\n${app_vars_path}" 12 72; then
       mkdir -p "$(dirname "$app_vars_path")"
-      install -m 0644 "$new_tmp" "$app_vars_path"
+      /usr/bin/install -m 0644 "$new_tmp" "$app_vars_path"
       msg_ok "Saved app defaults: ${app_vars_path}"
     fi
     rm -f "$new_tmp" "$diff_tmp"
@@ -1676,7 +1676,7 @@ maybe_offer_save_app_defaults() {
 
     case "$sel" in
     "Update Defaults")
-      install -m 0644 "$new_tmp" "$app_vars_path"
+      /usr/bin/install -m 0644 "$new_tmp" "$app_vars_path"
       msg_ok "Updated app defaults: ${app_vars_path}"
       break
       ;;


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Bare 'install' can be shadowed when scripts define their own install() function, causing hangs. Use absolute path /usr/bin/install in alpine-tools.func and build.func to match the fix already applied to tools.func.


## 🔗 Related Issue

Fixes #12642

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
