### PR TITLE
Add ProxMigrate LXC Script

### DIFF
--- a/ct/Proxmigrate.sh
+++ b/ct/Proxmigrate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: csd440
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/backupassure/proxmigrate
+
+APP="ProxMigrate"
+var_tags="${var_tags:-proxmox;migration;vm;management;import;backup}"
+var_cpu="${var_cpu:-2}"
+var_ram="${var_ram:-2048}"
+var_disk="${var_disk:-16}"
+var_os="${var_os:-debian}"
+var_version="${var_version:-12}"
+var_unprivileged="${var_unprivileged:-1}"
+
+header_info "$APP"
+variables
+color
+catch_errors
+
+function update_script() {
+  header_info
+  check_container_storage
+  check_container_resources
+
+  if [[ ! -d /opt/proxmigrate-src ]]; then
+    msg_error "No ${APP} Installation Found!"
+    exit
+  fi
+
+  msg_info "Updating ${APP}"
+  cd /opt/proxmigrate-src || exit
+  $STD git pull origin main
+  $STD sudo ./update.sh
+  msg_ok "Updated ${APP}"
+
+  exit
+}
+
+start
+build_container
+description
+
+msg_ok "Completed successfully!\n"
+echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
+echo -e "${INFO}${YW} Access it using the following URL:${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}:8443${CL}"

--- a/install/proxmigrate-install.sh
+++ b/install/proxmigrate-install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2021-2026 community-scripts ORG
+# Author: csd440
+# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+# Source: https://github.com/backupassure/proxmigrate
+
+source /dev/stdin <<<"$FUNCTIONS_FILE_PATH"
+color
+verb_ip6
+catch_errors
+setting_up_container
+network_check
+update_os
+
+msg_info "Installing Dependencies"
+$STD apt-get install -y git
+msg_ok "Installed Dependencies"
+
+msg_info "Cloning ${APP} Repository"
+$STD git clone https://github.com/backupassure/proxmigrate.git /opt/proxmigrate-src
+msg_ok "Cloned ${APP} Repository"
+
+msg_info "Running ${APP} Installer"
+cd /opt/proxmigrate-src || exit
+$STD bash install.sh
+msg_ok "Installed ${APP}"
+
+motd_ssh
+customize
+cleanup_lxc


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

ProxMigrate is a free, self-hosted Django web UI for Proxmox VE — import disk images, create/manage VMs and LXC containers, deploy community scripts, all from a browser. Made by Backup Assure. HTTPS on port 8443.

- **ct/Proxmigrate.sh** — Container creation wrapper (sources build.func, sets defaults, includes update_script)
- **install/proxmigrate-install.sh** — Clones the ProxMigrate repo and runs its bare-metal installer (handles Python venv, nginx, systemd, SSL certs, etc.)

Source: https://github.com/backupassure/proxmigrate

## 🔗 Related Issue

N/A

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [x] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
