### PR TITLE
immich: disable upgrade-insecure-requests CSP directive

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -181,6 +181,12 @@ EOF
     unset SHARP_IGNORE_GLOBAL_LIBVIPS
     export SHARP_FORCE_GLOBAL_LIBVIPS=true
     $STD pnpm --filter immich --frozen-lockfile --prod --no-optional deploy "$APP_DIR"
+
+    # Patch helmet.json: disable upgrade-insecure-requests for HTTP access
+    if [[ -f "$APP_DIR/helmet.json" ]]; then
+      jq '.contentSecurityPolicy.directives["upgrade-insecure-requests"] = null' "$APP_DIR/helmet.json" >"$APP_DIR/helmet.json.tmp" && mv "$APP_DIR/helmet.json.tmp" "$APP_DIR/helmet.json"
+    fi
+
     cp "$APP_DIR"/package.json "$APP_DIR"/bin
     sed -i "s|^start|${APP_DIR}/bin/start|" "$APP_DIR"/bin/immich-admin
 

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -312,6 +312,12 @@ $STD pnpm --filter immich --frozen-lockfile build
 unset SHARP_IGNORE_GLOBAL_LIBVIPS
 export SHARP_FORCE_GLOBAL_LIBVIPS=true
 $STD pnpm --filter immich --frozen-lockfile --prod --no-optional deploy "$APP_DIR"
+
+# Patch helmet.json: disable upgrade-insecure-requests for HTTP access
+if [[ -f "$APP_DIR/helmet.json" ]]; then
+  jq '.contentSecurityPolicy.directives["upgrade-insecure-requests"] = null' "$APP_DIR/helmet.json" >"$APP_DIR/helmet.json.tmp" && mv "$APP_DIR/helmet.json.tmp" "$APP_DIR/helmet.json"
+fi
+
 cp "$APP_DIR"/package.json "$APP_DIR"/bin
 sed -i "s|^start|${APP_DIR}/bin/start|" "$APP_DIR"/bin/immich-admin
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Helmet's useDefaults adds upgrade-insecure-requests to the CSP, which forces browsers to upgrade all HTTP requests to HTTPS. Since most LXC users access Immich directly via HTTP, this breaks the web UI completely (CORS errors, spinning logo).

Patch helmet.json after deploy to explicitly null out the directive, keeping CSP benefits while allowing HTTP access.

## 🔗 Related Issue

Fixes #13597

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
