### PR TITLE
Fix: Update gokapi binary name for v2.2.4+ and add migration step

### DIFF
--- a/ct/gokapi.sh
+++ b/ct/gokapi.sh
@@ -34,6 +34,15 @@ function update_script() {
 
     fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "*linux*amd64.zip"
 
+    # Migrate from pre-v2.2.4 binary name (gokapi-linux_amd64 → gokapi)
+    if [[ -f /opt/gokapi/gokapi-linux_amd64 ]]; then
+      rm -f /opt/gokapi/gokapi-linux_amd64
+    fi
+    if grep -q "gokapi-linux_amd64" /etc/systemd/system/gokapi.service 2>/dev/null; then
+      sed -i 's|gokapi-linux_amd64|gokapi|g' /etc/systemd/system/gokapi.service
+      systemctl daemon-reload
+    fi
+
     msg_info "Starting Service"
     systemctl start gokapi
     msg_ok "Started Service"

--- a/ct/gokapi.sh
+++ b/ct/gokapi.sh
@@ -34,7 +34,7 @@ function update_script() {
 
     fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/gokapi" "*linux*amd64.zip"
 
-    # Migrate from pre-v2.2.4 binary name (gokapi-linux_amd64 → gokapi)
+    # Migrate from pre-v2.2.4 binary name (gokapi-linux_amd64 -> gokapi)
     if [[ -f /opt/gokapi/gokapi-linux_amd64 ]]; then
       rm -f /opt/gokapi/gokapi-linux_amd64
     fi

--- a/install/gokapi-install.sh
+++ b/install/gokapi-install.sh
@@ -17,7 +17,7 @@ fetch_and_deploy_gh_release "gokapi" "Forceu/Gokapi" "prebuild" "latest" "/opt/g
 
 msg_info "Configuring Gokapi"
 mkdir -p /opt/gokapi/{data,config}
-chmod +x /opt/gokapi/gokapi-linux_amd64
+chmod +x /opt/gokapi/gokapi
 msg_ok "Configured Gokapi"
 
 msg_info "Creating Service"
@@ -29,7 +29,7 @@ Description=gokapi
 Type=simple
 Environment=GOKAPI_DATA_DIR=/opt/gokapi/data
 Environment=GOKAPI_CONFIG_DIR=/opt/gokapi/config
-ExecStart=/opt/gokapi/gokapi-linux_amd64
+ExecStart=/opt/gokapi/gokapi
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Change the installed binary name from pre-v2.2.4 `gokapi-linux_amd64` to v2.2.4+ `gokapi` and update service configuration accordingly. Add a migration step to remove any legacy `gokapi-linux_amd64` binary file, update binary reference in existing `gokapi.service`, and reload systemd before starting the service.

## 🔗 Related Issue

Related to #13369 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
