### PR TITLE
kasm: fix: fetch latest version

### DIFF
--- a/ct/kasm.sh
+++ b/ct/kasm.sh
@@ -15,6 +15,7 @@ var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-0}"
 var_fuse="${var_fuse:-yes}"
 var_tun="${var_tun:-yes}"
+var_kasm_version="${var_kasm_version:-}"
 
 header_info "$APP"
 variables
@@ -46,6 +47,13 @@ function update_script() {
   if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
     msg_error "Unable to detect latest Kasm release URL."
     exit 250
+  fi
+
+  # Manual override (if var_kasm_version is set)
+  if [[ -n "$var_kasm_version" ]]; then
+    msg_info "Overriding detected version with user-defined version: $var_kasm_version"
+    KASM_VERSION="$var_kasm_version"
+    KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
   fi
   msg_info "Checked for new version"
 

--- a/ct/kasm.sh
+++ b/ct/kasm.sh
@@ -33,27 +33,23 @@ function update_script() {
 
   msg_info "Checking for new version"
   CURRENT_VERSION=$(readlink -f /opt/kasm/current | awk -F'/' '{print $4}')
-  KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
-  if [[ -z "$KASM_URL" ]]; then
-    SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
-    if [[ -n "$SERVICE_IMAGE_URL" ]]; then
-      KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-      KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
-    fi
-  else
-    KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-  fi
+  KASM_VERSION=$(curl -s https://kasm.com/downloads | grep -oP '<h1[^>]*>.*?</h1>' | sed -E 's/<\/?h1[^>]*>//g' | grep -oP '\d+\.\d+\.\d+')
+  KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION:-var_kasm_version}.tar.gz"
   
-  if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
+  # KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
+  # if [[ -z "$KASM_URL" ]]; then
+  #   SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+  #   if [[ -n "$SERVICE_IMAGE_URL" ]]; then
+  #     KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  #     KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
+  #   fi
+  # else
+  #   KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+  # fi
+  
+  if [[ -z "$KASM_VERSION" ]] || [[ -z "$KASM_URL" ]]; then
     msg_error "Unable to detect latest Kasm release URL."
     exit 250
-  fi
-
-  # Manual override (if var_kasm_version is set)
-  if [[ -n "$var_kasm_version" ]]; then
-    msg_info "Overriding detected version with user-defined version: $var_kasm_version"
-    KASM_VERSION="$var_kasm_version"
-    KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
   fi
   msg_info "Checked for new version"
 

--- a/install/kasm-install.sh
+++ b/install/kasm-install.sh
@@ -18,18 +18,21 @@ $STD sh <(curl -fsSL https://get.docker.com/)
 msg_ok "Installed Docker"
 
 msg_info "Detecting latest Kasm Workspaces release"
-KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
-if [[ -z "$KASM_URL" ]]; then
-  SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
-  if [[ -n "$SERVICE_IMAGE_URL" ]]; then
-    KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-    KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
-  fi
-else
-  KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
-fi
+KASM_VERSION=$(curl -s https://kasm.com/downloads | grep -oP '<h1[^>]*>.*?</h1>' | sed -E 's/<\/?h1[^>]*>//g' | grep -oP '\d+\.\d+\.\d+')
+KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION:-var_kasm_version}.tar.gz"
+  
+# KASM_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_[0-9]+\.[0-9]+\.[0-9]+\.[a-z0-9]+\.tar\.gz' | head -n 1)
+# if [[ -z "$KASM_URL" ]]; then
+#   SERVICE_IMAGE_URL=$(curl -fsSL "https://www.kasm.com/downloads" | tr '\n' ' ' | grep -oE 'https://kasm-static-content[^"]*kasm_release_service_images_amd64_[0-9]+\.[0-9]+\.[0-9]+\.tar\.gz' | head -n 1)
+#   if [[ -n "$SERVICE_IMAGE_URL" ]]; then
+#     KASM_VERSION=$(echo "$SERVICE_IMAGE_URL" | sed -E 's/.*kasm_release_service_images_amd64_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+#     KASM_URL="https://kasm-static-content.s3.amazonaws.com/kasm_release_${KASM_VERSION}.tar.gz"
+#   fi
+# else
+#   KASM_VERSION=$(echo "$KASM_URL" | sed -E 's/.*kasm_release_([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+# fi
 
-if [[ -z "$KASM_URL" ]] || [[ -z "$KASM_VERSION" ]]; then
+if [[ -z "$KASM_VERSION" ]] || [[ -z "$KASM_URL" ]]; then
   msg_error "Unable to detect latest Kasm release URL."
   exit 250
 fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
due to ongoing problems and not yet any updates from kasm, we implement a way for the user to override the latest version manually and a potential fit by extracting the current version number from <\h1> Element. 

## 🔗 Related Issue

Fixes #13540

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
