### PR TITLE
core: hotfix - prefer silent mode on PHS env conflict

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3520,10 +3520,14 @@ msg_menu() {
 # ------------------------------------------------------------------------------
 resolve_phs_mode() {
   if [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]] && [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then
-    whiptail --backtitle "Proxmox VE Helper Scripts" \
-      --title "⚠️ Configuration Conflict Warning" \
-      --msgbox "PHS_SILENT and PHS_VERBOSE environment variables are both set.\n\nFalling back to interactive mode." 10 58
-    PHS_MODE="interactive"
+    # Conflict handling must never block unattended/non-TTY updates.
+    # Prefer silent mode to keep automation safe.
+    if [[ -t 0 ]] && [[ -t 1 ]] && command -v whiptail >/dev/null 2>&1; then
+      whiptail --backtitle "Proxmox VE Helper Scripts" \
+        --title "Configuration Conflict Warning" \
+        --msgbox "PHS_SILENT and PHS_VERBOSE are both set.\n\nFalling back to silent mode." 10 58 || true
+    fi
+    PHS_MODE="silent"
   elif [[ -n "${PHS_SILENT+x}" ]] && [[ "${PHS_SILENT}" == "1" ]]; then
     PHS_MODE="silent"
   elif [[ -n "${PHS_VERBOSE+x}" ]] && [[ "${PHS_VERBOSE}" == "1" ]]; then


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When PHS_SILENT and PHS_VERBOSE are both set, stop falling back to interactive mode. Changes prefer silent mode to keep automation safe and avoid blocking unattended/non-TTY updates. Only show a whiptail warning when both stdin/stdout are TTYs and whiptail is present, and ignore any whiptail errors. Added a brief comment and adjusted the fallback message accordingly.


## 🔗 Related Issue

Fixes #13947

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
