### PR TITLE
Lyrion: correct service name and version file in update script

### DIFF
--- a/ct/lyrionmusicserver.sh
+++ b/ct/lyrionmusicserver.sh
@@ -30,16 +30,16 @@ function update_script() {
     exit
   fi
 
-  DEB_URL=$(curl -s 'https://lyrion.org/getting-started/' | grep -oP '<a\s[^>]*href="\K[^"]*amd64\.deb(?="[^>]*>)' | head -n 1)
+  DEB_URL=$(curl_with_retry 'https://lyrion.org/getting-started/' | grep -oP '<a\s[^>]*href="\K[^"]*amd64\.deb(?="[^>]*>)' | head -n 1)
   RELEASE=$(echo "$DEB_URL" | grep -oP 'lyrionmusicserver_\K[0-9.]+(?=_amd64\.deb)')
   DEB_FILE="/tmp/lyrionmusicserver_${RELEASE}_amd64.deb"
   if [[ ! -f /opt/lyrion_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/lyrion_version.txt)" ]]; then
     msg_info "Updating $APP to ${RELEASE}"
-    curl -fsSL -o "$DEB_FILE" "$DEB_URL"
+    curl_with_retry "$DEB_URL" "$DEB_FILE"
     $STD apt install "$DEB_FILE" -y
-    systemctl restart lyrion
-    $STD rm -f "$DEB_FILE"
-    echo "${RELEASE}" >/opt/${APP}_version.txt
+    systemctl restart lyrionmusicserver
+    rm -f "$DEB_FILE"
+    echo "${RELEASE}" >/opt/lyrion_version.txt
     msg_ok "Updated $APP to ${RELEASE}"
     msg_ok "Updated successfully!"
   else

--- a/install/lyrionmusicserver-install.sh
+++ b/install/lyrionmusicserver-install.sh
@@ -14,10 +14,10 @@ network_check
 update_os
 
 msg_info "Setup Lyrion Music Server"
-DEB_URL=$(curl -fsSL 'https://lyrion.org/getting-started/' | grep -oP '<a\s[^>]*href="\K[^"]*amd64\.deb(?="[^>]*>)' | head -n 1)
+DEB_URL=$(curl_with_retry 'https://lyrion.org/getting-started/' | grep -oP '<a\s[^>]*href="\K[^"]*amd64\.deb(?="[^>]*>)' | head -n 1)
 RELEASE=$(echo "$DEB_URL" | grep -oP 'lyrionmusicserver_\K[0-9.]+(?=_amd64\.deb)')
 DEB_FILE="/tmp/lyrionmusicserver_${RELEASE}_amd64.deb"
-curl -fsSL -o "$DEB_FILE" "$DEB_URL"
+curl_with_retry "$DEB_URL" "$DEB_FILE"
 $STD apt install "$DEB_FILE" -y
 rm -f "$DEB_FILE"
 echo "${RELEASE}" >"/opt/lyrion_version.txt"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Fix systemctl restart from 'lyrion' to 'lyrionmusicserver'
- Fix version file path from /opt/\_version.txt (which expanded to 'Lyrion Music Server' with spaces) to /opt/lyrion_version.txt
- Remove unnecessary \ wrapper on rm command

## 🔗 Related Issue

Fixes #13723

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
