### PR TITLE
fix(victoriametrics): use jq to filter releases

### DIFF
--- a/ct/victoriametrics.sh
+++ b/ct/victoriametrics.sh
@@ -34,24 +34,26 @@ function update_script() {
     [[ -f /etc/systemd/system/victoriametrics-logs.service ]] && systemctl stop victoriametrics-logs
     msg_ok "Stopped Service"
 
-    victoriametrics_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases/latest" |
-      jq -r '.assets[].name' |
-      grep -E '^victoria-metrics-linux-amd64-v[0-9.]+\.tar\.gz$')
-    vmutils_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases/latest" |
-      jq -r '.assets[].name' |
-      grep -E '^vmutils-linux-amd64-v[0-9.]+\.tar\.gz$')
+    victoriametrics_release=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases" |
+      jq -r '.[] | select(.assets[].name | match("^victoria-metrics-linux-amd64-v[0-9.]+.tar.gz$")) | .tag_name' |
+      head -n 1)
 
-    fetch_and_deploy_gh_release "victoriametrics" "VictoriaMetrics/VictoriaMetrics" "prebuild" "latest" "/opt/victoriametrics" "$victoriametrics_filename"
-    fetch_and_deploy_gh_release "vmutils" "VictoriaMetrics/VictoriaMetrics" "prebuild" "latest" "/opt/victoriametrics" "$vmutils_filename"
+    msg_debug "Using release $victoriametrics_release"
+
+    victoriametrics_filename="victoria-metrics-linux-amd64-${victoriametrics_release}.tar.gz"
+    vmutils_filename="vmutils-linux-amd64-${victoriametrics_release}.tar.gz"
+
+    fetch_and_deploy_gh_release "victoriametrics" "VictoriaMetrics/VictoriaMetrics" "prebuild" "$victoriametrics_release" "/opt/victoriametrics" "$victoriametrics_filename"
+    fetch_and_deploy_gh_release "vmutils" "VictoriaMetrics/VictoriaMetrics" "prebuild" "$victoriametrics_release" "/opt/victoriametrics" "$vmutils_filename"
 
     if [[ -f /etc/systemd/system/victoriametrics-logs.service ]]; then
       vmlogs_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaLogs/releases/latest" |
         jq -r '.assets[].name' |
-        grep -E '^victoria-logs-linux-amd64-v[0-9.]+\.tar\.gz$')  
+        grep -E '^victoria-logs-linux-amd64-v[0-9.]+\.tar\.gz$')
       vlutils_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaLogs/releases/latest" |
         jq -r '.assets[].name' |
         grep -E '^vlutils-linux-amd64-v[0-9.]+\.tar\.gz$')
-        
+
       fetch_and_deploy_gh_release "victorialogs" "VictoriaMetrics/VictoriaLogs" "prebuild" "latest" "/opt/victoriametrics" "$vmlogs_filename"
       fetch_and_deploy_gh_release "vlutils" "VictoriaMetrics/VictoriaLogs" "prebuild" "latest" "/opt/victoriametrics" "$vlutils_filename"
     fi

--- a/install/victoriametrics-install.sh
+++ b/install/victoriametrics-install.sh
@@ -14,16 +14,16 @@ network_check
 update_os
 
 msg_info "Getting latest version of VictoriaMetrics"
-victoriametrics_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases/latest" |
-  jq -r '.assets[].name' |
-  grep -E '^victoria-metrics-linux-amd64-v[0-9.]+\.tar\.gz$')
-vmutils_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases/latest" |
-  jq -r '.assets[].name' |
-  grep -E '^vmutils-linux-amd64-v[0-9.]+\.tar\.gz$')
-msg_ok "Got latest version of VictoriaMetrics"
 
-fetch_and_deploy_gh_release "victoriametrics" "VictoriaMetrics/VictoriaMetrics" "prebuild" "latest" "/opt/victoriametrics" "$victoriametrics_filename"
-fetch_and_deploy_gh_release "vmutils" "VictoriaMetrics/VictoriaMetrics" "prebuild" "latest" "/opt/victoriametrics" "$vmutils_filename"
+victoriametrics_release=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases" |
+  jq -r '.[] | select(.assets[].name | match("^victoria-metrics-linux-amd64-v[0-9.]+.tar.gz$")) | .tag_name' |
+  head -n 1)
+victoriametrics_filename="victoria-metrics-linux-amd64-${victoriametrics_release}.tar.gz"
+vmutils_filename="vmutils-linux-amd64-${victoriametrics_release}.tar.gz"
+msg_ok "Got version $victoriametrics_release of VictoriaMetrics"
+
+fetch_and_deploy_gh_release "victoriametrics" "VictoriaMetrics/VictoriaMetrics" "prebuild" "$victoriametrics_release" "/opt/victoriametrics" "$victoriametrics_filename"
+fetch_and_deploy_gh_release "vmutils" "VictoriaMetrics/VictoriaMetrics" "prebuild" "$victoriametrics_release" "/opt/victoriametrics" "$vmutils_filename"
 
 read -r -p "${TAB3}Would you like to add VictoriaLogs? <y/N> " prompt
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

This PR changes how the releases of VictoriaMetrics are retrieved. Instead of just grabbing the latest release according to GitHub, use `jq` to find the first release that has an asset that matches what we need.

In this case it would also be possible to sort the releases by version number, grab the highest number, and search for the assets in there. Let me know if that is preferred.

## 🔗 Related Issue

Fixes #13376

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
