### PR TITLE
Fix for bambuddy community script update

### DIFF
--- a/ct/bambuddy.sh
+++ b/ct/bambuddy.sh
@@ -48,7 +48,7 @@ function update_script() {
 
     msg_info "Updating Python Dependencies"
     cd /opt/bambuddy
-    $STD uv venv
+    $STD uv venv --clear
     $STD uv pip install -r requirements.txt
     msg_ok "Updated Python Dependencies"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The community script runs a `uv venv` without `--clear` which breaks the update and leaves the CT in an unusable state


## 🔗 Related Issue

Fixes #
Just added `--clear` to the `uv venv` command

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
