### PR TITLE
feat(mailcow): add Mailcow LXC container script

### DIFF
--- a/ct/mailcow.sh
+++ b/ct/mailcow.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: reptil1990
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://mailcow.email/
+
+APP="Mailcow"
+var_tags="${var_tags:-mail;docker}"
+var_cpu="${var_cpu:-4}"
+var_ram="${var_ram:-8192}"
+var_disk="${var_disk:-30}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-13}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/mailcow-dockerized ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating Mailcow"
+  cd /opt/mailcow-dockerized
+  $STD ./update.sh --skip-branch-check
+  msg_ok "Updated Mailcow"
+
+  msg_ok "Updated successfully!"
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}${CL}"

--- a/frontend/public/json/mailcow.json
+++ b/frontend/public/json/mailcow.json
@@ -1,0 +1,48 @@
+{
+  "name": "Mailcow",
+  "slug": "mailcow",
+  "categories": [
+    1
+  ],
+  "date_created": "2026-04-06",
+  "type": "ct",
+  "updateable": true,
+  "privileged": false,
+  "interface_port": 443,
+  "documentation": "https://docs.mailcow.email/",
+  "website": "https://mailcow.email/",
+  "logo": "https://cdn.jsdelivr.net/gh/selfhst/icons@main/webp/mailcow.webp",
+  "config_path": "/opt/mailcow-dockerized/mailcow.conf",
+  "description": "Mailcow is a Docker-based open source groupware/email suite providing a full-featured mail server with web administration, webmail (SOGo), antispam (Rspamd), antivirus (ClamAV), and more.",
+  "install_methods": [
+    {
+      "type": "default",
+      "script": "ct/mailcow.sh",
+      "resources": {
+        "cpu": 4,
+        "ram": 8192,
+        "hdd": 30,
+        "os": "Debian",
+        "version": "13"
+      }
+    }
+  ],
+  "default_credentials": {
+    "username": "admin",
+    "password": "moohoo"
+  },
+  "notes": [
+    {
+      "text": "Requires a valid FQDN with proper DNS records (A, MX, SPF, DKIM, DMARC) pointing to the container IP.",
+      "type": "warning"
+    },
+    {
+      "text": "Change the default admin password immediately after first login!",
+      "type": "warning"
+    },
+    {
+      "text": "Ensure ports 25, 80, 143, 443, 465, 587, 993, 995, 4190 are not blocked by your firewall.",
+      "type": "info"
+    }
+  ]
+}

--- a/install/mailcow-install.sh
+++ b/install/mailcow-install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: reptil1990
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://mailcow.email/
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Docker"
+setup_docker
+msg_ok "Installed Docker"
+
+msg_info "Cloning Mailcow"
+$STD git clone https://github.com/mailcow/mailcow-dockerized.git /opt/mailcow-dockerized
+msg_ok "Cloned Mailcow"
+
+read -r -p "${TAB3}Enter Mailcow FQDN (e.g., mail.example.com): " MAILCOW_FQDN
+if [[ -z "$MAILCOW_FQDN" ]]; then
+  msg_error "FQDN cannot be empty!"
+  exit 1
+fi
+
+msg_info "Generating Mailcow Configuration"
+cd /opt/mailcow-dockerized
+MAILCOW_HOSTNAME="$MAILCOW_FQDN" MAILCOW_TZ="$tz" $STD ./generate_config.sh
+msg_ok "Generated Mailcow Configuration"
+
+msg_info "Applying LXC-specific adjustments"
+# Redis: Comment out sysctls (not supported in unprivileged LXC)
+sed -i '/redis-mailcow:/,/restart:/{
+  /sysctls:/,/net\.core\.somaxconn/{
+    s/^/#/
+  }
+}' /opt/mailcow-dockerized/docker-compose.yml
+
+# Dovecot: Reduce nproc ulimit for unprivileged container
+sed -i '/dovecot-mailcow:/,/restart:/{
+  s/nproc: 65536/nproc: 30000/
+}' /opt/mailcow-dockerized/docker-compose.yml
+msg_ok "Applied LXC-specific adjustments"
+
+msg_info "Pulling Mailcow Docker Images"
+cd /opt/mailcow-dockerized
+$STD docker compose pull
+msg_ok "Pulled Mailcow Docker Images"
+
+msg_info "Starting Mailcow"
+cd /opt/mailcow-dockerized
+$STD docker compose up -d
+msg_ok "Started Mailcow"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
Standalone Docker-based Mailcow mail server in an unprivileged Debian 13 LXC with interactive FQDN setup, LXC-specific patches (redis sysctls, dovecot ulimits), and update support via official update.sh.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
