### PR TITLE
Fix: update gokapi asset matching for v2.2.4+ naming convention

### DIFF
--- a/ct/gokapi.sh
+++ b/ct/gokapi.sh
@@ -32,7 +32,7 @@ function update_script() {
     systemctl stop gokapi
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "gokapi-linux_amd64.zip"
+    fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "*linux*amd64.zip"
 
     msg_info "Starting Service"
     systemctl start gokapi

--- a/install/gokapi-install.sh
+++ b/install/gokapi-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "gokapi-linux_amd64.zip"
+fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "*linux*amd64.zip"
 
 msg_info "Configuring Gokapi"
 mkdir -p /opt/gokapi/{data,config}


### PR DESCRIPTION
<!--📝 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
    PRs without prior testing will be closed. -->
    
## ✍️ Description
    
Update `fetch_and_deploy_gh_release` in the Gokapi scripts to use a wildcard pattern (`*linux*amd64.zip`). This restores compatibility with the new versioned asset filenames introduced in Gokapi v2.2.4.
    
## 🔗 Related Issue
N/A

    
## ✅ Prerequisites (**X** in brackets)
    
- [x] **Self-review completed** - Code follows project standards.
- [x] **Tested thoroughly** - Changes work as expected.
- [x] **No security risks** - No hardcoded secrets, unnecessary privilege escalations, or permission issues.


## 🛠️ Type of Change (**X** in brackets)
 
- [x] **🐞 Bug fix** - Resolves an issue without breaking functionality.
- [ ] **✨ New feature** - Adds new, non-breaking functionality.
- [ ] **💥 Breaking change** - Alters existing functionality in a way that may require updates.
- [ ] **🎉 New script** - A fully functional and tested script or script set.
- [ ] **🚧 Website update** - Changes to website-related JSON files or metadata.
- [ ] **✨ Refactoring / Code Cleanup** - Improves readability or maintainability without changing functionality.
- [ ] **📝 Documentation update** - Changes to `README.md`, `AppName.md`, `CONTRIBUTING.md`, or other docs.   
    