### PR TITLE
OpenWRT-VM: use poweroff instead of halt to properly stop VM

### DIFF
--- a/vm/openwrt-vm.sh
+++ b/vm/openwrt-vm.sh
@@ -663,7 +663,7 @@ if qm status "$VMID" | grep -q "running"; then
   send_line_to_vm "uci set network.lan.ipaddr=${LAN_IP_ADDR}"
   send_line_to_vm "uci set network.lan.netmask=${LAN_NETMASK}"
   send_line_to_vm "uci commit"
-  send_line_to_vm "halt"
+  send_line_to_vm "poweroff"
   msg_ok "Network interfaces configured in OpenWrt"
 else
   msg_error "VM is not running"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
halt seems to be deprecated, use poweroff

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
