### PR TITLE
feat: add CinePlete LXC script

### DIFF
--- a/ct/cineplete.sh
+++ b/ct/cineplete.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sdblepas
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/sdblepas/CinePlete
+
+APP="CinePlete"
+var_tags="${var_tags:-media;plex;jellyfin}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-512}"
+var_disk="${var_disk:-4}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+  if [[ ! -d /opt/cineplete ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  if check_for_gh_release "cineplete" "sdblepas/CinePlete"; then
+    msg_info "Stopping Service"
+    systemctl stop cineplete
+    msg_ok "Stopped Service"
+
+    msg_info "Updating ${APP}"
+    fetch_and_deploy_gh_release "cineplete" "sdblepas/CinePlete" "tarball" "latest" "/opt/cineplete"
+    /opt/cineplete/.venv/bin/pip install --quiet --upgrade pip
+    /opt/cineplete/.venv/bin/pip install --quiet -r /opt/cineplete/requirements.txt
+    msg_ok "Updated ${APP}"
+
+    msg_info "Starting Service"
+    systemctl start cineplete
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:7474${CL}"

--- a/install/cineplete-install.sh
+++ b/install/cineplete-install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: sdblepas
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/sdblepas/CinePlete
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y \
+  python3 \
+  python3-pip \
+  python3-venv \
+  curl \
+  ca-certificates
+msg_ok "Installed Dependencies"
+
+msg_info "Installing ${APP}"
+fetch_and_deploy_gh_release "cineplete" "sdblepas/CinePlete" "tarball" "latest" "/opt/cineplete"
+mkdir -p /data /config
+python3 -m venv /opt/cineplete/.venv
+/opt/cineplete/.venv/bin/pip install --quiet --upgrade pip
+/opt/cineplete/.venv/bin/pip install --quiet -r /opt/cineplete/requirements.txt
+msg_ok "Installed ${APP}"
+
+msg_info "Creating Service"
+cat <<EOF >/etc/systemd/system/cineplete.service
+[Unit]
+Description=CinePlete — Movie library gap finder
+After=network.target
+Wants=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/cineplete
+Environment=DATA_DIR=/data
+Environment=CONFIG_DIR=/config
+Environment=STATIC_DIR=/opt/cineplete/static
+ExecStart=/opt/cineplete/.venv/bin/uvicorn app.web:app --host 0.0.0.0 --port 7474 --workers 1
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable -q --now cineplete
+msg_ok "Created Service"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
## CinePlete — Plex & Jellyfin Movie Audit

**Website:** https://github.com/sdblepas/CinePlete
**Docker Hub:** https://hub.docker.com/r/sdblepas/cineplete

### Description
Self-hosted tool that scans your Plex or Jellyfin movie library and shows exactly what you're missing — franchises, directors, actors, and classics. Includes a dashboard with charts, Radarr/Overseerr/Jellyseerr integration, Letterboxd import, wishlist, and smart authentication.

### Files added
- `ct/cineplete.sh` — LXC container creator
- `install/cineplete-install.sh` — installer that runs inside the container

### Resources
- **CPU:** 2 cores
- **RAM:** 512 MB
- **Disk:** 4 GB
- **OS:** Debian 12 (unprivileged)
- **Port:** 7474

### Notes
- No database required — file-based storage
- No Nginx — uvicorn serves directly on port 7474
- Re-running the update function upgrades to the latest GitHub release