### PR TITLE
Wanderer: add pocketbase CLI wrapper with env

### DIFF
--- a/install/wanderer-install.sh
+++ b/install/wanderer-install.sh
@@ -60,6 +60,16 @@ wait -n
 EOF
 chmod +x /opt/wanderer/start.sh
 
+cat <<'EOF' >/usr/local/bin/wanderer-pb
+#!/usr/bin/env bash
+set -a
+source /opt/wanderer/.env
+set +a
+cd /opt/wanderer/source/db
+exec ./pocketbase "$@" --dir="$PB_DB_LOCATION"
+EOF
+chmod +x /usr/local/bin/wanderer-pb
+
 cat <<EOF >/etc/systemd/system/wanderer-web.service
 [Unit]
 Description=wanderer


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Running pocketbase commands manually (e.g. superuser upsert) fails because POCKETBASE_ENCRYPTION_KEY is only loaded via systemd env. Add /usr/local/bin/wanderer-pb wrapper that sources .env before executing pocketbase.

## 🔗 Related Issue

Fixes #13858

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
