### PR TITLE
slskd: migrate config keys for 0.25.0 breaking change

### DIFF
--- a/ct/slskd.sh
+++ b/ct/slskd.sh
@@ -43,6 +43,10 @@ function update_script() {
 
     msg_info "Restoring config"
     mv /opt/slskd.yml.bak /opt/slskd/config/slskd.yml
+
+    # Migrate 0.25.0 breaking config key renames
+    sed -i 's/^global:/transfers:/' /opt/slskd/config/slskd.yml
+    sed -i 's/^integration:/integrations:/' /opt/slskd/config/slskd.yml
     msg_ok "Restored config"
 
     msg_info "Starting Service(s)"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Rename 'global' to 'transfers' and 'integration' to 'integrations' in slskd.yml during update, matching upstream 0.25.0 changes

install.sh not changed, because we copy the upstream slskd.example.yml

## 🔗 Related Issue

Fixes #13859

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
