### PR TITLE
CheckMK: Bump Default OS to 13 (trixie) + dynamic codename + fix RELEASE-Tag Fetching

### DIFF
--- a/ct/checkmk.sh
+++ b/ct/checkmk.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-6}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -29,10 +29,11 @@ function update_script() {
   fi
 
   RELEASE=$(curl -fsSL https://api.github.com/repos/checkmk/checkmk/tags | grep "name" | awk '{print substr($2, 3, length($2)-4) }' | tr ' ' '\n' | grep -Ev 'rc|b' | sort -V | tail -n 1)
+  RELEASE="${RELEASE%%+*}"
   msg_info "Updating ${APP} to v${RELEASE}"
   $STD omd stop monitoring
   $STD omd cp monitoring monitoringbackup
-  curl -fsSL "https://download.checkmk.com/checkmk/${RELEASE}/check-mk-raw-${RELEASE}_0.bookworm_amd64.deb" -o "/opt/checkmk.deb"
+  curl -fsSL "https://download.checkmk.com/checkmk/${RELEASE}/check-mk-raw-${RELEASE}_0.$(get_os_info codename)_amd64.deb" -o "/opt/checkmk.deb"
   $STD apt-get install -y /opt/checkmk.deb
   $STD omd --force -V ${RELEASE}.cre update --conflict=install monitoring
   $STD omd start monitoring

--- a/install/checkmk-install.sh
+++ b/install/checkmk-install.sh
@@ -15,7 +15,8 @@ update_os
 
 msg_info "Install Checkmk"
 RELEASE=$(curl -fsSL https://api.github.com/repos/checkmk/checkmk/tags | grep "name" | awk '{print substr($2, 3, length($2)-4) }' | tr ' ' '\n' | grep -Ev 'rc|b' | sort -V | tail -n 1)
-curl -fsSL "https://download.checkmk.com/checkmk/${RELEASE}/check-mk-raw-${RELEASE}_0.bookworm_amd64.deb" -o "/opt/checkmk.deb"
+RELEASE="${RELEASE%%+*}"
+curl -fsSL "https://download.checkmk.com/checkmk/${RELEASE}/check-mk-raw-${RELEASE}_0.$(get_os_info codename)_amd64.deb" -o "/opt/checkmk.deb"
 $STD apt-get install -y /opt/checkmk.deb
 rm -rf /opt/checkmk.deb
 echo "${RELEASE}" >"/opt/checkmk_version.txt"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Bump default Checkmk version to 13 and make package download resilient across OS codenames and tag metadata. Trim any "+" suffix from the GitHub tag (RELEASE="${RELEASE%%+*}") and replace the hardcoded "bookworm" in the .deb filename with $(get_os_info codename). Changes applied to ct/checkmk.sh and install/checkmk-install.sh to ensure correct package selection and installation/update flow.

## 🔗 Related Issue

Fixes #13609

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
