### PR TITLE
Ollama: add error handling for Intel GPG key imports

### DIFF
--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -22,7 +22,7 @@ msg_ok "Installed Dependencies"
 
 msg_info "Setting up Intel® Repositories"
 mkdir -p /usr/share/keyrings
-curl -fsSL https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+curl -fsSL https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg 2>/dev/null || true
 cat <<EOF >/etc/apt/sources.list.d/intel-gpu.sources
 Types: deb
 URIs: https://repositories.intel.com/gpu/ubuntu
@@ -31,7 +31,7 @@ Components: client
 Architectures: amd64 i386
 Signed-By: /usr/share/keyrings/intel-graphics.gpg
 EOF
-curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg
+curl -fsSL https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor -o /usr/share/keyrings/oneapi-archive-keyring.gpg 2>/dev/null || true
 cat <<EOF >/etc/apt/sources.list.d/oneAPI.sources
 Types: deb
 URIs: https://apt.repos.intel.com/oneapi


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Prevents install failure when Intel GPU repository key download returns HTTP 403. Aligns with openwebui approach.

## 🔗 Related Issue

Fixes #13387

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
