### PR TITLE
fix(2fauth): handle stale backup directory on update

### DIFF
--- a/ct/2fauth.sh
+++ b/ct/2fauth.sh
@@ -24,7 +24,7 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  if [[ ! -d "/opt/2fauth" ]]; then
+  if [[ ! -d /opt/2fauth ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
@@ -34,7 +34,8 @@ function update_script() {
     $STD apt -y upgrade
 
     msg_info "Creating Backup"
-    mv "/opt/2fauth" "/opt/2fauth-backup"
+    rm -rf /opt/2fauth-backup
+    mv /opt/2fauth /opt/2fauth-backup
     if ! dpkg -l | grep -q 'php8.4'; then
       cp /etc/nginx/conf.d/2fauth.conf /etc/nginx/conf.d/2fauth.conf.bak
     fi
@@ -46,15 +47,17 @@ function update_script() {
     fi
     fetch_and_deploy_gh_release "2fauth" "Bubka/2FAuth" "tarball"
     setup_composer
-    mv "/opt/2fauth-backup/.env" "/opt/2fauth/.env"
-    mv "/opt/2fauth-backup/storage" "/opt/2fauth/storage"
-    cd "/opt/2fauth" || return
-    chown -R www-data: "/opt/2fauth"
-    chmod -R 755 "/opt/2fauth"
+    cp /opt/2fauth-backup/.env /opt/2fauth/.env
+    cp -r /opt/2fauth-backup/storage /opt/2fauth/storage
+    cd /opt/2fauth || return
     export COMPOSER_ALLOW_SUPERUSER=1
     $STD composer install --no-dev --prefer-dist
     php artisan 2fauth:install
+    chown -R www-data: /opt/2fauth
+    chmod -R 755 /opt/2fauth
+    $STD systemctl restart php8.4-fpm
     $STD systemctl restart nginx
+    rm -rf /opt/2fauth-backup
     msg_ok "Updated successfully!"
   fi
   exit


### PR DESCRIPTION
## ✍️ Description

Update script failed with `'mv: cannot stat /opt/2fauth-backup/.env: No such file or directory'`  whenever `/opt/2fauth-backup` already existed from a previous run. `mv` would nest `/opt/2fauth` inside the existing backup directory (as /opt/2fauth-backup/2fauth/), so the subsequent restore of `.env/storage` looked at the wrong path.

- Remove any stale `/opt/2fauth-backup` before creating the backup
- Use `cp` instead of `mv` when restoring `.env/storage` so the backup remains intact until the update completes
- Remove `/opt/2fauth-backup` at the end of a successful update so the next run starts from a clean state


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [ X] **Self-review completed** – Code follows project standards.
- [ X] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
