### PR TITLE
chore(immich): bump pinned release to v2.7.0

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -109,7 +109,7 @@ EOF
     msg_ok "Image-processing libraries up to date"
   fi
 
-  RELEASE="v2.6.3"
+  RELEASE="v2.7.0"
   if check_for_gh_release "Immich" "immich-app/immich" "${RELEASE}" "each release is tested individually before the version is updated. Please do not open issues for this"; then
     if [[ $(cat ~/.immich) > "2.5.1" ]]; then
       msg_info "Enabling Maintenance Mode"

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -295,7 +295,7 @@ ML_DIR="${APP_DIR}/machine-learning"
 GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
 
-fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v2.6.3" "$SRC_DIR"
+fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v2.7.0" "$SRC_DIR"
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
 NODE_VERSION="24" NODE_MODULE="pnpm@${PNPM_VERSION}" setup_nodejs
 


### PR DESCRIPTION
## Summary

This PR updates the pinned Immich release from `v2.6.3` to `v2.7.0` in the Community Scripts Immich install/update flow.

Changed files:
- `ct/immich.sh`
- `install/immich-install.sh`

## Validation

Validated in this environment:
- Confirmed the upstream Immich tag `v2.7.0` exists.
- Inspected the `v2.7.0` release layout and metadata to check whether this update appeared to require script changes beyond the version bump.
- Confirmed the release still uses the expected monorepo layout, `pnpm` package manager, Node 24 in `mise.toml`, and Python 3.11-compatible machine-learning requirements.
- Ran `bash -n ct/immich.sh`.
- Ran `bash -n install/immich-install.sh`.
- Ran `git diff --check`.

## Not validated here

Not validated in this environment:
- Full Proxmox LXC install from scratch.
- In-place upgrade of an existing Immich container from `v2.6.3` to `v2.7.0`.
- Runtime verification of web, CLI, plugin, and machine-learning services after deployment.
- Rebuild/runtime verification of the custom image-processing libraries against this Immich release.

## Risk / Notes

This is intentionally a minimal bump only. Based on a quick inspection of the upstream `v2.7.0` release, I did not find an obvious packaging or layout change that required adjustments beyond the pinned version references. The remaining risk is runtime behavior that only shows up during a real Proxmox install/update path, especially around build-time dependencies, plugin build steps, and machine-learning setup.