### PR TITLE
core: skip empty gateway value in network config

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3530,6 +3530,7 @@ build_container() {
   # Gateway
   if [[ -n "$GATE" ]]; then
     case "$GATE" in
+    ,gw=) ;;
     ,gw=*) NET_STRING+="$GATE" ;;
     *) NET_STRING+=",gw=$GATE" ;;
     esac


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When var_gateway is set to an empty string, the resulting gw= token in the comma-separated network string causes pct create to fail with a 'missing key in comma-separated list property' error.


## 🔗 Related Issue

Fixes #13421

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
