### PR TITLE
Refactor: PeaNUT for v6

### DIFF
--- a/ct/peanut.sh
+++ b/ct/peanut.sh
@@ -45,6 +45,33 @@ function update_script() {
       msg_ok "Fixed entrypoint"
     fi
 
+    if [[ ! -f /etc/peanut/peanut.env ]]; then
+      msg_info "Migrating service to EnvironmentFile"
+      mkdir -p /etc/peanut
+      cat <<EOF >/etc/peanut/peanut.env
+NODE_ENV=production
+
+#WEB_HOST=0.0.0.0
+#WEB_PORT=8080
+#NUT_HOST=localhost
+#NUT_PORT=3493
+
+# Disable auth entirely:
+#AUTH_DISABLED=true
+
+# Bootstrap initial account on first start (ignored afterwards):
+#WEB_USERNAME=admin
+#WEB_PASSWORD=changeme
+EOF
+      chmod 600 /etc/peanut/peanut.env
+      sed -i '/^Environment=/d' /etc/systemd/system/peanut.service
+      if ! grep -q '^EnvironmentFile=/etc/peanut/peanut.env' /etc/systemd/system/peanut.service; then
+        sed -i '/^Type=simple/a EnvironmentFile=/etc/peanut/peanut.env' /etc/systemd/system/peanut.service
+      fi
+      systemctl daemon-reload
+      msg_ok "Migrated to /etc/peanut/peanut.env"
+    fi
+
     msg_info "Updating PeaNUT"
     cd /opt/peanut
     $STD pnpm i

--- a/install/peanut-install.sh
+++ b/install/peanut-install.sh
@@ -29,13 +29,28 @@ cp -r .next/static .next/standalone/.next/
 mkdir -p /opt/peanut/.next/standalone/config
 mkdir -p /etc/peanut/
 ln -sf .next/standalone/server.js server.js
-cat <<EOF >/etc/peanut/settings.yml
-WEB_HOST: 0.0.0.0
-WEB_PORT: 8080
-NUT_HOST: 0.0.0.0
-NUT_PORT: 3493
+if [[ ! -f /etc/peanut/settings.yml ]]; then
+  cat <<EOF >/etc/peanut/settings.yml
+NUT_SERVERS: []
 EOF
+fi
 ln -sf /etc/peanut/settings.yml /opt/peanut/.next/standalone/config/settings.yml
+cat <<EOF >/etc/peanut/peanut.env
+NODE_ENV=production
+
+#WEB_HOST=0.0.0.0
+#WEB_PORT=8080
+#NUT_HOST=localhost
+#NUT_PORT=3493
+
+# Disable auth entirely:
+#AUTH_DISABLED=true
+
+# Bootstrap initial account on first start (ignored afterwards):
+#WEB_USERNAME=admin
+#WEB_PASSWORD=changeme
+EOF
+chmod 600 /etc/peanut/peanut.env
 msg_ok "Setup Peanut"
 
 msg_info "Creating Service"
@@ -48,11 +63,7 @@ SyslogIdentifier=peanut
 Restart=always
 RestartSec=5
 Type=simple
-Environment="NODE_ENV=production"
-#Environment="NUT_HOST=localhost"
-#Environment="NUT_PORT=3493"
-#Environment="WEB_HOST=0.0.0.0"
-#Environment="WEB_PORT=8080"
+EnvironmentFile=/etc/peanut/peanut.env
 WorkingDirectory=/opt/peanut
 ExecStart=node /opt/peanut/entrypoint.mjs
 TimeoutStopSec=30


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
PeaNUT v6 enables authentication by default and on first boot redirects to a setup page (#14221). Settings can only be controlled via environment variables (AUTH_DISABLED, WEB_USERNAME, WEB_PASSWORD, WEB_HOST/PORT, NUT_HOST/PORT) — settings.yml does not cover them.

Refactor the systemd unit to load all runtime configuration from /etc/peanut/peanut.env (mode 0600) instead of hardcoded Environment= lines. The file documents every supported variable, with auth-related options pre-listed but commented out.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
