### PR TITLE
Graylog: set vm.max_map_count on host for OpenSearch

### DIFF
--- a/ct/graylog.sh
+++ b/ct/graylog.sh
@@ -64,6 +64,12 @@ function update_script() {
 }
 
 start
+
+if [[ $(sysctl -n vm.max_map_count 2>/dev/null) -lt 262144 ]]; then
+  sysctl -w vm.max_map_count=262144 >/dev/null 2>&1
+  echo "vm.max_map_count=262144" >/etc/sysctl.d/graylog.conf
+fi
+
 build_container
 description
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
OpenSearch requires vm.max_map_count >= 262144 -- Linux default is 65530. Since this is not a namespaced sysctl, it must be set on the Proxmox host rather than inside the unprivileged LXC.

that only affect if the host system is not configured correctly.

## 🔗 Related Issue

Fixes #13420

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
