### PR TITLE
alpine-nextcloud-install: do not use deprecated nginx config

### DIFF
--- a/install/alpine-nextcloud-install.sh
+++ b/install/alpine-nextcloud-install.sh
@@ -102,8 +102,9 @@ server {
         fastcgi_read_timeout 120s;
 }
 server {
-        listen       443 ssl http2;
-        listen       [::]:443 ssl http2;
+        listen       443 ssl;
+        listen       [::]:443 ssl;
+        http2        on;
         server_name  localhost;
         root /usr/share/webapps/nextcloud;
         index  index.php index.html index.htm;


### PR DESCRIPTION
Fixes the warning:

## ✍️ Description
The current `nginx` config generates the warnings
```
[warn] 1455#1455: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/http.d/nextcloud.conf:10
[warn] 1455#1455: the "listen ... http2" directive is deprecated, use the "http2" directive instead in /etc/nginx/http.d/nextcloud.conf:11
```

## 🔗 Related Issue



## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
