### PR TITLE
BabyBuddy: set DJANGO_SETTINGS_MODULE before migrate in update

### DIFF
--- a/ct/babybuddy.sh
+++ b/ct/babybuddy.sh
@@ -48,6 +48,7 @@ function update_script() {
     mv /tmp/production.py.bak /opt/babybuddy/babybuddy/settings/production.py
     source .venv/bin/activate
     $STD uv pip install -r requirements.txt
+    export DJANGO_SETTINGS_MODULE=babybuddy.settings.production
     $STD python manage.py migrate
     msg_ok "Updated ${APP}"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The upgrade from 2.7.1 to 2.8.0 fails because manage.py migrate is called without DJANGO_SETTINGS_MODULE being set, causing Django to raise ImproperlyConfigured
the install script sets it but the update function was missing it

## 🔗 Related Issue

Fixes #13800

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
