### PR TITLE
core: auto-size NODE_OPTIONS heap

### DIFF
--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -155,6 +155,8 @@ EOF
       /opt/termix/nginx/client_body
     msg_ok "Recreated Directories"
 
+    NODE_VERSION="24" setup_nodejs
+
     msg_info "Building Frontend"
     cd /opt/termix
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -313,6 +313,55 @@ error_handler() {
     echo -e "${TAB}-----------------------------------\n"
   fi
 
+  # Detect probable Node.js heap OOM and print actionable guidance.
+  # This avoids generic SIGABRT/SIGKILL confusion for frontend build failures.
+  local node_oom_detected="false"
+  local node_build_context="false"
+  if [[ "$command" =~ (npm|pnpm|yarn|node|vite|turbo) ]]; then
+    node_build_context="true"
+  fi
+  if [[ "$exit_code" == "243" ]]; then
+    node_oom_detected="true"
+  elif [[ -n "$active_log" && -s "$active_log" ]]; then
+    if tail -n 200 "$active_log" 2>/dev/null | grep -Eqi 'Reached heap limit|JavaScript heap out of memory|Allocation failed - JavaScript heap out of memory|FATAL ERROR: Reached heap limit'; then
+      node_oom_detected="true"
+    fi
+  fi
+
+  if [[ "$node_oom_detected" == "true" ]] || { [[ "$node_build_context" == "true" ]] && [[ "$exit_code" =~ ^(134|137)$ ]]; }; then
+    local heap_hint_mb=""
+
+    # If explicitly configured, prefer the current value for troubleshooting output.
+    if [[ -n "${NODE_OPTIONS:-}" ]] && [[ "${NODE_OPTIONS}" =~ max-old-space-size=([0-9]+) ]]; then
+      heap_hint_mb="${BASH_REMATCH[1]}"
+    elif [[ -n "${var_ram:-}" ]] && [[ "${var_ram}" =~ ^[0-9]+$ ]]; then
+      heap_hint_mb=$((var_ram * 75 / 100))
+    else
+      local mem_kb=""
+      mem_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo "")
+      if [[ "$mem_kb" =~ ^[0-9]+$ ]]; then
+        local mem_mb=$((mem_kb / 1024))
+        heap_hint_mb=$((mem_mb * 75 / 100))
+      fi
+    fi
+
+    if [[ -z "$heap_hint_mb" ]] || ((heap_hint_mb < 1024)); then
+      heap_hint_mb=1024
+    elif ((heap_hint_mb > 4096)); then
+      heap_hint_mb=4096
+    fi
+
+    if declare -f msg_warn >/dev/null 2>&1; then
+      msg_warn "Detected possible Node.js heap OOM during build."
+      msg_warn "Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" before npm/pnpm/yarn build."
+      msg_warn "Recommendation: call setup_nodejs before build steps so heap defaults are applied automatically."
+    else
+      echo -e "${YW}Detected possible Node.js heap OOM during build.${CL}"
+      echo -e "${YW}Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" before npm/pnpm/yarn build.${CL}"
+      echo -e "${YW}Recommendation: call setup_nodejs before build steps so heap defaults are applied automatically.${CL}"
+    fi
+  fi
+
   # Detect context: Container (INSTALL_LOG set + inside container /root) vs Host
   if [[ -n "${INSTALL_LOG:-}" && -f "${INSTALL_LOG:-}" && -d /root ]]; then
     # CONTAINER CONTEXT: Copy log and create flag file for host

