### PR TITLE
bambuddy: add mkdir before data restore & add ffmpeg dependency

### DIFF
--- a/ct/bambuddy.sh
+++ b/ct/bambuddy.sh
@@ -29,6 +29,8 @@ function update_script() {
     exit
   fi
 
+  ensure_dependencies ffmpeg
+
   if check_for_gh_release "bambuddy" "maziggy/bambuddy"; then
     msg_info "Stopping Service"
     systemctl stop bambuddy
@@ -54,6 +56,7 @@ function update_script() {
     msg_ok "Rebuilt Frontend"
 
     msg_info "Restoring Configuration and Data"
+    mkdir -p /opt/bambuddy/data
     cp /opt/bambuddy.env.bak /opt/bambuddy/.env
     cp -r /opt/bambuddy_data_bak/. /opt/bambuddy/data/
     rm -f /opt/bambuddy.env.bak

--- a/install/bambuddy-install.sh
+++ b/install/bambuddy-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y libglib2.0-0
+$STD apt install -y libglib2.0-0 ffmpeg
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.13" setup_uv


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Add mkdir -p before restoring data dir to prevent data loss on update (CLEAN_INSTALL=1 wipes target dir including SQLite DB)
- Add ffmpeg as dependency for printer cam support
- Add ensure_dependencies ffmpeg to update path for existing containers

## 🔗 Related Issue

Fixes #13598, Fixes #13599

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
