### PR TITLE
BentoPDF: replace http-server with nginx to fix WASM initialization timeout

### DIFF
--- a/ct/bentopdf.sh
+++ b/ct/bentopdf.sh
@@ -51,6 +51,11 @@ function update_script() {
     export SIMPLE_MODE=true
     export VITE_USE_CDN=true
     $STD npm run build:all
+    if [[ ! -f /opt/bentopdf/dist/config.json ]]; then
+      cat <<'EOF' >/opt/bentopdf/dist/config.json
+{}
+EOF
+    fi
     msg_ok "Updated BentoPDF"
 
     msg_info "Starting Service"

--- a/ct/bentopdf.sh
+++ b/ct/bentopdf.sh
@@ -42,7 +42,6 @@ function update_script() {
     msg_info "Updating BentoPDF"
     cd /opt/bentopdf
     $STD npm ci --no-audit --no-fund
-    $STD npm install http-server -g
     if [[ -f /opt/production.env ]]; then
       mv /opt/production.env ./.env.production
     else
@@ -55,10 +54,47 @@ function update_script() {
     msg_ok "Updated BentoPDF"
 
     msg_info "Starting Service"
-    if grep -q '8080' /etc/systemd/system/bentopdf.service; then
-      sed -i -e 's|/bentopdf|/bentopdf/dist|' \
-        -e 's|npx.*|npx http-server -g -b -d false -r --no-dotfiles|' \
-        /etc/systemd/system/bentopdf.service
+    if ! command -v nginx &>/dev/null; then
+      ensure_dependencies nginx
+      cat <<'EOF' >/etc/nginx/sites-available/bentopdf
+server {
+    listen 8080;
+    server_name _;
+    root /opt/bentopdf/dist;
+    index index.html;
+
+    # Required for LibreOffice WASM (Word/Excel/PowerPoint to PDF via SharedArrayBuffer)
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp" always;
+    add_header Cross-Origin-Resource-Policy "cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    gzip_static on;
+
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    error_page 404 /404.html;
+}
+EOF
+      rm -f /etc/nginx/sites-enabled/default
+      ln -sf /etc/nginx/sites-available/bentopdf /etc/nginx/sites-enabled/bentopdf
+      cat <<'EOF' >/etc/systemd/system/bentopdf.service
+[Unit]
+Description=BentoPDF Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/sbin/nginx -g "daemon off;"
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
       systemctl daemon-reload
     fi
     systemctl start bentopdf

--- a/ct/bentopdf.sh
+++ b/ct/bentopdf.sh
@@ -54,9 +54,8 @@ function update_script() {
     msg_ok "Updated BentoPDF"
 
     msg_info "Starting Service"
-    if ! command -v nginx &>/dev/null; then
-      ensure_dependencies nginx
-      cat <<'EOF' >/etc/nginx/sites-available/bentopdf
+    ensure_dependencies nginx
+    cat <<'EOF' >/etc/nginx/sites-available/bentopdf
 server {
     listen 8080;
     server_name _;
@@ -72,6 +71,33 @@ server {
 
     gzip_static on;
 
+    location ~* /libreoffice-wasm/soffice\.wasm\.gz$ {
+      gzip off;
+      types {} default_type application/wasm;
+      add_header Content-Encoding gzip;
+      add_header Vary "Accept-Encoding";
+      add_header Cache-Control "public, immutable";
+    }
+
+    location ~* /libreoffice-wasm/soffice\.data\.gz$ {
+      gzip off;
+      types {} default_type application/octet-stream;
+      add_header Content-Encoding gzip;
+      add_header Vary "Accept-Encoding";
+      add_header Cache-Control "public, immutable";
+    }
+
+    location ~* \.wasm$ {
+      types {} default_type application/wasm;
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+    }
+
+    location ~* \.(wasm\.gz|data\.gz|data)$ {
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+    }
+
     location / {
         try_files $uri $uri/ $uri.html =404;
     }
@@ -79,9 +105,9 @@ server {
     error_page 404 /404.html;
 }
 EOF
-      rm -f /etc/nginx/sites-enabled/default
-      ln -sf /etc/nginx/sites-available/bentopdf /etc/nginx/sites-enabled/bentopdf
-      cat <<'EOF' >/etc/systemd/system/bentopdf.service
+    rm -f /etc/nginx/sites-enabled/default
+    ln -sf /etc/nginx/sites-available/bentopdf /etc/nginx/sites-enabled/bentopdf
+    cat <<'EOF' >/etc/systemd/system/bentopdf.service
 [Unit]
 Description=BentoPDF Service
 After=network.target
@@ -95,8 +121,7 @@ Restart=always
 [Install]
 WantedBy=multi-user.target
 EOF
-      systemctl daemon-reload
-    fi
+    systemctl daemon-reload
     systemctl start bentopdf
     msg_ok "Started Service"
     msg_ok "Updated successfully!"

--- a/ct/bentopdf.sh
+++ b/ct/bentopdf.sh
@@ -54,11 +54,26 @@ function update_script() {
     msg_ok "Updated BentoPDF"
 
     msg_info "Starting Service"
-    ensure_dependencies nginx
+    ensure_dependencies nginx openssl
+    if [[ ! -f /etc/ssl/private/bentopdf-selfsigned.key || ! -f /etc/ssl/certs/bentopdf-selfsigned.crt ]]; then
+      CERT_CN="$(hostname -I | awk '{print $1}')"
+      $STD openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+      -keyout /etc/ssl/private/bentopdf-selfsigned.key \
+      -out /etc/ssl/certs/bentopdf-selfsigned.crt \
+      -subj "/CN=${CERT_CN}"
+    fi
     cat <<'EOF' >/etc/nginx/sites-available/bentopdf
 server {
     listen 8080;
     server_name _;
+    return 301 https://$host:8443$request_uri;
+  }
+
+  server {
+    listen 8443 ssl;
+    server_name _;
+    ssl_certificate /etc/ssl/certs/bentopdf-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/bentopdf-selfsigned.key;
     root /opt/bentopdf/dist;
     index index.html;
 
@@ -136,4 +151,4 @@ description
 msg_ok "Completed successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW} Access it using the following URL:${CL}"
-echo -e "${TAB}${GATEWAY}${BGN}http://${IP}:8080${CL}"
+echo -e "${TAB}${GATEWAY}${BGN}https://${IP}:8443${CL}"

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -13,7 +13,6 @@ setting_up_container
 network_check
 update_os
 
-
 msg_info "Installing Dependencies"
 $STD apt install nginx -y
 msg_ok "Installed Dependencies"
@@ -47,6 +46,33 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
 
     gzip_static on;
+
+    location ~* /libreoffice-wasm/soffice\.wasm\.gz$ {
+        gzip off;
+        types {} default_type application/wasm;
+        add_header Content-Encoding gzip;
+        add_header Vary "Accept-Encoding";
+        add_header Cache-Control "public, immutable";
+    }
+
+    location ~* /libreoffice-wasm/soffice\.data\.gz$ {
+        gzip off;
+        types {} default_type application/octet-stream;
+        add_header Content-Encoding gzip;
+        add_header Vary "Accept-Encoding";
+        add_header Cache-Control "public, immutable";
+    }
+
+    location ~* \.wasm$ {
+        types {} default_type application/wasm;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location ~* \.(wasm\.gz|data\.gz|data)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
 
     location / {
         try_files $uri $uri/ $uri.html =404;

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -26,6 +26,11 @@ export NODE_OPTIONS="--max-old-space-size=3072"
 export SIMPLE_MODE=true
 export VITE_USE_CDN=true
 $STD npm run build:all
+if [[ ! -f /opt/bentopdf/dist/config.json ]]; then
+    cat <<'EOF' >/opt/bentopdf/dist/config.json
+{}
+EOF
+fi
 msg_ok "Setup BentoPDF"
 
 msg_info "Creating Service"

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -19,7 +19,7 @@ fetch_and_deploy_gh_release "bentopdf" "alam00000/bentopdf" "tarball" "latest" "
 msg_info "Setup BentoPDF"
 cd /opt/bentopdf
 $STD npm ci --no-audit --no-fund
-$STD npm install http-server -g
+ensure_dependencies nginx
 cp ./.env.example ./.env.production
 export NODE_OPTIONS="--max-old-space-size=3072"
 export SIMPLE_MODE=true
@@ -28,17 +28,41 @@ $STD npm run build:all
 msg_ok "Setup BentoPDF"
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/bentopdf.service
+cat <<'EOF' >/etc/nginx/sites-available/bentopdf
+server {
+    listen 8080;
+    server_name _;
+    root /opt/bentopdf/dist;
+    index index.html;
+
+    # Required for LibreOffice WASM (Word/Excel/PowerPoint to PDF via SharedArrayBuffer)
+    add_header Cross-Origin-Opener-Policy "same-origin" always;
+    add_header Cross-Origin-Embedder-Policy "require-corp" always;
+    add_header Cross-Origin-Resource-Policy "cross-origin" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+
+    gzip_static on;
+
+    location / {
+        try_files $uri $uri/ $uri.html =404;
+    }
+
+    error_page 404 /404.html;
+}
+EOF
+rm -f /etc/nginx/sites-enabled/default
+ln -sf /etc/nginx/sites-available/bentopdf /etc/nginx/sites-enabled/bentopdf
+cat <<'EOF' >/etc/systemd/system/bentopdf.service
 [Unit]
 Description=BentoPDF Service
 After=network.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/bentopdf/dist
-ExecStart=/usr/bin/npx http-server -g -b -d false -r --no-dotfiles
+ExecStart=/usr/sbin/nginx -g "daemon off;"
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
-RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -13,13 +13,17 @@ setting_up_container
 network_check
 update_os
 
+
+msg_info "Installing Dependencies"
+$STD apt install nginx -y
+msg_ok "Installed Dependencies"
+
 NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "bentopdf" "alam00000/bentopdf" "tarball" "latest" "/opt/bentopdf"
 
 msg_info "Setup BentoPDF"
 cd /opt/bentopdf
 $STD npm ci --no-audit --no-fund
-ensure_dependencies nginx
 cp ./.env.example ./.env.production
 export NODE_OPTIONS="--max-old-space-size=3072"
 export SIMPLE_MODE=true

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -26,11 +26,9 @@ export NODE_OPTIONS="--max-old-space-size=3072"
 export SIMPLE_MODE=true
 export VITE_USE_CDN=true
 $STD npm run build:all
-if [[ ! -f /opt/bentopdf/dist/config.json ]]; then
-    cat <<'EOF' >/opt/bentopdf/dist/config.json
+cat <<'EOF' >/opt/bentopdf/dist/config.json
 {}
 EOF
-fi
 msg_ok "Setup BentoPDF"
 
 msg_info "Creating Service"

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -13,7 +13,11 @@ setting_up_container
 network_check
 update_os
 
-ensure_dependencies nginx openssl
+msg_info "Installing Dependencies"
+$STD apt install -y \
+  nginx \
+  openssl
+msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "bentopdf" "alam00000/bentopdf" "tarball" "latest" "/opt/bentopdf"

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -32,13 +32,11 @@ EOF
 msg_ok "Setup BentoPDF"
 
 msg_info "Creating Service"
-if [[ ! -f /etc/ssl/private/bentopdf-selfsigned.key || ! -f /etc/ssl/certs/bentopdf-selfsigned.crt ]]; then
-  CERT_CN="$(hostname -I | awk '{print $1}')"
-  $STD openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+CERT_CN="$(hostname -I | awk '{print $1}')"
+$STD openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
     -keyout /etc/ssl/private/bentopdf-selfsigned.key \
     -out /etc/ssl/certs/bentopdf-selfsigned.crt \
     -subj "/CN=${CERT_CN}"
-fi
 
 cat <<'EOF' >/etc/nginx/sites-available/bentopdf
 server {

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -13,9 +13,7 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Dependencies"
-$STD apt install nginx -y
-msg_ok "Installed Dependencies"
+ensure_dependencies nginx openssl
 
 NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "bentopdf" "alam00000/bentopdf" "tarball" "latest" "/opt/bentopdf"
@@ -31,10 +29,26 @@ $STD npm run build:all
 msg_ok "Setup BentoPDF"
 
 msg_info "Creating Service"
+if [[ ! -f /etc/ssl/private/bentopdf-selfsigned.key || ! -f /etc/ssl/certs/bentopdf-selfsigned.crt ]]; then
+  CERT_CN="$(hostname -I | awk '{print $1}')"
+  $STD openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+    -keyout /etc/ssl/private/bentopdf-selfsigned.key \
+    -out /etc/ssl/certs/bentopdf-selfsigned.crt \
+    -subj "/CN=${CERT_CN}"
+fi
+
 cat <<'EOF' >/etc/nginx/sites-available/bentopdf
 server {
     listen 8080;
     server_name _;
+    return 301 https://$host:8443$request_uri;
+}
+
+server {
+    listen 8443 ssl;
+    server_name _;
+    ssl_certificate /etc/ssl/certs/bentopdf-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/bentopdf-selfsigned.key;
     root /opt/bentopdf/dist;
     index index.html;
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Replace \http-server\ with **nginx** as the static file server
- Configure a nginx site at \/etc/nginx/sites-available/bentopdf\ with the required \COOP\/\COEP\ headers (matching upstream)
- Add a **one-time migration** in \update_script\ so existing installations running the old \http-server\-based service are automatically migrated to nginx on next update

## 🔗 Related Issue

Fixes #13619

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
