### PR TITLE
[FIX]ShelfMark: Use UV sync for shelfmark backend build; update to Python 3.14

### DIFF
--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -30,7 +30,7 @@ function update_script() {
   fi
 
   NODE_VERSION="24" setup_nodejs
-  PYTHON_VERSION="3.12" setup_uv
+  PYTHON_VERSION="3.14" setup_uv
 
   if check_for_gh_release "shelfmark" "calibrain/shelfmark"; then
     msg_info "Stopping Service(s)"
@@ -59,6 +59,7 @@ function update_script() {
     RELEASE_VERSION=$(cat "$HOME/.shelfmark")
 
     msg_info "Updating Shelfmark"
+    export VIRTUAL_ENV=/opt/shelfmark/venv
     sed -i "s/^RELEASE_VERSION=.*/RELEASE_VERSION=$RELEASE_VERSION/" /etc/shelfmark/.env
     cd /opt/shelfmark/src/frontend
     $STD npm ci
@@ -67,9 +68,10 @@ function update_script() {
     cd /opt/shelfmark
     $STD uv venv -c ./venv
     $STD source ./venv/bin/activate
-    $STD uv pip install -r ./requirements-base.txt
     if [[ $(sed -n '/_BYPASS=/s/[^=]*=//p' /etc/shelfmark/.env) == "true" ]] && [[ $(sed -n '/BYPASSER=/s/[^=]*=//p' /etc/shelfmark/.env) == "false" ]]; then
-      $STD uv pip install -r ./requirements-shelfmark.txt
+      $STD uv sync --active --locked --no-default-groups --extra browser
+    else
+      $STD uv sync --active --locked --no-default-groups
     fi
     mv /opt/start.sh.bak /opt/shelfmark/start.sh
     msg_ok "Updated Shelfmark"

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -116,7 +116,7 @@ else
 fi
 
 NODE_VERSION="24" setup_nodejs
-PYTHON_VERSION="3.12" setup_uv
+PYTHON_VERSION="3.14" setup_uv
 
 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"
 RELEASE_VERSION=$(cat "$HOME/.shelfmark")
@@ -130,11 +130,15 @@ mv /opt/shelfmark/src/frontend/dist /opt/shelfmark/frontend-dist
 msg_ok "Built Shelfmark frontend"
 
 msg_info "Configuring Shelfmark"
+export VIRTUAL_ENV=/opt/shelfmark/venv
 cd /opt/shelfmark
 $STD uv venv --clear ./venv
 $STD source ./venv/bin/activate
-$STD uv pip install -r ./requirements-base.txt
-[[ "$DEPLOYMENT_TYPE" == "1" ]] && $STD uv pip install -r ./requirements-shelfmark.txt
+if [[ "$DEPLOYMENT_TYPE" == "1" ]]; then
+  $STD uv sync --active --locked --no-default-groups --extra browser
+else
+  $STD uv sync --active --locked --no-default-groups
+fi
 mkdir -p {/var/log/shelfmark,/tmp/shelfmark}
 msg_ok "Configured Shelfmark"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- ShelfMark now uses `uv sync` to manage Python packages, so `uv pip install -r requirements.txt` would fail. 
- Will still install the additional dependencies if user chooses to use the internal CAPTCHA bypasser (`--extra browser`)
- Bump Python version to 3.14

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
