### PR TITLE
tools.func: upgrade Node.js minor/patch on same major version

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -6336,11 +6336,14 @@ function setup_nodejs() {
     }
   fi
 
-  # Scenario 1: Already installed at target version - just update packages/modules
+  # Scenario 1: Already installed at target version - upgrade to latest minor/patch + update packages/modules
   if [[ -n "$CURRENT_NODE_VERSION" && "$CURRENT_NODE_VERSION" == "$NODE_VERSION" ]]; then
     msg_info "Update Node.js $NODE_VERSION"
 
     ensure_apt_working || return 100
+
+    # Upgrade to the latest minor/patch release from NodeSource
+    $STD apt-get install -y --only-upgrade nodejs 2>/dev/null || true
 
     # Pin npm to 11.11.0 to work around Node.js 22.22.2 regression (nodejs/node#62425)
     $STD npm install -g npm@11.11.0 2>/dev/null || true


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
In setup_nodejs() Scenario 1 (major version already matches), only npm was refreshed - apt never upgraded the nodejs package itself. This left existing LXCs stuck on older minor releases (e.g. 22.13.1) even though NodeSource ships newer ones (e.g. 22.19+).

## 🔗 Related Issue

Fixes #13955

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
