### PR TITLE
pve/pbs scripts: guard sed against missing /etc/apt/sources.list

### DIFF
--- a/tools/pve/pbs4-upgrade.sh
+++ b/tools/pve/pbs4-upgrade.sh
@@ -57,7 +57,9 @@ start_routines() {
   yes)
     msg_info "Switching to Debian 13 (Trixie) Sources"
     rm -f /etc/apt/sources.list.d/*.list
-    sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list || true
+    if [ -f /etc/apt/sources.list ]; then
+      sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list
+    fi
     cat >/etc/apt/sources.list.d/debian.sources <<EOF
 Types: deb
 URIs: http://deb.debian.org/debian

--- a/tools/pve/post-pbs-install.sh
+++ b/tools/pve/post-pbs-install.sh
@@ -188,7 +188,9 @@ start_routines_4() {
   yes)
     msg_info "Correcting Debian Sources (deb822)"
     rm -f /etc/apt/sources.list.d/*.list
-    sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list || true
+    if [ -f /etc/apt/sources.list ]; then
+      sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list
+    fi
     cat >/etc/apt/sources.list.d/debian.sources <<EOF
 Types: deb
 URIs: http://deb.debian.org/debian/

--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -251,8 +251,10 @@ start_routines_9() {
       msg_info "Correcting Proxmox VE Sources (deb822)"
       # remove all existing .list files
       rm -f /etc/apt/sources.list.d/*.list
-      # remove bookworm and proxmox entries from sources.list
-      sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list || true
+      # remove bookworm and proxmox entries from sources.list (if it exists)
+      if [ -f /etc/apt/sources.list ]; then
+        sed -i '/proxmox/d;/bookworm/d' /etc/apt/sources.list
+      fi
       # Create new deb822 sources
       cat >/etc/apt/sources.list.d/debian.sources <<EOF
 Types: deb


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
PBS 4.x and fresh PVE 9 / Trixie installs no longer ship /etc/apt/sources.list (deb822 only). Running 'sed -i ... /etc/apt/sources.list || true' suppresses the exit code but still prints the noisy stderr message 'sed: can't read /etc/apt/sources.list: No such file or directory' during the post-install routine.


## 🔗 Related Issue

Fixes #14174

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
