### PR TITLE
MeTube: Allow pnpm build scripts to fix ERR_PNPM_IGNORED_BUILDS

### DIFF
--- a/ct/metube.sh
+++ b/ct/metube.sh
@@ -62,6 +62,7 @@ function update_script() {
       $STD corepack enable
       $STD corepack prepare pnpm --activate || true
     fi
+    echo 'onlyBuiltDependencies=*' >> .npmrc
     $STD pnpm install --frozen-lockfile
     $STD pnpm run build
     msg_ok "Built Frontend"

--- a/install/metube-install.sh
+++ b/install/metube-install.sh
@@ -41,6 +41,7 @@ if command -v corepack >/dev/null 2>&1; then
   $STD corepack enable
   $STD corepack prepare pnpm --activate || true
 fi
+echo 'onlyBuiltDependencies=*' >> .npmrc
 $STD pnpm install --frozen-lockfile
 $STD pnpm run build
 cd /opt/metube


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
“onlyBuiltDependencies=*” in .npmrc to resolve ERR_PNPM_IGNORED_BUILDS (Installation + Update)

## 🔗 Related Issue

Fixes #13650

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
