### PR TITLE
Dawarich: run db:migrate before assets:precompile

### DIFF
--- a/ct/dawarich.sh
+++ b/ct/dawarich.sh
@@ -53,6 +53,10 @@ function update_script() {
     export PATH="/root/.rbenv/shims:/root/.rbenv/bin:$PATH"
     eval "$(/root/.rbenv/bin/rbenv init - bash)"
 
+    if ! grep -q "OTP_ENCRYPTION_PRIMARY_KEY" /opt/dawarich/.env; then
+      echo "OTP_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 32)" >>/opt/dawarich/.env
+    fi
+
     set -a && source /opt/dawarich/.env && set +a
 
     $STD bundle config set --local deployment 'true'

--- a/ct/dawarich.sh
+++ b/ct/dawarich.sh
@@ -67,8 +67,8 @@ function update_script() {
       $STD npm install
     fi
 
-    $STD bundle exec rake assets:precompile
     $STD bundle exec rails db:migrate
+    $STD bundle exec rake assets:precompile
     $STD bundle exec rake data:migrate
     msg_ok "Ran Migrations"
 

--- a/install/dawarich-install.sh
+++ b/install/dawarich-install.sh
@@ -46,10 +46,12 @@ msg_ok "Set up Directories"
 
 msg_info "Configuring Environment"
 SECRET_KEY_BASE=$(openssl rand -hex 64)
+OTP_ENCRYPTION_PRIMARY_KEY=$(openssl rand -hex 32)
 RELEASE=$(get_latest_github_release "Freika/dawarich")
 cat <<EOF >/opt/dawarich/.env
 RAILS_ENV=production
 SECRET_KEY_BASE=${SECRET_KEY_BASE}
+OTP_ENCRYPTION_PRIMARY_KEY=${OTP_ENCRYPTION_PRIMARY_KEY}
 DATABASE_HOST=localhost
 DATABASE_USERNAME=${PG_DB_USER}
 DATABASE_PASSWORD=${PG_DB_PASS}


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Dawarich 1.7.0 adds new tables (monthly digest email preferences, S3 storage settings). Running precompile before migrate causes 'Operation not permitted' / exit code 1 when those tables do not exist yet.

Reordered to db:migrate -> assets:precompile -> data:migrate


add OTP Key as required in .env

## 🔗 Related Issue

Fixes #14048 | Fixes #14056

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
