### PR TITLE
core: fix validate_bridge function

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -513,7 +513,7 @@ validate_bridge() {
   [[ -z "$bridge" ]] && return 1
 
   # Check if bridge interface exists
-  if ! ip link show "$bridge" &>/dev/null; then
+  if ! ip link show dev "$bridge" &>/dev/null; then
     return 1
   fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

validate_bridge was passing the bridge name as the final argument to the `ip link show` command. This command will assume that this parameter is a device except if the argument is specified in the grammar. So certain valid bridge names were failing to pass this validation function (e.g. dev, group, master, vrf, type).

By calling `ip link show dev "$bridge"` instead, the ip command knows that the `$bridge` argument is really a device and not part of the grammar.

## 🔗 Related Issue


## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
