### PR TITLE
Add option to build Guacamole Server (guacd) from main branch with user prompt

### DIFF
--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -29,7 +29,9 @@ function update_script() {
     exit
   fi
 
-  if check_for_gh_tag "guacd" "apache/guacamole-server"; then
+  GUACD_BUILD_MODE="$(cat /opt/.guacd_build_mode 2>/dev/null || echo "stable")"
+
+  if [[ "$GUACD_BUILD_MODE" == "main" ]] || check_for_gh_tag "guacd" "apache/guacamole-server"; then
     msg_info "Stopping guacd"
     systemctl stop guacd 2>/dev/null || true
     msg_ok "Stopped guacd"
@@ -55,8 +57,16 @@ function update_script() {
       libavutil-dev \
       libavformat-dev
 
-    msg_info "Updating Guacamole Server (guacd)"
-    fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "${CHECK_UPDATE_RELEASE}" "/opt/guacamole-server"
+    if [[ "$GUACD_BUILD_MODE" == "main" ]]; then
+      msg_info "Updating Guacamole Server (guacd) from main branch"
+      ensure_dependencies git
+      rm -rf /opt/guacamole-server
+      $STD git clone --depth 1 https://github.com/apache/guacamole-server.git /opt/guacamole-server
+    else
+      msg_info "Updating Guacamole Server (guacd)"
+      fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "${CHECK_UPDATE_RELEASE}" "/opt/guacamole-server"
+    fi
+
     cd /opt/guacamole-server
     export CPPFLAGS="-Wno-error=deprecated-declarations"
     $STD autoreconf -fi
@@ -66,7 +76,12 @@ function update_script() {
     $STD ldconfig
     cd /opt
     rm -rf /opt/guacamole-server
-    msg_ok "Updated Guacamole Server (guacd) to ${CHECK_UPDATE_RELEASE}"
+
+    if [[ "$GUACD_BUILD_MODE" == "main" ]]; then
+      msg_ok "Updated Guacamole Server (guacd) from main branch"
+    else
+      msg_ok "Updated Guacamole Server (guacd) to ${CHECK_UPDATE_RELEASE}"
+    fi
 
     if [[ ! -f /etc/guacamole/guacd.conf ]]; then
       mkdir -p /etc/guacamole

--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  GUACD_BUILD_MODE="$(cat /opt/.guacd_build_mode 2>/dev/null || echo "stable")"
+  GUACD_BUILD_MODE="$(cat /root/.guacd_build_mode 2>/dev/null || echo "stable")"
 
   if [[ "$GUACD_BUILD_MODE" == "main" ]] || check_for_gh_tag "guacd" "apache/guacamole-server"; then
     msg_info "Stopping guacd"

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -41,8 +41,22 @@ $STD apt install -y \
   libavformat-dev
 msg_ok "Installed Dependencies"
 
+echo ""
+read -rp "${TAB3}Build guacd from main branch? Includes Wayland RDP fixes for Ubuntu/Zorin OS [y/N]: " REPLY
+GUACD_BUILD_MODE="stable"
+if [[ "${REPLY,,}" =~ ^(y|yes)$ ]]; then
+  GUACD_BUILD_MODE="main"
+  msg_warn "Main branch builds may be unstable. Proceeding with main branch."
+fi
+echo "$GUACD_BUILD_MODE" >/opt/.guacd_build_mode
+
 msg_info "Building Guacamole Server (guacd)"
-fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "latest" "/opt/guacamole-server"
+if [[ "$GUACD_BUILD_MODE" == "main" ]]; then
+  ensure_dependencies git
+  $STD git clone --depth 1 https://github.com/apache/guacamole-server.git /opt/guacamole-server
+else
+  fetch_and_deploy_gh_tag "guacd" "apache/guacamole-server" "latest" "/opt/guacamole-server"
+fi
 cd /opt/guacamole-server
 export CPPFLAGS="-Wno-error=deprecated-declarations"
 $STD autoreconf -fi

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -48,7 +48,7 @@ if [[ "${REPLY,,}" =~ ^(y|yes)$ ]]; then
   GUACD_BUILD_MODE="main"
   msg_warn "Main branch builds may be unstable. Proceeding with main branch."
 fi
-echo "$GUACD_BUILD_MODE" >/opt/.guacd_build_mode
+echo "$GUACD_BUILD_MODE" >/root/.guacd_build_mode
 
 msg_info "Building Guacamole Server (guacd)"
 if [[ "$GUACD_BUILD_MODE" == "main" ]]; then


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Adds an opt-in prompt during install and updates to build guacamole-server (guacd) from the upstream main branch instead of the latest stable release tag. This is useful for users who need fixes that haven't landed in a release yet — most notably Wayland RDP session support for distros such as Ubuntu and Zorin OS. (Running on the latest tagged release (1.6.0) _does not_ work with distros using this RDP implementation but the main branch does work)

  - install/termix-install.sh: Prompts the user before the guacd build step; uses git clone --depth 1 for main-branch builds and the existing fetch_and_deploy_gh_tag path for stable. The choice is persisted to                
  /root/.guacd_build_mode.
  
  - ct/termix.sh (update_script): Reads the saved build mode on each update run. Main-branch installs always rebuild from HEAD; stable installs continue using the existing check_for_gh_tag / ${CHECK_UPDATE_RELEASE}           
  version-gated path. The stable-path version tracking in /root/.guacd is unchanged. 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
