### PR TITLE
feat(homelable): add password reset utility script

### DIFF
--- a/install/homelable-install.sh
+++ b/install/homelable-install.sh
@@ -46,7 +46,7 @@ EOF
 msg_ok "Configured Homelable"
 
 msg_info "Creating Password Reset Utility"
-cat <<'EOF' >/opt/homelable/change_password.sh
+cat <<'EOF' >/root/change_password.sh
 #!/usr/bin/env bash
 
 NEW_PASS=""

--- a/install/homelable-install.sh
+++ b/install/homelable-install.sh
@@ -45,6 +45,30 @@ STATUS_CHECKER_INTERVAL=60
 EOF
 msg_ok "Configured Homelable"
 
+msg_info "Creating Password Reset Utility"
+cat <<'EOF' >/opt/homelable/change_password.sh
+#!/usr/bin/env bash
+
+NEW_PASS=""
+
+while [[ -z "$NEW_PASS" ]]; do
+    read -s -p "Enter new password: " NEW_PASS
+    echo ""
+    if [[ -z "$NEW_PASS" ]]; then
+        echo "Error: Password cannot be blank. Try again."
+    fi
+done
+
+HASH=$(/opt/homelable/backend/.venv/bin/python -c "from passlib.context import CryptContext; print(CryptContext(schemes=['bcrypt']).hash('${NEW_PASS}'))")
+
+sed -i "s|^AUTH_PASSWORD_HASH=.*|AUTH_PASSWORD_HASH='${HASH}'|" /opt/homelable/backend/.env
+
+systemctl restart homelable
+echo "Password updated and service restarted successfully!"
+EOF
+chmod +x /opt/homelable/change_password.sh
+msg_ok "Created Password Reset Utility"
+
 msg_info "Building Frontend"
 cd /opt/homelable/frontend
 $STD npm ci


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Added a utility script (`change_password.sh`) during the installation process to allow users to easily reset the default admin password. This resolves the UX issue where users had to manually generate a bcrypt hash and edit the `.env` file via CLI to change the default credentials.

## 🔗 Related Issue
N/A
Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
