### PR TITLE
Databasus: update mongo-tools fallback to 100.16.1 and use now pnpm instead of npm ci

### DIFF
--- a/ct/databasus.sh
+++ b/ct/databasus.sh
@@ -46,7 +46,7 @@ function update_script() {
     # Install MongoDB Database Tools via direct .deb (no APT repo for Debian 13)
     if ! command -v mongodump &>/dev/null; then
       [[ "$(get_os_info id)" == "ubuntu" ]] && MONGO_DIST="ubuntu2204" || MONGO_DIST="debian12"
-      fetch_and_deploy_from_url "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-${MONGO_DIST}-x86_64-100.14.1.deb"
+      fetch_and_deploy_from_url "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-${MONGO_DIST}-x86_64-100.16.1.deb"
     fi
     [[ -f /usr/bin/mongodump ]] && ln -sf /usr/bin/mongodump /usr/local/mongodb-database-tools/bin/mongodump
     [[ -f /usr/bin/mongorestore ]] && ln -sf /usr/bin/mongorestore /usr/local/mongodb-database-tools/bin/mongorestore
@@ -67,8 +67,9 @@ function update_script() {
 
     msg_info "Updating Databasus"
     cd /opt/databasus/frontend
-    $STD npm ci
-    $STD npm run build
+    $STD corepack enable
+    $STD pnpm install --frozen-lockfile
+    $STD pnpm run build
     cd /opt/databasus/backend
     $STD go mod download
     $STD /root/go/bin/swag init -g cmd/main.go -o swagger

--- a/install/databasus-install.sh
+++ b/install/databasus-install.sh
@@ -32,7 +32,7 @@ for v in 12 13 14 15 16 18; do
 done
 # Install MongoDB Database Tools via direct .deb (no APT repo for Debian 13)
 [[ "$(get_os_info id)" == "ubuntu" ]] && MONGO_DIST="ubuntu2204" || MONGO_DIST="debian12"
-MONGO_VERSION=$(get_latest_gh_tag "mongodb/mongo-tools" "100." || echo "100.14.1")
+MONGO_VERSION=$(get_latest_gh_tag "mongodb/mongo-tools" "100." || echo "100.16.1")
 fetch_and_deploy_from_url "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-${MONGO_DIST}-x86_64-${MONGO_VERSION}.deb" ""
 mkdir -p /usr/local/mongodb-database-tools/bin
 [[ -f /usr/bin/mongodump ]] && ln -sf /usr/bin/mongodump /usr/local/mongodb-database-tools/bin/mongodump
@@ -53,8 +53,9 @@ fetch_and_deploy_gh_release "databasus" "databasus/databasus" "tarball" "latest"
 
 msg_info "Building Databasus (Patience)"
 cd /opt/databasus/frontend
-$STD npm ci
-$STD npm run build
+$STD corepack enable
+$STD pnpm install --frozen-lockfile
+$STD pnpm run build
 cd /opt/databasus/backend
 $STD go mod tidy
 $STD go mod download


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Bump Mongodb tools
- Update to use corepack and pnpm (yes in a minor version...) 

## 🔗 Related Issue

Fixes #14239

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
