### PR TITLE
omv: bumps default os to v13 (trixie) + network fix + omv-extras installation step

### DIFF
--- a/ct/omv.sh
+++ b/ct/omv.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -23,13 +23,13 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /etc/apt/sources.list.d/openmediavault.list ]]; then
+  if ! dpkg -s openmediavault &>/dev/null; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
   msg_info "Updating ${APP} LXC"
   $STD apt update
-  $STD apt -y upgrade
+  $STD apt upgrade -y
   msg_ok "Updated successfully!"
   exit
 }

--- a/install/omv-install.sh
+++ b/install/omv-install.sh
@@ -13,19 +13,47 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing OpenMediaVault (Patience)"
+msg_info "Installing OpenMediaVault (patience)"
+nameservers=$(grep '^nameserver' /etc/resolv.conf | awk '{print $2}' | xargs)
 curl -fsSL "https://packages.openmediavault.org/public/archive.key" | gpg --dearmor >"/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg"
-cat <<EOF >/etc/apt/sources.list.d/openmediavault.list
-deb [signed-by=/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public sandworm main
-EOF
-
-export LANG=C.UTF-8
-export DEBIAN_FRONTEND=noninteractive
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.gpg] http://packages.openmediavault.org/public synchrony main" >/etc/apt/sources.list.d/openmediavault.list
 export APT_LISTCHANGES_FRONTEND=none
+export DEBIAN_FRONTEND=noninteractive
+export LANG=C.UTF-8
 $STD apt update
-apt -y --auto-remove --show-upgraded --allow-downgrades --allow-change-held-packages --no-install-recommends --option DPkg::Options::="--force-confdef" --option DPkg::Options::="--force-confold" install openmediavault-keyring openmediavault &>/dev/null
-omv-confdbadm populate &>/dev/null
+$STD apt install -y openmediavault openmediavault-keyring \
+  --allow-change-held-packages \
+  --allow-downgrades \
+  --auto-remove \
+  --no-install-recommends
 msg_ok "Installed OpenMediaVault"
+
+msg_info "Configuring OpenMediaVault (patience)"
+$STD omv-confdbadm populate
+sed -i "s/^#\?DNS=.*/DNS=$nameservers/" /etc/systemd/resolved.conf
+$STD systemctl restart systemd-resolved
+$STD apt update
+msg_ok "Configured OpenMediaVault index"
+
+echo
+read -r -p "${TAB3}Would you like to add plugins from OMV-extras repository? [y/N]: " CONFIRM
+echo
+if [[ "$CONFIRM" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+  msg_warn "WARNING: This script will run an external installer from a third-party source (https://wiki.omv-extras.org/)."
+  msg_warn "The following code is NOT maintained or audited by our repository."
+  msg_warn "If you have any doubts or concerns, please review the installer code before proceeding:"
+  msg_custom "${TAB3}${GATEWAY}${BGN}${CL}" "\e[1;34m" "→  https://github.com/OpenMediaVault-Plugin-Developers/packages/raw/master/install"
+  echo
+  read -r -p "${TAB3}Do you want to continue? [y/N]: " CONFIRM
+  echo
+  if [[ "$CONFIRM" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    msg_info "Installing OMV extras"
+    $STD bash <(curl -fsSL https://github.com/OpenMediaVault-Plugin-Developers/packages/raw/master/install)
+    msg_ok "Installed OMV extras"
+  else
+    msg_error "Aborted by user. No changes have been made."
+  fi
+fi
 
 motd_ssh
 customize


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Creating a new PR following https://github.com/community-scripts/ProxmoxVE/pull/13644 .

Changes done:
- bumped base OS to `trixie`
- added omv-extras installation step, installation option - it is not mandatory
- fixed a network issue by restarting the system networking service caused by the omv installation - this issue was there from the previous version

Tests done:
- update script on the current `bookworm` version of the container
- new container created with the updated installation script
- update script on the updated `trixie`version of the container

I appreaciate your feedback and thanks :)

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