--- a/misc/error_handler.func
+++ b/misc/error_handler.func
@@ -347,18 +347,14 @@ error_handler() {
 
     if [[ -z "$heap_hint_mb" ]] || ((heap_hint_mb < 1024)); then
       heap_hint_mb=1024
-    elif ((heap_hint_mb > 4096)); then
-      heap_hint_mb=4096
+    elif ((heap_hint_mb > 12288)); then
+      heap_hint_mb=12288
     fi
 
     if declare -f msg_warn >/dev/null 2>&1; then
-      msg_warn "Detected possible Node.js heap OOM during build."
-      msg_warn "Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" before npm/pnpm/yarn build."
-      msg_warn "Recommendation: call setup_nodejs before build steps so heap defaults are applied automatically."
+      msg_warn "Possible Node.js heap OOM. Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" and rerun the build."
     else
-      echo -e "${YW}Detected possible Node.js heap OOM during build.${CL}"
-      echo -e "${YW}Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" before npm/pnpm/yarn build.${CL}"
-      echo -e "${YW}Recommendation: call setup_nodejs before build steps so heap defaults are applied automatically.${CL}"
+      echo -e "${YW}Possible Node.js heap OOM. Try: export NODE_OPTIONS=\"--max-old-space-size=${heap_hint_mb}\" and rerun the build.${CL}"
     fi
   fi
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -6420,7 +6420,37 @@ function setup_nodejs() {
     msg_ok "Setup Node.js $NODE_VERSION"
   fi
 
-  export NODE_OPTIONS="--max-old-space-size=4096"
+  # Set a safe default heap limit for Node.js builds if not explicitly provided.
+  # Priority:
+  #   1) NODE_OPTIONS (caller/user override)
+  #   2) NODE_MAX_OLD_SPACE_SIZE (explicit MB override)
+  #   3) var_ram (LXC memory setting, MB)
+  #   4) /proc/meminfo (runtime memory detection)
+  # Auto value is clamped to 1024..4096 MB.
+  if [[ -z "${NODE_OPTIONS:-}" ]]; then
+    local node_heap_mb=""
+
+    if [[ -n "${NODE_MAX_OLD_SPACE_SIZE:-}" ]] && [[ "${NODE_MAX_OLD_SPACE_SIZE}" =~ ^[0-9]+$ ]]; then
+      node_heap_mb="${NODE_MAX_OLD_SPACE_SIZE}"
+    elif [[ -n "${var_ram:-}" ]] && [[ "${var_ram}" =~ ^[0-9]+$ ]]; then
+      node_heap_mb=$((var_ram * 75 / 100))
+    else
+      local total_mem_kb=""
+      total_mem_kb=$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo 2>/dev/null || echo "")
+      if [[ "$total_mem_kb" =~ ^[0-9]+$ ]]; then
+        local total_mem_mb=$((total_mem_kb / 1024))
+        node_heap_mb=$((total_mem_mb * 75 / 100))
+      fi
+    fi
+
+    if [[ -z "$node_heap_mb" ]] || ((node_heap_mb < 1024)); then
+      node_heap_mb=1024
+    elif ((node_heap_mb > 4096)); then
+      node_heap_mb=4096
+    fi
+
+    export NODE_OPTIONS="--max-old-space-size=${node_heap_mb}"
+  fi
 
   # Ensure valid working directory for npm (avoids uv_cwd error)
   if [[ ! -d /opt ]]; then

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -6426,7 +6426,7 @@ function setup_nodejs() {
   #   2) NODE_MAX_OLD_SPACE_SIZE (explicit MB override)
   #   3) var_ram (LXC memory setting, MB)
   #   4) /proc/meminfo (runtime memory detection)
-  # Auto value is clamped to 1024..4096 MB.
+  # Auto value is clamped to 1024..12288 MB.
   if [[ -z "${NODE_OPTIONS:-}" ]]; then
     local node_heap_mb=""
 
@@ -6445,8 +6445,8 @@ function setup_nodejs() {
 
     if [[ -z "$node_heap_mb" ]] || ((node_heap_mb < 1024)); then
       node_heap_mb=1024
-    elif ((node_heap_mb > 4096)); then
-      node_heap_mb=4096
+    elif ((node_heap_mb > 12288)); then
+      node_heap_mb=12288
     fi
 
     export NODE_OPTIONS="--max-old-space-size=${node_heap_mb}"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- setup_nodejs now sets NODE_OPTIONS only when not already set
- Heap size is auto-derived from NODE_MAX_OLD_SPACE_SIZE, var_ram, or MemTotal
- Auto heap is clamped to 1024..4096 to max 12288 MB (because lobeHub and other intense scripts) to avoid too-small or too-large defaults
- optimized the error_handler to changes from nodejs 

Additional:
- Termix update path now calls setup_nodejs before frontend/backend builds so Node heap defaults are applied consistently during updates
=> i make another pr later, to add setup_nodejs in all "update_scripts" that dont have it atm. 

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
