### PR TITLE
VictoriaMetrics: Stop vmagent/vmalert before update

### DIFF
--- a/ct/victoriametrics.sh
+++ b/ct/victoriametrics.sh
@@ -32,6 +32,8 @@ function update_script() {
     msg_info "Stopping Service"
     systemctl stop victoriametrics
     [[ -f /etc/systemd/system/victoriametrics-logs.service ]] && systemctl stop victoriametrics-logs
+    [[ -f /etc/systemd/system/vmagent.service ]] && systemctl stop vmagent
+    [[ -f /etc/systemd/system/vmalert.service ]] && systemctl stop vmalert
     msg_ok "Stopped Service"
 
     victoriametrics_release=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases" |
@@ -62,6 +64,8 @@ function update_script() {
     msg_info "Starting Service"
     systemctl start victoriametrics
     [[ -f /etc/systemd/system/victoriametrics-logs.service ]] && systemctl start victoriametrics-logs
+    [[ -f /etc/systemd/system/vmagent.service ]] && systemctl start vmagent
+    [[ -f /etc/systemd/system/vmalert.service ]] && systemctl start vmalert
     msg_ok "Started Service"
     msg_ok "Updated successfully!"
   fi


### PR DESCRIPTION
## Summary

- Stop `vmagent` and `vmalert` services (if present) before deploying the vmutils tarball during an update, and restart them afterward
- The vmutils tarball contains daemon binaries (`vmagent-prod`, `vmalert-prod`) that, if running, cause `cp` to fail with **ETXTBSY** when trying to overwrite them in `/opt/victoriametrics/`, producing exit code 252
- Service checks are guarded by `[[ -f /etc/systemd/system/<name>.service ]]` so they are no-ops for users without those services configured

Fixes #14014

## Test plan

- [x] Run update on a VictoriaMetrics LXC without vmagent/vmalert configured — update completes normally
- [x] Run update on a VictoriaMetrics LXC with vmagent running as a systemd service — update completes without ETXTBSY error and vmagent is restarted afterward