### PR TITLE
add --clear to uv venv in update_script() to prevent interactive prompt

### DIFF
--- a/ct/calibre-web.sh
+++ b/ct/calibre-web.sh
@@ -44,7 +44,7 @@ function update_script() {
 
     msg_info "Installing Dependencies"
     cd /opt/calibre-web
-    $STD uv venv
+    $STD uv venv --clear /opt/calibre-web/.venv
     $STD uv pip install --python /opt/calibre-web/.venv/bin/python --no-cache-dir --upgrade pip setuptools wheel
     $STD uv pip install --python /opt/calibre-web/.venv/bin/python --no-cache-dir -r requirements.txt
     msg_ok "Installed Dependencies"

--- a/ct/homelable.sh
+++ b/ct/homelable.sh
@@ -43,7 +43,7 @@ function update_script() {
 
     msg_info "Updating Python Dependencies"
     cd /opt/homelable/backend
-    $STD uv venv /opt/homelable/backend/.venv
+    $STD uv venv --clear /opt/homelable/backend/.venv
     $STD uv pip install --python /opt/homelable/backend/.venv/bin/python -r requirements.txt
     msg_ok "Updated Python Dependencies"
 

--- a/ct/profilarr.sh
+++ b/ct/profilarr.sh
@@ -44,7 +44,7 @@ function update_script() {
 
     msg_info "Installing Python Dependencies"
     cd /opt/profilarr/backend
-    $STD uv venv /opt/profilarr/backend/.venv
+    $STD uv venv --clear /opt/profilarr/backend/.venv
     sed 's/==/>=/g' requirements.txt >requirements-relaxed.txt
     $STD uv pip install --python /opt/profilarr/backend/.venv/bin/python -r requirements-relaxed.txt
     rm -f requirements-relaxed.txt

--- a/ct/yamtrack.sh
+++ b/ct/yamtrack.sh
@@ -43,7 +43,7 @@ function update_script() {
 
     msg_info "Installing Python Dependencies"
     cd /opt/yamtrack
-    $STD uv venv .venv
+    $STD uv venv --clear .venv
     $STD uv pip install --no-cache-dir -r requirements.txt
     msg_ok "Installed Python Dependencies"
 


### PR DESCRIPTION




<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
uv venv asks interactively when .venv already exists:
  `? A virtual environment already exists at .venv. Do you want to replace it? [y/n]`

This hangs update scripts. Using --clear avoids the prompt. Not needed in install scripts since .venv does not exist there yet.

Affected: calibre-web, homelable, profilarr, yamtrack

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
