### PR TITLE
Pangolin: pre-apply schema migrations to prevent data loss

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -69,7 +69,18 @@ function update_script() {
 
     msg_info "Running database migrations"
     cd /opt/pangolin
-    ENVIRONMENT=prod $STD npx drizzle-kit push --config drizzle.sqlite.config.ts
+
+    # Pre-apply potentially destructive schema changes safely so drizzle-kit
+    # does not recreate tables (which would delete all rows).
+    local DB="/opt/pangolin/config/db/db.sqlite"
+    if [[ -f "$DB" ]]; then
+      sqlite3 "$DB" "ALTER TABLE 'orgs' ADD COLUMN 'settingsLogRetentionDaysConnection' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
+      sqlite3 "$DB" "ALTER TABLE 'clientSitesAssociationsCache' ADD COLUMN 'isJitMode' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
+      # Migrate roleId from userOrgs → userOrgRoles before the column is dropped
+      sqlite3 "$DB" "INSERT OR IGNORE INTO 'userOrgRoles' (userId, orgId, roleId) SELECT userId, orgId, roleId FROM 'userOrgs' WHERE roleId IS NOT NULL;" 2>/dev/null || true
+    fi
+
+    ENVIRONMENT=prod $STD npx drizzle-kit push --force --config drizzle.sqlite.config.ts
     msg_ok "Ran database migrations"
 
     msg_info "Updating Badger plugin version"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
drizzle-kit push recreates tables when adding NOT NULL columns without defaults, deleting all rows. Pre-apply settingsLogRetentionDaysConnection and isJitMode columns with defaults via sqlite3 before running drizzle. Migrate roleId data from userOrgs to userOrgRoles before the column is dropped. Add --force flag since destructive ops are now safe.

Fix based on their docs / dockerfile / code, not tested


## 🔗 Related Issue

Fixes #13857

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
