### PR TITLE
core: remove unused TEMP_DIR mktemp leak in build_container / clean sonarqube

### DIFF
--- a/ct/sonarqube.sh
+++ b/ct/sonarqube.sh
@@ -43,6 +43,7 @@ function update_script() {
     RELEASE=$(get_latest_github_release "SonarSource/sonarqube")
     curl -fsSL "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${RELEASE}.zip" -o $temp_file
     unzip -q "$temp_file" -d /opt
+    rm -f "$temp_file"
     mv /opt/sonarqube-${RELEASE} /opt/sonarqube
     echo "${RELEASE}" > ~/.sonarqube
     msg_ok "Updated SonarQube"

--- a/install/sonarqube-install.sh
+++ b/install/sonarqube-install.sh
@@ -21,6 +21,7 @@ temp_file=$(mktemp)
 RELEASE=$(get_latest_github_release "SonarSource/sonarqube")
 curl -fsSL "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-${RELEASE}.zip" -o $temp_file
 unzip -q "$temp_file" -d /opt
+rm -f "$temp_file"
 mv /opt/sonarqube-* /opt/sonarqube
 $STD useradd -r -m -U -d /opt/sonarqube -s /bin/bash sonarqube
 chown -R sonarqube:sonarqube /opt/sonarqube

--- a/misc/build.func
+++ b/misc/build.func
@@ -3613,8 +3613,6 @@ build_container() {
   fi
 
   # Build PCT_OPTIONS as string for export
-  TEMP_DIR=$(mktemp -d)
-  pushd "$TEMP_DIR" >/dev/null
   local _func_url
   if [ "$var_os" == "alpine" ]; then
     _func_url="https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/alpine-install.func"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
the build_container function created a temp directory via mktemp -d and pushd into it, but never popd or rm -rf. The directory was not used for anything — FUNCTIONS_FILE_PATH is downloaded into a variable, not a file.

Remove the mktem and pushd entirely to eliminate possible leak

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
