### PR TITLE
alpine: remove deb/ubuntu-only resource & storage checks from update-script

### DIFF
--- a/ct/alpine-ironclaw.sh
+++ b/ct/alpine-ironclaw.sh
@@ -21,8 +21,6 @@ catch_errors
 
 function update_script() {
   header_info
-  check_container_storage
-  check_container_resources
 
   if [[ ! -f /usr/local/bin/ironclaw ]]; then
     msg_error "No ${APP} Installation Found!"

--- a/ct/alpine-ntfy.sh
+++ b/ct/alpine-ntfy.sh
@@ -22,8 +22,6 @@ catch_errors
 
 function update_script() {
   header_info
-  check_container_storage
-  check_container_resources
   if [[ ! -d /etc/ntfy ]]; then
     msg_error "No ${APP} Installation Found!"
     exit

--- a/ct/alpine-redlib.sh
+++ b/ct/alpine-redlib.sh
@@ -21,7 +21,6 @@ catch_errors
 
 function update_script() {
   header_info
-  check_container_resources
 
   if [[ ! -d /opt/redlib ]]; then
     msg_error "No ${APP} Installation Found!"

--- a/ct/alpine-rustypaste.sh
+++ b/ct/alpine-rustypaste.sh
@@ -21,8 +21,6 @@ catch_errors
 
 function update_script() {
   header_info
-  check_container_storage
-  check_container_resources
 
   if ! apk info -e rustypaste >/dev/null 2>&1; then
     msg_error "No ${APP} Installation Found!"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

check_container_storage uses 'df /boot --output=size' which is unsupported by BusyBox df on Alpine and /boot is not a separate partition there. Both helpers are designed for Debian/Ubuntu hosts only.

just an bugfix, maybe we add this functions later (with combined install.func from VED)

Affected: alpine-ntfy, alpine-rustypaste, alpine-ironclaw, alpine-redlib.

## 🔗 Related Issue

Fixes #14163

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
