### PR TITLE
Several Scripts: Bump NodeJS to align Node.js versions with upstream for 5 scripts

### DIFF
--- a/ct/iobroker.sh
+++ b/ct/iobroker.sh
@@ -27,6 +27,9 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+
+  NODE_VERSION="24" setup_nodejs
+
   msg_info "Updating ${APP} LXC"
   $STD apt update
   $STD apt -y upgrade

--- a/ct/kima-hub.sh
+++ b/ct/kima-hub.sh
@@ -29,6 +29,8 @@ function update_script() {
     exit
   fi
 
+  NODE_VERSION="22" setup_nodejs
+
   if check_for_gh_release "kima-hub" "Chevron7Locked/kima-hub"; then
     msg_info "Stopping Services"
     systemctl stop kima-frontend kima-backend kima-analyzer kima-analyzer-clap

--- a/ct/myip.sh
+++ b/ct/myip.sh
@@ -28,6 +28,8 @@ function update_script() {
     exit
   fi
 
+  NODE_VERSION="24" setup_nodejs
+
   if check_for_gh_release "myip" "jason5ng32/MyIP"; then
     msg_info "Stopping Services"
     systemctl stop myip

--- a/ct/outline.sh
+++ b/ct/outline.sh
@@ -28,7 +28,7 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="22" setup_nodejs
+  NODE_VERSION="24" setup_nodejs
 
   if check_for_gh_release "outline" "outline/outline"; then
     msg_info "Stopping Services"

--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="22" setup_nodejs
+  NODE_VERSION="24" setup_nodejs
   PYTHON_VERSION="3.12" setup_uv
 
   if check_for_gh_release "shelfmark" "calibrain/shelfmark"; then

--- a/install/iobroker-install.sh
+++ b/install/iobroker-install.sh
@@ -28,7 +28,7 @@ if [[ ! "$CONFIRM" =~ ^([yY][eE][sS]|[yY])$ ]]; then
   exit 10
 fi
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 
 msg_info "Installing ioBroker (Patience)"
 $STD bash <(curl -fsSL https://iobroker.net/install.sh)

--- a/install/kima-hub-install.sh
+++ b/install/kima-hub-install.sh
@@ -28,7 +28,7 @@ msg_ok "Installed Dependencies"
 
 PG_VERSION="16" PG_MODULES="pgvector" setup_postgresql
 PG_DB_NAME="kima" PG_DB_USER="kima" PG_DB_GRANT_SUPERUSER="true" setup_postgresql_db
-NODE_VERSION="20" setup_nodejs
+NODE_VERSION="22" setup_nodejs
 
 msg_info "Configuring Redis"
 systemctl enable -q --now redis-server

--- a/install/myip-install.sh
+++ b/install/myip-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "myip" "jason5ng32/MyIP" "tarball"
 
 msg_info "Configuring MyIP"

--- a/install/outline-install.sh
+++ b/install/outline-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
   redis
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="outline" PG_DB_USER="outline" setup_postgresql_db
 

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -115,7 +115,7 @@ else
   msg_ok "Installed internal bypasser dependencies"
 fi
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 PYTHON_VERSION="3.12" setup_uv
 
 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update scripts where upstream requires a newer Node.js version:
- iobroker: 22 → 24 (upstream .nvmrc)
- kima-hub: 20 → 22 (upstream Dockerfile)
- myip: 22 → 24 (upstream Dockerfile)
- outline: 22 → 24 (upstream Dockerfile)
- shelfmark: 22 → 24 (upstream Dockerfile)

currently skipped 15 scripts where our version is already newer than upstream

## 🔗 Related Issue

Fixes #13870

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
