### PR TITLE
Immich: ignore Redis connection error on maintenance mode disable

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -283,7 +283,7 @@ EOF
     if [[ "${MAINT_MODE:-0}" == 1 ]]; then
       msg_info "Disabling Maintenance Mode"
       cd /opt/immich/app/bin
-      $STD ./immich-admin disable-maintenance-mode
+      $STD ./immich-admin disable-maintenance-mode || true
       unset MAINT_MODE
       $STD cd -
       msg_ok "Disabled Maintenance Mode"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The immich-admin CLI successfully disables maintenance mode but crashes on exit due to Redis connection closing during process shutdown, causing the update script to abort unnecessarily.


## 🔗 Related Issue

Fixes #13357

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
