### PR TITLE
core: pin IGC version to compute-runtime compatible tag (Intel GPU)

### DIFF
--- a/ct/jellyfin.sh
+++ b/ct/jellyfin.sh
@@ -32,10 +32,16 @@ function update_script() {
   if ! grep -qEi 'ubuntu' /etc/os-release; then
     msg_info "Updating Intel Dependencies"
     rm -f ~/.intel-* || true
-    fetch_and_deploy_gh_release "intel-igc-core-2" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-core-2_*_amd64.deb"
-    fetch_and_deploy_gh_release "intel-igc-opencl-2" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-opencl-2_*_amd64.deb"
+
+    # Fetch compute-runtime first so /tmp/gh_rel.json is populated for IGC tag resolution
     fetch_and_deploy_gh_release "intel-libgdgmm12" "intel/compute-runtime" "binary" "latest" "" "libigdgmm12_*_amd64.deb"
     fetch_and_deploy_gh_release "intel-opencl-icd" "intel/compute-runtime" "binary" "latest" "" "intel-opencl-icd_*_amd64.deb"
+
+    local igc_tag
+    _resolve_igc_tag igc_tag
+
+    fetch_and_deploy_gh_release "intel-igc-core-2" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-core-2_*_amd64.deb"
+    fetch_and_deploy_gh_release "intel-igc-opencl-2" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-opencl-2_*_amd64.deb"
     msg_ok "Updated Intel Dependencies"
   fi
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1139,39 +1139,42 @@ validate_github_token() {
     -H "Authorization: Bearer $token" \
     -H "Accept: application/vnd.github+json" \
     -H "X-GitHub-Api-Version: 2022-11-28" \
-    "https://api.github.com/user" 2>/dev/null) || { rm -f "$headers"; return 3; }
+    "https://api.github.com/user" 2>/dev/null) || {
+    rm -f "$headers"
+    return 3
+  }
   http_code="$response"
 
   # Read expiry header (fine-grained PATs carry this)
-  expiry_date=$(grep -i '^github-authentication-token-expiration:' "$headers" \
-    | sed 's/.*: *//' | tr -d '\r\n' || true)
+  expiry_date=$(grep -i '^github-authentication-token-expiration:' "$headers" |
+    sed 's/.*: *//' | tr -d '\r\n' || true)
   # Read token scopes (classic PATs)
-  scopes=$(grep -i '^x-oauth-scopes:' "$headers" \
-    | sed 's/.*: *//' | tr -d '\r\n' || true)
+  scopes=$(grep -i '^x-oauth-scopes:' "$headers" |
+    sed 's/.*: *//' | tr -d '\r\n' || true)
   rm -f "$headers"
 
   case "$http_code" in
-    200)
-      if [[ -n "$expiry_date" ]]; then
-        msg_ok "GitHub token is valid (expires: $expiry_date)."
-      else
-        msg_ok "GitHub token is valid (no expiry / fine-grained PAT)."
-      fi
-      # Warn if classic PAT has no public_repo scope
-      if [[ -n "$scopes" && "$scopes" != *"public_repo"* && "$scopes" != *"repo"* ]]; then
-        msg_warn "Token has no 'public_repo' scope - private repos and some release APIs may fail."
-        return 2
-      fi
-      return 0
-      ;;
-    401)
-      msg_error "GitHub token is invalid or expired (HTTP 401)."
-      return 1
-      ;;
-    *)
-      msg_warn "GitHub token validation returned HTTP $http_code - treating as valid."
-      return 0
-      ;;
+  200)
+    if [[ -n "$expiry_date" ]]; then
+      msg_ok "GitHub token is valid (expires: $expiry_date)."
+    else
+      msg_ok "GitHub token is valid (no expiry / fine-grained PAT)."
+    fi
+    # Warn if classic PAT has no public_repo scope
+    if [[ -n "$scopes" && "$scopes" != *"public_repo"* && "$scopes" != *"repo"* ]]; then
+      msg_warn "Token has no 'public_repo' scope - private repos and some release APIs may fail."
+      return 2
+    fi
+    return 0
+    ;;
+  401)
+    msg_error "GitHub token is invalid or expired (HTTP 401)."
+    return 1
+    ;;
+  *)
+    msg_warn "GitHub token validation returned HTTP $http_code - treating as valid."
+    return 0
+    ;;
   esac
 }
 
