### PR TITLE
core: sanitize mount_fs input — strip spaces and trailing commas

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1211,7 +1211,11 @@ load_vars_file() {
           fi
           ;;
         var_mount_fs)
-          if [[ ! "$var_val" =~ ^[a-zA-Z0-9,]+$ ]]; then
+          # Normalize: strip spaces, trailing commas
+          var_val="${var_val// /}"
+          var_val="${var_val%%,}"
+          var_val="${var_val##,}"
+          if [[ -n "$var_val" ]] && [[ ! "$var_val" =~ ^[a-zA-Z0-9]+(,[a-zA-Z0-9]+)*$ ]]; then
             msg_warn "Invalid mount_fs value '$var_val' in $file (comma-separated fs names only, e.g. nfs,cifs), ignoring"
             continue
           fi
@@ -2668,6 +2672,10 @@ advanced_settings() {
         --ok-button "Next" --cancel-button "Back" \
         --inputbox "\nAllow specific filesystem mounts.\n\nComma-separated list: nfs, cifs, fuse, ext4, etc.\nLeave empty for defaults (none).\n\nCurrent: $mount_hint" 14 62 "$_mount_fs" \
         3>&1 1>&2 2>&3); then
+        # Normalize: strip spaces and trailing/leading commas
+        result="${result// /}"
+        result="${result%%,}"
+        result="${result##,}"
         _mount_fs="$result"
         ((STEP++))
       else
@@ -3638,8 +3646,16 @@ build_container() {
 
   # Mount filesystem types (user configurable via advanced settings)
   if [ -n "${ALLOW_MOUNT_FS:-}" ]; then
-    [ -n "$FEATURES" ] && FEATURES="$FEATURES,"
-    FEATURES="${FEATURES}mount=${ALLOW_MOUNT_FS//,/;}"
+    # Sanitize: strip spaces, trailing/leading commas, then convert commas to semicolons
+    local _mount_clean="${ALLOW_MOUNT_FS// /}"
+    _mount_clean="${_mount_clean%%,}"
+    _mount_clean="${_mount_clean##,}"
+    _mount_clean="${_mount_clean%%;}"  
+    _mount_clean="${_mount_clean//,/;}"
+    if [ -n "$_mount_clean" ]; then
+      [ -n "$FEATURES" ] && FEATURES="$FEATURES,"
+      FEATURES="${FEATURES}mount=${_mount_clean}"
+    fi
   fi
 
   # Build PCT_OPTIONS as string for export


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Documented by Telemetry, some users write "cifs  nfs" or "nfs;" or "nfs, cifs".

This would produce invalid pct features strings like 'mount=nfs; cifs' (space breaks pct argument parsing) or 'mount=nfs;' (trailing semicolon). Fixes:

- Whiptail dialog (Step 27): normalize input immediately after entry
- load_vars_file validation: normalize before regex check, use stricter regex that rejects trailing/leading commas

All three layers ensure 'nfs, cifs' -> 'nfs,cifs' -> 'mount=nfs;cifs'

Main Issue:
  ✖️   Container creation failed. See /tmp/pct_create_110_20260417_115036_3c42c4da.log
+ tee -a /tmp/pct_create_110_20260417_115036_3c42c4da.log
+ pct create 110 local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst -features 'nesting=1,keyctl=1,mount=nfs;' cifs -hostname debian -tags 'community-script;os' -net0 name=eth0,bridge=vmbr0,ip=dhcp,ip6=auto -onboot 1 -cores 1 -memory 512 -unprivileged 1 -timezone Europe/Berlin -rootfs local-lvm:2
400 too many arguments
pct create <vmid> <ostemplate> [OPTIONS]


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
