### PR TITLE
Koillection: ensure newline before appending to .env.local

### DIFF
--- a/ct/koillection.sh
+++ b/ct/koillection.sh
@@ -48,7 +48,9 @@ function update_script() {
     
     # Ensure APP_RUNTIME is in .env.local for CLI commands (upgrades from older versions)
     if ! grep -q "APP_RUNTIME" /opt/koillection/.env.local 2>/dev/null; then
-      echo 'APP_RUNTIME="Symfony\Component\Runtime\SymfonyRuntime"' >> /opt/koillection/.env.local
+      # Ensure file ends with newline before appending to avoid concatenation
+      [[ -s /opt/koillection/.env.local && -n "$(tail -c 1 /opt/koillection/.env.local)" ]] && echo "" >>/opt/koillection/.env.local
+      echo 'APP_RUNTIME="Symfony\Component\Runtime\SymfonyRuntime"' >>/opt/koillection/.env.local
     fi
     
     export COMPOSER_ALLOW_SUPERUSER=1


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
If .env.local does not end with a newline, the APP_RUNTIME entry gets concatenated with the previous line, causing Symfony to fail with an invalid trusted header error during composer install.

## 🔗 Related Issue

Fixes #13438

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
