### PR TITLE
Clean-Orphan-LVM: check all cluster nodes for VM/CT configs

### DIFF
--- a/tools/pve/clean-orphaned-lvm.sh
+++ b/tools/pve/clean-orphaned-lvm.sh
@@ -37,8 +37,9 @@ function find_orphaned_lvm {
     fi
 
     container_id=$(echo "$lv" | grep -oE "[0-9]+" | head -1)
-    # Check if the ID exists as a VM or LXC container
-    if [ -f "/etc/pve/lxc/${container_id}.conf" ] || [ -f "/etc/pve/qemu-server/${container_id}.conf" ]; then
+    # Check if the ID exists as a VM or LXC container on any cluster node
+    if compgen -G "/etc/pve/nodes/*/lxc/${container_id}.conf" >/dev/null 2>&1 ||
+      compgen -G "/etc/pve/nodes/*/qemu-server/${container_id}.conf" >/dev/null 2>&1; then
       continue
     fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
On multi-host clusters with shared storage (iSCSI/NAS), the script only checked the local node's configs (/etc/pve/lxc/ and /etc/pve/qemu-server/) and falsely flagged VMs/CTs running on other nodes as orphaned. Now checks /etc/pve/nodes/*/lxc/ and /etc/pve/nodes/*/qemu-server/ to cover all cluster members.

## 🔗 Related Issue

Fixes #13827

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
