### PR TITLE
ActualBudget: change migration messages to warnings

### DIFF
--- a/ct/actualbudget.sh
+++ b/ct/actualbudget.sh
@@ -48,9 +48,9 @@ function update_script() {
       msg_ok "Updated successfully!"
     fi
   else
-    msg_info "Old Installation Found, you need to migrate your data and recreate to a new container"
-    msg_info "Please follow the instructions on the Actual Budget website to migrate your data"
-    msg_info "https://actualbudget.org/docs/backup-restore/backup"
+    msg_warn "Old Installation Found, you need to migrate your data and recreate to a new container"
+    msg_warn "Please follow the instructions on the Actual Budget website to migrate your data"
+    msg_warn "https://actualbudget.org/docs/backup-restore/backup"
     exit
   fi
   exit


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replace msg_info calls with msg_warn in actualbudget for the old-installation migration prompts so the migration instructions are shown as warnings rather than informational messages and endless spinner.

## 🔗 Related Issue

https://github.com/community-scripts/ProxmoxVE/discussions/807#discussioncomment-15441093

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
