### PR TITLE
fix(flaresolverr): use rm -f for google-chrome.list (Debian 13 Trixie)

### DIFF
--- a/install/flaresolverr-install.sh
+++ b/install/flaresolverr-install.sh
@@ -28,8 +28,9 @@ setup_deb822_repo \
   "stable"
 $STD apt update
 $STD apt install -y google-chrome-stable
-# remove google-chrome.list added by google-chrome-stable
-rm /etc/apt/sources.list.d/google-chrome.list
+# remove google-chrome.list added by google-chrome-stable (skipped on Debian 13 Trixie,
+# where postinst detects the pre-existing .sources file and does not write the legacy .list)
+rm -f /etc/apt/sources.list.d/google-chrome.list
 msg_ok "Installed Chrome"
 
 fetch_and_deploy_gh_release "flaresolverr" "FlareSolverr/FlareSolverr" "prebuild" "latest" "/opt/flaresolverr" "flaresolverr_linux_x64.tar.gz"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fix FlareSolverr installer aborting at line 32 of `install/flaresolverr-install.sh` with:

```
[ERROR] in line 32: exit code 1 (General error / Operation not permitted): while executing command rm /etc/apt/sources.list.d/google-chrome.list
```

**Root cause:** On Debian 13 "Trixie", `google-chrome-stable`'s postinst script detects the pre-existing deb822 `.sources` file written earlier by `setup_deb822_repo` and **skips** writing the legacy `/etc/apt/sources.list.d/google-chrome.list`. The subsequent unconditional `rm` then fails because the file never existed, and `catch_errors` aborts the install.

**Fix:** Switch `rm` → `rm -f` so the cleanup is a no-op when the file is absent, while still removing it on hosts/edge cases where postinst did create it. Also updated the inline comment to explain the Trixie behavior.

## 🔗 Related Issue

Fixes #13585

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Verified fresh FlareSolverr LXC create on a Debian 13 Trixie template completes past the Chrome install step; `apt update` inside the container produces no duplicate-repo warnings (only the `.sources` file remains).
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues. `rm -f` is a drop-in replacement of the existing `rm` with identical scope.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.