### PR TITLE
omv: bumps default os to v13 (trixie) + network fix + omv-extras installation step

### DIFF
--- a/ct/omv.sh
+++ b/ct/omv.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -23,14 +23,17 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /etc/apt/sources.list.d/openmediavault.list ]]; then
+
+  if ! dpkg -s openmediavault &>/dev/null; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+
   msg_info "Updating ${APP} LXC"
   $STD apt update
   $STD apt -y upgrade
   msg_ok "Updated successfully!"
+
   exit
 }
 

--- a/install/omv-install.sh
+++ b/install/omv-install.sh
@@ -13,19 +13,37 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing OpenMediaVault (Patience)"
+msg_info "Installing OpenMediaVault (patience)"
 curl -fsSL "https://packages.openmediavault.org/public/archive.key" | gpg --dearmor >"/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg"
-cat <<EOF >/etc/apt/sources.list.d/openmediavault.list
-deb [signed-by=/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public sandworm main
-EOF
-
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public synchrony main" >/etc/apt/sources.list.d/openmediavault.list
+$STD apt update
 export LANG=C.UTF-8
 export DEBIAN_FRONTEND=noninteractive
 export APT_LISTCHANGES_FRONTEND=none
-$STD apt update
-apt -y --auto-remove --show-upgraded --allow-downgrades --allow-change-held-packages --no-install-recommends --option DPkg::Options::="--force-confdef" --option DPkg::Options::="--force-confold" install openmediavault-keyring openmediavault &>/dev/null
+apt install -y openmediavault-keyring openmediavault \
+  --allow-change-held-packages \
+  --allow-downgrades \
+  --auto-remove \
+  --no-install-recommends \
+  --option DPkg::Options::="--force-confdef" \
+  --option DPkg::Options::="--force-confold" \
+  --show-upgraded \
+  &>/dev/null
 omv-confdbadm populate &>/dev/null
+(systemctl restart networking &) &>/dev/null
 msg_ok "Installed OpenMediaVault"
+
+msg_info "Regenerating OpenMediaVault index (patience)"
+timeout 300s bash -c "until ping -c1 -W1 community-scripts.org &>/dev/null; do sleep 1; done"
+$STD apt update
+msg_ok "Regenerated OpenMediaVault index"
+
+if whiptail --title "Customize OMV" --yesno "Would you like to add OMV extras?" 8 60; then
+  msg_info "Installing OMV extras"
+  $STD bash <(curl -fsSL https://github.com/OpenMediaVault-Plugin-Developers/packages/raw/master/install)
+  rm -f /var/lib/dpkg/lock
+  msg_ok "Installed OMV extras"
+fi
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Bumped the base os version to trixie
- Added omv-extras installation step while providing the user an option to skip it
- Fixed a network issue by restarting the system networking service caused by the omv installation - this issue was there in the previous version

Tested this on a fresh lxc creation and update, as well as tested the update script on the previous v12 version.

I appreaciate your feedback and thanks :)

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
