### PR TITLE
core: Add PHS_VERBOSE env var to skip verbose mode prompts

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -2702,16 +2702,21 @@ advanced_settings() {
     # STEP 28: Verbose Mode & Confirmation
     # ═══════════════════════════════════════════════════════════════════════════
     28)
-      local verbose_default_flag="--defaultno"
-      [[ "$_verbose" == "yes" ]] && verbose_default_flag=""
-
-      if whiptail --backtitle "Proxmox VE Helper Scripts [Step $STEP/$MAX_STEP]" \
-        --title "VERBOSE MODE" \
-        $verbose_default_flag \
-        --yesno "\nEnable Verbose Mode?\n\nShows detailed output during installation." 12 58; then
+      # PHS_VERBOSE=1 forces verbose mode and skips the prompt
+      if [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
         _verbose="yes"
       else
-        _verbose="no"
+        local verbose_default_flag="--defaultno"
+        [[ "$_verbose" == "yes" ]] && verbose_default_flag=""
+
+        if whiptail --backtitle "Proxmox VE Helper Scripts [Step $STEP/$MAX_STEP]" \
+          --title "VERBOSE MODE" \
+          $verbose_default_flag \
+          --yesno "\nEnable Verbose Mode?\n\nShows detailed output during installation." 12 58; then
+          _verbose="yes"
+        else
+          _verbose="no"
+        fi
       fi
       # Build summary
       local ct_type_desc="Unprivileged"
@@ -3519,6 +3524,14 @@ start() {
     return 0
   elif [ ! -z ${PHS_SILENT+x} ] && [[ "${PHS_SILENT}" == "1" ]]; then
     VERBOSE="no"
+    set_std_mode
+    ensure_profile_loaded
+    get_lxc_ip
+    update_script
+    update_motd_ip
+    cleanup_lxc
+  elif [ ! -z ${PHS_VERBOSE+x} ] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+    VERBOSE="yes"
     set_std_mode
     ensure_profile_loaded
     get_lxc_ip

--- a/misc/build.func
+++ b/misc/build.func
@@ -3522,22 +3522,16 @@ start() {
   if command -v pveversion >/dev/null 2>&1; then
     install_script || return 0
     return 0
-  elif [ ! -z ${PHS_SILENT+x} ] && [[ "${PHS_SILENT}" == "1" ]]; then
+  elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]] && [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+    whiptail --backtitle "Proxmox VE Helper Scripts" \
+      --title "⚠️ CONFLICT WARNING" \
+      --msgbox "PHS_SILENT and PHS_VERBOSE are both set.\n\nIgnoring both and prompting for selection." 10 58
+  elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
     VERBOSE="no"
     set_std_mode
-    ensure_profile_loaded
-    get_lxc_ip
-    update_script
-    update_motd_ip
-    cleanup_lxc
-  elif [ ! -z ${PHS_VERBOSE+x} ] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+  elif [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
     VERBOSE="yes"
     set_std_mode
-    ensure_profile_loaded
-    get_lxc_ip
-    update_script
-    update_motd_ip
-    cleanup_lxc
   else
     CHOICE=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "${APP} LXC Update/Setting" --menu \
       "Support/Update functions for ${APP} LXC. Choose an option:" \
@@ -3561,12 +3555,12 @@ start() {
       exit 0
       ;;
     esac
-    ensure_profile_loaded
-    get_lxc_ip
-    update_script
-    update_motd_ip
-    cleanup_lxc
   fi
+  ensure_profile_loaded
+  get_lxc_ip
+  update_script
+  update_motd_ip
+  cleanup_lxc
 }
 
 # ==============================================================================

--- a/misc/build.func
+++ b/misc/build.func
@@ -3521,8 +3521,8 @@ msg_menu() {
 resolve_phs_mode() {
   if [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]] && [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
     whiptail --backtitle "Proxmox VE Helper Scripts" \
-      --title "⚠️ CONFLICT WARNING" \
-      --msgbox "PHS_SILENT and PHS_VERBOSE are both set.\n\nIgnoring both and prompting for selection." 10 58
+      --title "⚠️ Configuration Conflict Warning" \
+      --msgbox "PHS_SILENT and PHS_VERBOSE environment variables are both set.\n\nFalling back to interactive mode." 10 58
     PHS_MODE="interactive"
   elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
     PHS_MODE="silent"

--- a/misc/build.func
+++ b/misc/build.func
@@ -2702,8 +2702,8 @@ advanced_settings() {
     # STEP 28: Verbose Mode & Confirmation
     # ═══════════════════════════════════════════════════════════════════════════
     28)
-      # PHS_VERBOSE=1 forces verbose mode and skips the prompt
-      if [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+      # PHS_VERBOSE forces verbose mode and skips the prompt
+      if [[ "$PHS_MODE" == "verbose" ]]; then
         _verbose="yes"
       else
         local verbose_default_flag="--defaultno"
@@ -3449,7 +3449,7 @@ configure_ssh_settings() {
 # msg_menu()
 #
 # - Displays a numbered menu for update_script() functions
-# - In silent mode (PHS_SILENT=1): auto-selects the default option
+# - In silent mode (PHS_MODE=silent): auto-selects the default option
 # - In interactive mode: shows menu via read with 10s timeout + default fallback
 # - Usage: CHOICE=$(msg_menu "Title" "tag1" "Description 1" "tag2" "Desc 2" ...)
 # - The first item is always the default
@@ -3473,7 +3473,7 @@ msg_menu() {
   local count=${#tags[@]}
 
   # Silent mode: return default immediately
-  if [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
+  if [[ "$PHS_MODE" == "silent" ]]; then
     echo "$default_tag"
     return 0
   fi
@@ -3510,6 +3510,30 @@ msg_menu() {
 }
 
 # ------------------------------------------------------------------------------
+# resolve_phs_mode()
+#
+# - Resolves PHS_SILENT/PHS_VERBOSE env vars into a single PHS_MODE enum
+# - Values: "silent", "verbose", "interactive"
+# - If both PHS_SILENT=1 and PHS_VERBOSE=1, shows a conflict warning
+#   and defaults to "interactive"
+# - Should be called once early, before any mode-dependent logic
+# ------------------------------------------------------------------------------
+resolve_phs_mode() {
+  if [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]] && [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+    whiptail --backtitle "Proxmox VE Helper Scripts" \
+      --title "⚠️ CONFLICT WARNING" \
+      --msgbox "PHS_SILENT and PHS_VERBOSE are both set.\n\nIgnoring both and prompting for selection." 10 58
+    PHS_MODE="interactive"
+  elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
+    PHS_MODE="silent"
+  elif [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+    PHS_MODE="verbose"
+  else
+    PHS_MODE="interactive"
+  fi
+}
+
+# ------------------------------------------------------------------------------
 # start()
 #
 # - Entry point of script
@@ -3519,17 +3543,14 @@ msg_menu() {
 # ------------------------------------------------------------------------------
 start() {
   source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/tools.func)
+  resolve_phs_mode
   if command -v pveversion >/dev/null 2>&1; then
     install_script || return 0
     return 0
-  elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]] && [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
-    whiptail --backtitle "Proxmox VE Helper Scripts" \
-      --title "⚠️ CONFLICT WARNING" \
-      --msgbox "PHS_SILENT and PHS_VERBOSE are both set.\n\nIgnoring both and prompting for selection." 10 58
-  elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
+  elif [[ "$PHS_MODE" == "silent" ]]; then
     VERBOSE="no"
     set_std_mode
-  elif [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
+  elif [[ "$PHS_MODE" == "verbose" ]]; then
     VERBOSE="yes"
     set_std_mode
   else

--- a/misc/core.func
+++ b/misc/core.func
@@ -940,7 +940,7 @@ is_verbose_mode() {
 #
 # - Detects if script is running in unattended/non-interactive mode
 # - Checks MODE variable first (primary method)
-# - Falls back to legacy flags (PHS_SILENT, var_unattended)
+# - Falls back to legacy flags (PHS_MODE, var_unattended)
 # - Returns 0 (true) if unattended, 1 (false) otherwise
 # - Used by prompt functions to auto-apply defaults
 #
@@ -984,7 +984,7 @@ is_unattended() {
   esac
 
   # Legacy fallbacks for compatibility
-  [[ "${PHS_SILENT:-0}" == "1" ]] && return 0
+  [[ "${PHS_MODE:-}" == "silent" ]] && return 0
   [[ "${var_unattended:-}" =~ ^(yes|true|1)$ ]] && return 0
   [[ "${UNATTENDED:-}" =~ ^(yes|true|1)$ ]] && return 0
 


### PR DESCRIPTION
## ✍️ Description

Adds a new `PHS_VERBOSE` environment variable to `misc/build.func` that mirrors the existing `PHS_SILENT` pattern. When `PHS_VERBOSE=1` is set:

- `VERBOSE` is forced to `"yes"`
- The verbose-mode whiptail prompt is skipped in the LXC update flow (`start()`)
- The verbose-mode prompt is skipped in the advanced-settings creation flow (step 28)

This lets users wire verbose mode into automation (e.g. `/usr/bin/update` inside an LXC) without touching the script or interacting with the menu, the same way `PHS_SILENT=1` already enables non-interactive silent updates.

Usage:

```bash
PHS_VERBOSE=1 update
```

## 🔗 Related Issue

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.