### PR TITLE
core: Correct deb822 repository flat path detection

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1924,8 +1924,8 @@ setup_deb822_repo() {
     echo "Types: deb"
     echo "URIs: $repo_url"
     echo "Suites: $suite"
-    # Flat repositories (suite="./" or absolute path) must not have Components
-    if [[ "$suite" != "./" && -n "$component" ]]; then
+    # Flat repositories (suite ending with "/" or "./") must not have Components
+    if [[ "$suite" != *"/" && -n "$component" ]]; then
       echo "Components: $component"
     fi
     [[ -n "$architectures" ]] && echo "Architectures: $architectures"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The setup_deb822_repo function was only checking for the literal './' suite value, but should reject any suite ending with '/', which indicates a flat repository that must not include Components in the DEB822 format.

This fix aligns ProxmoxVE with the correct behavior already present in ProxmoxVED.


## 🔗 Related Issue

Fixes #14036

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
