### PR TITLE
update-lxcs/apps: avoid pct exec on containers mid-shutdown

### DIFF
--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -405,11 +405,6 @@ for container in $CHOICE; do
   esac
   exit_code=$?
 
-  if [ "$template" == "false" ] && [ "$status" == "status: stopped" ]; then
-    echo -e "${BL}[Info]${GN} Shutting down${BL} $container ${CL} \n"
-    pct shutdown $container &
-  fi
-
   #5) if build resources are different than run resources, then:
   if [ "$UPDATE_BUILD_RESOURCES" -eq "1" ]; then
     pct set "$container" --cores "$run_cpu" --memory "$run_ram"
@@ -419,6 +414,11 @@ for container in $CHOICE; do
     # Get the container's hostname and add it to the list
     container_hostname=$(pct exec "$container" hostname)
     containers_needing_reboot+=("$container ($container_hostname)")
+  fi
+
+  if [ "$template" == "false" ] && [ "$status" == "status: stopped" ]; then
+    echo -e "${BL}[Info]${GN} Shutting down${BL} $container ${CL} \n"
+    pct shutdown $container &>/dev/null &
   fi
 
   if [ $exit_code -eq 0 ]; then

--- a/tools/pve/update-lxcs.sh
+++ b/tools/pve/update-lxcs.sh
@@ -110,15 +110,17 @@ for container in $(pct list | awk '{if(NR>1) print $1}'); do
     elif [ "$status" == "status: running" ]; then
       update_container $container
     fi
-    if pct exec "$container" -- [ -e "/var/run/reboot-required" ]; then
-      # Get the container's hostname and add it to the list
-      container_hostname=$(pct exec "$container" hostname)
-      containers_needing_reboot+=("$container ($container_hostname)")
-    fi
-    # check if patchmon agent is present in container and run a report if found
-    if pct exec "$container" -- [ -e "/usr/local/bin/patchmon-agent" ]; then
-      echo -e "${BL}[Info]${GN} patchmon-agent found in ${BL} $container ${CL}, triggering report. \n"
-      pct exec "$container" -- "/usr/local/bin/patchmon-agent" "report"
+    if [ "$status" == "status: running" ]; then
+      if pct exec "$container" -- [ -e "/var/run/reboot-required" ]; then
+        # Get the container's hostname and add it to the list
+        container_hostname=$(pct exec "$container" hostname)
+        containers_needing_reboot+=("$container ($container_hostname)")
+      fi
+      # check if patchmon agent is present in container and run a report if found
+      if pct exec "$container" -- [ -e "/usr/local/bin/patchmon-agent" ]; then
+        echo -e "${BL}[Info]${GN} patchmon-agent found in ${BL} $container ${CL}, triggering report. \n"
+        pct exec "$container" -- "/usr/local/bin/patchmon-agent" "report"
+      fi
     fi
   fi
 done


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Both update-lxcs.sh and update-apps.sh backgrounded pct shutdown and then immediately called pct exec on the same container, causing 'Error: unexpected status' which terminated the loop after the first container.

Hopefully this Fix users Reported Issue. 


## 🔗 Related Issue

Fixes #14027

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
