### PR TITLE
pangolin: create migration tables before data transfer to prevent role loss

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -76,8 +76,23 @@ function update_script() {
     if [[ -f "$DB" ]]; then
       sqlite3 "$DB" "ALTER TABLE 'orgs' ADD COLUMN 'settingsLogRetentionDaysConnection' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
       sqlite3 "$DB" "ALTER TABLE 'clientSitesAssociationsCache' ADD COLUMN 'isJitMode' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
-      # Migrate roleId from userOrgs → userOrgRoles before the column is dropped
+
+      # Create new role-mapping tables and migrate data before drizzle-kit
+      # drops the roleId columns from userOrgs and userInvites.
+      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS 'userOrgRoles' (
+        'userId' text NOT NULL REFERENCES 'user'('id') ON DELETE CASCADE,
+        'orgId' text NOT NULL REFERENCES 'orgs'('orgId') ON DELETE CASCADE,
+        'roleId' integer NOT NULL REFERENCES 'roles'('roleId') ON DELETE CASCADE,
+        UNIQUE('userId', 'orgId', 'roleId')
+      );" 2>/dev/null || true
       sqlite3 "$DB" "INSERT OR IGNORE INTO 'userOrgRoles' (userId, orgId, roleId) SELECT userId, orgId, roleId FROM 'userOrgs' WHERE roleId IS NOT NULL;" 2>/dev/null || true
+
+      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS 'userInviteRoles' (
+        'inviteId' text NOT NULL REFERENCES 'userInvites'('inviteId') ON DELETE CASCADE,
+        'roleId' integer NOT NULL REFERENCES 'roles'('roleId') ON DELETE CASCADE,
+        PRIMARY KEY('inviteId', 'roleId')
+      );" 2>/dev/null || true
+      sqlite3 "$DB" "INSERT OR IGNORE INTO 'userInviteRoles' (inviteId, roleId) SELECT inviteId, roleId FROM 'userInvites' WHERE roleId IS NOT NULL;" 2>/dev/null || true
     fi
 
     ENVIRONMENT=prod $STD npx drizzle-kit push --force --config drizzle.sqlite.config.ts


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The previous migration fix attempted to INSERT INTO 'userOrgRoles' before that table existed (it is new in 1.17.1). The error was silently ignored, so no role data was migrated. When drizzle-kit then dropped roleId from userOrgs, all user-role associations were permanently lost.

- CREATE TABLE IF NOT EXISTS for userOrgRoles before migrating data
- Same treatment for userInviteRoles (also new in 1.17.1)

## 🔗 Related Issue

Fixes #13857

## ✅ Prerequisites (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
