### PR TITLE
pangolin: pin version, drop manual SQL, use upstream migrator

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -6,6 +6,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 # Source: https://pangolin.net/ | Github: https://github.com/fosrl/pangolin
 
 APP="Pangolin"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.2}"
 var_tags="${var_tags:-proxy}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
@@ -33,7 +34,7 @@ function update_script() {
 
   NODE_VERSION="24" setup_nodejs
 
-  if check_for_gh_release "pangolin" "fosrl/pangolin"; then
+  if check_for_gh_release "pangolin" "fosrl/pangolin" "$PANGOLIN_VERSION" "Pinned to a tested release because Pangolin's schema changes have repeatedly broken unattended updates. To try a newer version at your own risk, run: 'export PANGOLIN_VERSION=<tag>' and re-run update. If it breaks, please open an issue at https://github.com/community-scripts/ProxmoxVE/issues with the error log."; then
     msg_info "Stopping Service"
     systemctl stop pangolin
     systemctl stop gerbil
@@ -41,9 +42,13 @@ function update_script() {
 
     msg_info "Creating backup"
     tar -czf /opt/pangolin_config_backup.tar.gz -C /opt/pangolin config
+    if [[ -f /opt/pangolin/config/db/db.sqlite ]]; then
+      cp -a /opt/pangolin/config/db/db.sqlite \
+        "/opt/pangolin/config/db/db.sqlite.pre-${PANGOLIN_VERSION}-$(date +%Y%m%d-%H%M%S).bak"
+    fi
     msg_ok "Created backup"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_amd64"
 
     msg_info "Updating Pangolin"
@@ -67,36 +72,16 @@ function update_script() {
     rm -f /opt/pangolin_config_backup.tar.gz
     msg_ok "Restored config"
 
-    msg_info "Running database migrations"
-    cd /opt/pangolin
-
-    # Pre-apply potentially destructive schema changes safely so drizzle-kit
-    # does not recreate tables (which would delete all rows).
-    local DB="/opt/pangolin/config/db/db.sqlite"
-    if [[ -f "$DB" ]]; then
-      sqlite3 "$DB" "ALTER TABLE 'orgs' ADD COLUMN 'settingsLogRetentionDaysConnection' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
-      sqlite3 "$DB" "ALTER TABLE 'clientSitesAssociationsCache' ADD COLUMN 'isJitMode' integer DEFAULT 0 NOT NULL;" 2>/dev/null || true
-      sqlite3 "$DB" "ALTER TABLE 'userOrgs' ADD COLUMN 'pamUsername' text;" 2>/dev/null || true
-
-      # Create new role-mapping tables and migrate data before drizzle-kit
-      # drops the roleId columns from userOrgs and userInvites.
-      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS 'userOrgRoles' (
-        'userId' text NOT NULL REFERENCES 'user'('id') ON DELETE CASCADE,
-        'orgId' text NOT NULL REFERENCES 'orgs'('orgId') ON DELETE CASCADE,
-        'roleId' integer NOT NULL REFERENCES 'roles'('roleId') ON DELETE CASCADE,
-        UNIQUE('userId', 'orgId', 'roleId')
-      );" 2>/dev/null || true
-      sqlite3 "$DB" "INSERT OR IGNORE INTO 'userOrgRoles' (userId, orgId, roleId) SELECT userId, orgId, roleId FROM 'userOrgs' WHERE roleId IS NOT NULL;" 2>/dev/null || true
-
-      sqlite3 "$DB" "CREATE TABLE IF NOT EXISTS 'userInviteRoles' (
-        'inviteId' text NOT NULL REFERENCES 'userInvites'('inviteId') ON DELETE CASCADE,
-        'roleId' integer NOT NULL REFERENCES 'roles'('roleId') ON DELETE CASCADE,
-        PRIMARY KEY('inviteId', 'roleId')
-      );" 2>/dev/null || true
-      sqlite3 "$DB" "INSERT OR IGNORE INTO 'userInviteRoles' (inviteId, roleId) SELECT inviteId, roleId FROM 'userInvites' WHERE roleId IS NOT NULL;" 2>/dev/null || true
+    if ! grep -q '^ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service 2>/dev/null; then
+      msg_info "Adding migration step to pangolin.service"
+      sed -i '/^ExecStart=\/usr\/bin\/node --enable-source-maps dist\/server.mjs/i ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service
+      systemctl daemon-reload
+      msg_ok "Updated pangolin.service"
     fi
 
-    ENVIRONMENT=prod $STD npx drizzle-kit push --force --config drizzle.sqlite.config.ts
+    msg_info "Running database migrations"
+    cd /opt/pangolin
+    ENVIRONMENT=prod $STD node dist/migrations.mjs
     msg_ok "Ran database migrations"
 
     msg_info "Updating Badger plugin version"

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -22,7 +22,8 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.2}"
+fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_amd64"
 fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_amd64.tar.gz"
 
@@ -204,6 +205,7 @@ User=root
 Environment=NODE_ENV=production
 Environment=ENVIRONMENT=prod
 WorkingDirectory=/opt/pangolin
+ExecStartPre=/usr/bin/node dist/migrations.mjs
 ExecStart=/usr/bin/node --enable-source-maps dist/server.mjs
 Restart=always
 RestartSec=10


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Pangolin updates regularly broke (last: #14147 networkId/defaultNetworkId) because ct/pangolin.sh ran 'drizzle-kit push --force' against the live schema, which prompts interactively when columns look like renames.

Pin Version now to 1.18.2
Migrate to migrations.mjs in pangolin.service, that should migrate the db automatically on every restrt if needed

## 🔗 Related Issue

Fixes #14147

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
