### PR TITLE
 Increase Frigate default CPU cores from 4 to 8

### DIFF
--- a/ct/frigate.sh
+++ b/ct/frigate.sh
@@ -7,7 +7,7 @@ source <(curl -fsSL https://git.community-scripts.org/community-scripts/ProxmoxV
 
 APP="Frigate"
 var_tags="${var_tags:-nvr}"
-var_cpu="${var_cpu:-4}"
+var_cpu="${var_cpu:-8}"
 var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Frigate requires 6+ CPU cores for stable operation (issue #13981). Default of 4 cores causes frequent crashes and websocket errors.

The existing OpenVINO initialization already has a fallback to CPU model on unsupported hardware, so boot loop issues (#14032) are resolved by increasing available resources.

## 🔗 Related Issue

Fixes #14032

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
