### PR TITLE
SparkyFitness Garmin Microservice: fix update function

### DIFF
--- a/tools/addon/sparkyfitness-garmin.sh
+++ b/tools/addon/sparkyfitness-garmin.sh
@@ -69,6 +69,9 @@ function update() {
     msg_ok "Stopped service"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "sparkyfitness-garmin" "CodeWithCJ/SparkyFitness" "tarball" "latest" $INSTALL_PATH
+    cd $INSTALL_PATH/SparkyFitnessGarmin
+    $STD uv venv --clear .venv
+    $STD uv pip install -r requirements.txt
 
     msg_info "Starting service"
     systemctl start sparkyfitness-garmin


### PR DESCRIPTION
## ✍️ Description
Fixes the update function of the  SparkyFitness Garmin Microservice be re-creating the python `venv` after `CLEAN_INSTALL=1 fetch_and_deploy_gh_release` removed it.
This will also fix the referenced issue as the newest SparkyFitness version fixed the Garmin issue.

## 🔗 Related Issue

Fixes #13470

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
