### PR TITLE
TechnitiumDNS: always install .NET 10 if not already present

### DIFF
--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -32,8 +32,8 @@ function update_script() {
     systemctl daemon-reload
     systemctl enable -q --now technitium
   fi
-  if is_package_installed "aspnetcore-runtime-8.0" || is_package_installed "aspnetcore-runtime-9.0"; then
-    $STD apt remove -y aspnetcore-runtime-*
+  if ! is_package_installed "aspnetcore-runtime-10.0"; then
+    $STD apt remove -y aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 2>/dev/null || true
     [ -f /etc/apt/sources.list.d/microsoft-prod.list ] && rm -f /etc/apt/sources.list.d/microsoft-prod.list
     [ -f /usr/share/keyrings/microsoft-prod.gpg ] && rm -f /usr/share/keyrings/microsoft-prod.gpg
     setup_deb822_repo \


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Previously the update script only upgraded .NET when aspnetcore-runtime-8.0 or 9.0 was detected via is_package_installed. Containers where detection failed would silently skip the upgrade block, leaving Technitium v15 (requires .NET 10) starting against .NET 8/9 and immediately failing.

## 🔗 Related Issue

Fixes #14045

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