@@ -4605,6 +4608,23 @@ function setup_hwaccel() {
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
+# Resolve the IGC tag that the latest compute-runtime was built against.
+# Must be called AFTER a fetch_and_deploy_gh_release for intel/compute-runtime
+# so that /tmp/gh_rel.json contains the compute-runtime release metadata.
+# Sets the variable named by $1 (default: igc_tag) to the discovered tag.
+# ══════════════════════════════════════════════════════════════════════════════
+_resolve_igc_tag() {
+  local -n _out_ref="${1:-igc_tag}"
+  _out_ref="latest"
+  if [[ -f /tmp/gh_rel.json ]]; then
+    local _body _parsed
+    _body=$(jq -r '.body // empty' /tmp/gh_rel.json 2>/dev/null) || return 0
+    _parsed=$(grep -oP 'intel-graphics-compiler/releases/tag/\K[^\s\)]+' <<<"$_body" | head -1)
+    [[ -n "$_parsed" ]] && _out_ref="$_parsed"
+  fi
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
 # Intel Arc GPU Setup
 # ══════════════════════════════════════════════════════════════════════════════
 _setup_intel_arc() {
@@ -4630,12 +4650,17 @@ _setup_intel_arc() {
     if [[ "$os_codename" == "trixie" || "$os_codename" == "sid" ]]; then
       msg_info "Fetching Intel compute-runtime from GitHub for Arc support"
 
+      # Fetch a compute-runtime package first so /tmp/gh_rel.json is populated,
+      # then resolve the matching IGC tag from the release notes.
       # libigdgmm - bundled in compute-runtime releases
       fetch_and_deploy_gh_release "libigdgmm12" "intel/compute-runtime" "binary" "latest" "" "libigdgmm12_*_amd64.deb" || true
 
-      # Intel Graphics Compiler (note: packages have -2 suffix)
-      fetch_and_deploy_gh_release "intel-igc-core" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-core-2_*_amd64.deb" || true
-      fetch_and_deploy_gh_release "intel-igc-opencl" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-opencl-2_*_amd64.deb" || true
+      local igc_tag
+      _resolve_igc_tag igc_tag
+
+      # Intel Graphics Compiler – pinned to the version compute-runtime expects
+      fetch_and_deploy_gh_release "intel-igc-core" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-core-2_*_amd64.deb" || true
+      fetch_and_deploy_gh_release "intel-igc-opencl" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-opencl-2_*_amd64.deb" || true
 
       # Compute Runtime (depends on IGC and gmmlib)
       fetch_and_deploy_gh_release "intel-opencl-icd" "intel/compute-runtime" "binary" "latest" "" "intel-opencl-icd_*_amd64.deb" || true
@@ -4685,12 +4710,17 @@ _setup_intel_modern() {
     if [[ "$os_codename" == "trixie" || "$os_codename" == "sid" ]]; then
       msg_info "Fetching Intel compute-runtime from GitHub"
 
+      # Fetch a compute-runtime package first so /tmp/gh_rel.json is populated,
+      # then resolve the matching IGC tag from the release notes.
       # libigdgmm first (bundled in compute-runtime releases)
       fetch_and_deploy_gh_release "libigdgmm12" "intel/compute-runtime" "binary" "latest" "" "libigdgmm12_*_amd64.deb" || true
 
-      # Intel Graphics Compiler (note: packages have -2 suffix)
-      fetch_and_deploy_gh_release "intel-igc-core" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-core-2_*_amd64.deb" || true
-      fetch_and_deploy_gh_release "intel-igc-opencl" "intel/intel-graphics-compiler" "binary" "latest" "" "intel-igc-opencl-2_*_amd64.deb" || true
+      local igc_tag
+      _resolve_igc_tag igc_tag
+
+      # Intel Graphics Compiler – pinned to the version compute-runtime expects
+      fetch_and_deploy_gh_release "intel-igc-core" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-core-2_*_amd64.deb" || true
+      fetch_and_deploy_gh_release "intel-igc-opencl" "intel/intel-graphics-compiler" "binary" "$igc_tag" "" "intel-igc-opencl-2_*_amd64.deb" || true
 
       # Compute Runtime
       fetch_and_deploy_gh_release "intel-opencl-icd" "intel/compute-runtime" "binary" "latest" "" "intel-opencl-icd_*_amd64.deb" || true


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
intel-igc-core and intel-igc-opencl were fetched from intel/intel-graphics-compiler at 'latest' independently, which could install a version newer than what compute-runtime supports (e.g. IGC 2.32.7 vs compute-runtime expecting < 2.30.1), breaking apt deps for intel-opencl-icd and libze-intel-gpu1 on Debian Trixie.

Add _resolve_igc_tag() helper that parses the IGC tag from the compute-runtime release notes in /tmp/gh_rel.json (already written by fetch_and_deploy_gh_release). Use it in _setup_intel_arc(), _setup_intel_modern(), and ct/jellyfin.sh update_script() to always install the IGC version that compute-runtime was built against.


Currently affected and reproducable at flaresolverr 

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
