### PR TITLE
Grist: remove install:ee step (private repo, not needed for grist-core)

### DIFF
--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -53,7 +53,6 @@ function update_script() {
     [[ -f /opt/grist_bak/landing.db ]] && cp /opt/grist_bak/landing.db /opt/grist/landing.db
     cd /opt/grist
     $STD yarn install
-    $STD yarn run install:ee
     $STD yarn run build:prod
     $STD yarn run install:python
     msg_ok "Updated Grist"

--- a/install/grist-install.sh
+++ b/install/grist-install.sh
@@ -28,7 +28,6 @@ export CYPRESS_INSTALL_BINARY=0
 export NODE_OPTIONS="--max-old-space-size=2048"
 cd /opt/grist
 $STD yarn install
-$STD yarn run install:ee
 $STD yarn run build:prod
 $STD yarn run install:python
 cat <<EOF >/opt/grist/.env


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
remove ee from grist, it was once added as a request by a Grist contributor, but it no longer seems to be available. Grist works perfectly fine anyway.

## 🔗 Related Issue

Fixes #13521

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
