### PR TITLE
Add patchmon-agent report execution in update script

### DIFF
--- a/tools/pve/update-lxcs-cron.sh
+++ b/tools/pve/update-lxcs-cron.sh
@@ -66,10 +66,20 @@ for container in $(pct list | awk '{if(NR>1) print $1}'); do
       pct start "$container"
       sleep 5
       update_container "$container" || echo " [Error] Update failed for $container"
+      # check if patchmon agent is present in container and run a report if found
+      if pct exec "$container" -- [ -e "/usr/local/bin/patchmon-agent" ]; then
+        echo -e "${BL}[Info]${GN} patchmon-agent found in ${BL} $container ${CL}, triggering report. \n"
+        pct exec "$container" -- "/usr/local/bin/patchmon-agent" "report"
+      fi
       echo -e "[Info] Shutting down $container"
       pct shutdown "$container" --timeout 60 &
     elif [ "$status" == "status: running" ]; then
       update_container "$container" || echo " [Error] Update failed for $container"
+      # check if patchmon agent is present in container and run a report if found
+      if pct exec "$container" -- [ -e "/usr/local/bin/patchmon-agent" ]; then
+        echo -e "${BL}[Info]${GN} patchmon-agent found in ${BL} $container ${CL}, triggering report. \n"
+        pct exec "$container" -- "/usr/local/bin/patchmon-agent" "report"
+      fi
     fi
   fi
 done


### PR DESCRIPTION
Added checks to execute a patchmon-agent report if patchmon-agent is found in the container during updates.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Many users are using [PatchMon](https://community-scripts.org/scripts/patchmon) to monitor their patching status.

By adding  checks to execute a patchmon-agent report, the PatchMon Dashboard will be updated immediately.

## 🔗 Related Issue

Previous PR has been closed.
https://github.com/community-scripts/ProxmoxVE/pull/12967

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
