### PR TITLE
Domain-Monitor: start apache2 after stop instead of reload

### DIFF
--- a/ct/domain-monitor.sh
+++ b/ct/domain-monitor.sh
@@ -60,7 +60,7 @@ function update_script() {
     msg_ok "Restored backup"
 
     msg_info "Restarting Services"
-    systemctl reload apache2
+    systemctl start apache2
     msg_ok "Restarted Services"
     msg_ok "Updated successfully!"
   fi


### PR DESCRIPTION
## ✍️ Description

The update stops apache2 (line 42) and then tries to `reload` it at the end (line 63):
`systemctl stop apache2`
...
`systemctl reload apache2`

`reload` on a stopped service exits 1 ("apache2.service is not active, cannot reload"), `catch_errors` picks it up and aborts the run at the last step. Apache stays down and the site is unreachable until it's started manually.
Reproduced on a 1.1.4 → 1.1.5 update. Changed the final call from `reload` to `start` so it pairs with the earlier `stop`.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
