### PR TITLE
litellm: add prisma generate and use venv binary directly

### DIFF
--- a/ct/litellm.sh
+++ b/ct/litellm.sh
@@ -38,11 +38,17 @@ function update_script() {
 
   msg_info "Updating LiteLLM"
   $STD "$VENV_PATH/bin/python" -m pip install --upgrade litellm[proxy] prisma
+  $STD "$VENV_PATH/bin/prisma" generate
   msg_ok "LiteLLM updated"
 
   msg_info "Updating DB Schema"
-  $STD uv --directory=/opt/litellm run litellm --config /opt/litellm/litellm.yaml --use_prisma_db_push --skip_server_startup
+  $STD /opt/litellm/.venv/bin/litellm --config /opt/litellm/litellm.yaml --use_prisma_db_push --skip_server_startup
   msg_ok "DB Schema Updated"
+
+  msg_info "Updating Service"
+  sed -i 's|ExecStart=uv --directory=/opt/litellm run litellm|ExecStart=/opt/litellm/.venv/bin/litellm|' /etc/systemd/system/litellm.service
+  systemctl daemon-reload
+  msg_ok "Updated Service"
 
   msg_info "Starting Service"
   systemctl start litellm

--- a/install/litellm-install.sh
+++ b/install/litellm-install.sh
@@ -30,6 +30,7 @@ $STD uv venv --clear /opt/litellm/.venv
 $STD /opt/litellm/.venv/bin/python -m ensurepip --upgrade
 $STD /opt/litellm/.venv/bin/python -m pip install --upgrade pip
 $STD /opt/litellm/.venv/bin/python -m pip install litellm[proxy] prisma
+$STD /opt/litellm/.venv/bin/prisma generate
 msg_ok "Installed LiteLLM"
 
 msg_info "Configuring LiteLLM"
@@ -40,7 +41,7 @@ general_settings:
   database_url: postgresql://$PG_DB_USER:$PG_DB_PASS@127.0.0.1:5432/$PG_DB_NAME
   store_model_in_db: true
 EOF
-uv --directory=/opt/litellm run litellm --config /opt/litellm/litellm.yaml --use_prisma_db_push --skip_server_startup
+$STD /opt/litellm/.venv/bin/litellm --config /opt/litellm/litellm.yaml --use_prisma_db_push --skip_server_startup
 msg_ok "Configured LiteLLM"
 
 msg_info "Creating Service"
@@ -50,7 +51,7 @@ Description=LiteLLM
 
 [Service]
 Type=simple
-ExecStart=uv --directory=/opt/litellm run litellm --config /opt/litellm/litellm.yaml
+ExecStart=/opt/litellm/.venv/bin/litellm --config /opt/litellm/litellm.yaml
 Restart=always
 
 [Install]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The install failed on startup because Prisma engine binaries were never generated. Added 'prisma generate' after pip install and changed both the setup command and systemd service to use the venv binary directly instead of 'uv run', ensuring prisma binaries persist between install and service start.

## 🔗 Related Issue

Fixes #13793

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
