### PR TITLE
tools.func: add GitLab release check/fetch/deploy helpers

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8750,8 +8750,7 @@ check_for_gl_release() {
   ensure_dependencies jq
 
   local repo_encoded
-  repo_encoded=$(printf '%s' "$repo" | sed 's|/|%2F|g')
-    echo "$source" | sed 's|/|%2F|g')
+  repo_encoded=$(printf '%s' "$source" | sed 's|/|%2F|g')
 
   local header=()
   [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")
@@ -8921,7 +8920,6 @@ function fetch_and_deploy_gl_release() {
 
   local repo_encoded
   repo_encoded=$(printf '%s' "$repo" | sed 's|/|%2F|g')
-    echo "$repo" | sed 's|/|%2F|g')
 
   local api_base="https://gitlab.com/api/v4/projects/$repo_encoded/releases"
   local api_url

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8891,6 +8891,113 @@ check_for_gl_release() {
   return 1
 }
 
+# ------------------------------------------------------------------------------
+# Scan older GitLab releases for a matching asset (fallback helper).
+#
+# Description:
+#   When the latest release does not contain the expected asset
+#   (e.g. .deb for the current arch, or a custom pattern), walks back
+#   through up to 15 recent releases and returns the first release JSON
+#   that has a matching asset. Used internally by fetch_and_deploy_gl_release.
+#
+# Usage (internal):
+#   _gl_scan_older_releases "owner/repo" "owner%2Frepo" "https://gitlab.com" \
+#     "binary|prebuild|singlefile" "$asset_pattern" "$skip_tag"
+#
+# Returns:
+#   - stdout: JSON of the matching release (single object) on success
+#   - 0 on success, 22 on API error, 250 if no match found
+# ------------------------------------------------------------------------------
+_gl_scan_older_releases() {
+  local repo="$1"
+  local repo_encoded="$2"
+  local base_url="${3:-https://gitlab.com}"
+  local mode="$4"
+  local asset_pattern="$5"
+  local skip_tag="$6"
+
+  local header=()
+  [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")
+
+  local releases_list
+  releases_list=$(curl --connect-timeout 10 --max-time 30 -fsSL \
+    "${header[@]}" \
+    "${base_url}/api/v4/projects/${repo_encoded}/releases?per_page=15&order_by=released_at&sort=desc" 2>/dev/null) || {
+    msg_warn "Failed to fetch older releases for ${repo}"
+    return 22
+  }
+
+  local count
+  count=$(echo "$releases_list" | jq 'length' 2>/dev/null || echo 0)
+  [[ "$count" -eq 0 ]] && return 250
+
+  for ((i = 0; i < count; i++)); do
+    local rel_tag
+    rel_tag=$(echo "$releases_list" | jq -r ".[$i].tag_name")
+
+    # Skip the tag we already checked
+    [[ "$rel_tag" == "$skip_tag" ]] && continue
+
+    # Asset URLs for this release (direct_asset_url preferred, fallback to url)
+    local asset_urls
+    asset_urls=$(echo "$releases_list" | jq -r ".[$i].assets.links // [] | .[] | .direct_asset_url // .url")
+    [[ -z "$asset_urls" ]] && continue
+
+    local has_match=false
+
+    if [[ "$mode" == "binary" ]]; then
+      local arch
+      arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
+      [[ "$arch" == "x86_64" ]] && arch="amd64"
+      [[ "$arch" == "aarch64" ]] && arch="arm64"
+
+      # Check with explicit pattern first, then arch heuristic, then any .deb
+      if [[ -n "$asset_pattern" ]]; then
+        while read -r u; do
+          case "${u##*/}" in $asset_pattern)
+            has_match=true
+            break
+            ;;
+          esac
+        done <<<"$asset_urls"
+      fi
+      if [[ "$has_match" != "true" ]]; then
+        echo "$asset_urls" | grep -qE "($arch|amd64|x86_64|aarch64|arm64).*\.deb$" && has_match=true
+      fi
+      if [[ "$has_match" != "true" ]]; then
+        echo "$asset_urls" | grep -qE '\.deb$' && has_match=true
+      fi
+
+    elif [[ "$mode" == "prebuild" || "$mode" == "singlefile" ]]; then
+      while read -r u; do
+        case "${u##*/}" in $asset_pattern)
+          has_match=true
+          break
+          ;;
+        esac
+      done <<<"$asset_urls"
+    fi
+
+    if [[ "$has_match" == "true" ]]; then
+      local use_fallback="y"
+      if [[ -t 0 ]]; then
+        msg_warn "Release ${skip_tag} has no matching asset. Previous release ${rel_tag} has a compatible asset."
+        read -rp "Use version ${rel_tag} instead? [Y/n] (auto-yes in 60s): " -t 60 use_fallback || use_fallback="y"
+        use_fallback="${use_fallback:-y}"
+      fi
+
+      if [[ "${use_fallback,,}" == "y" || "${use_fallback,,}" == "yes" ]]; then
+        echo "$releases_list" | jq ".[$i]"
+        return 0
+      else
+        return 250
+      fi
+    fi
+  done
+
+  return 250
+}
+
 function fetch_and_deploy_gl_release() {
   local app="$1"
   local repo="$2"

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8920,7 +8920,7 @@ function fetch_and_deploy_gl_release() {
   ensure_dependencies jq
 
   local repo_encoded
-  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$repo" 2>/dev/null ||
+  repo_encoded=$(printf '%s' "$repo" | sed 's|/|%2F|g')
     echo "$repo" | sed 's|/|%2F|g')
 
   local api_base="https://gitlab.com/api/v4/projects/$repo_encoded/releases"

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8665,3 +8665,655 @@ EOF
   $STD apt update
   return 0
 }
+
+# ------------------------------------------------------------------------------
+# Get latest GitLab release version.
+# Usage: get_latest_gitlab_release "owner/repo" [strip_v]
+# ------------------------------------------------------------------------------
+get_latest_gitlab_release() {
+  local repo="$1"
+  local strip_v="${2:-true}"
+
+  local repo_encoded
+  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$repo" 2>/dev/null ||
+    echo "$repo" | sed 's|/|%2F|g')
+
+  local header=()
+  [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")
+
+  local temp_file
+  temp_file=$(mktemp)
+
+  local http_code
+  http_code=$(curl --connect-timeout 10 --max-time 30 -sSL \
+    -w "%{http_code}" -o "$temp_file" \
+    "${header[@]}" \
+    "https://gitlab.com/api/v4/projects/$repo_encoded/releases?per_page=1&order_by=released_at&sort=desc" 2>/dev/null) || true
+
+  if [[ "$http_code" != "200" ]]; then
+    rm -f "$temp_file"
+    msg_warn "GitLab API call failed for ${repo} (HTTP ${http_code})"
+    return 22
+  fi
+
+  local version
+  version=$(jq -r '.[0].tag_name // empty' "$temp_file")
+  rm -f "$temp_file"
+
+  if [[ -z "$version" ]]; then
+    msg_error "Could not determine latest version for ${repo}"
+    return 250
+  fi
+
+  if [[ "$strip_v" == "true" ]]; then
+    [[ "$version" =~ ^v[0-9] ]] && version="${version:1}"
+  fi
+
+  echo "$version"
+}
+
+# ------------------------------------------------------------------------------
+# Checks for new GitLab release (latest tag).
+#
+# Description:
+#   - Queries the GitLab API for the latest release tag
+#   - Compares it to a local cached version (~/.<app>)
+#   - If newer, sets global CHECK_UPDATE_RELEASE and returns 0
+#
+# Usage:
+#     if check_for_gl_release "myapp" "owner/repo" [optional] "v1.2.3"; then
+#       # trigger update...
+#     fi
+#     exit 0
+#     } (end of update_script not from the function)
+#
+# Notes:
+#   - Requires `jq` (auto-installed if missing)
+#   - Supports GITLAB_TOKEN env var for private/rate-limited repos
+#   - Does not modify anything, only checks version state
+# ------------------------------------------------------------------------------
+check_for_gl_release() {
+  local app="$1"
+  local source="$2"
+  local pinned_version_in="${3:-}" # optional
+  local pin_reason="${4:-}"        # optional reason shown to user
+  local app_lc="${app,,}"
+  local current_file="$HOME/.${app_lc}"
+
+  msg_info "Checking for update: ${app}"
+
+  # DNS check
+  if ! getent hosts gitlab.com >/dev/null 2>&1; then
+    msg_error "Network error: cannot resolve gitlab.com"
+    return 6
+  fi
+
+  ensure_dependencies jq
+
+  local repo_encoded
+  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$source" 2>/dev/null ||
+    echo "$source" | sed 's|/|%2F|g')
+
+  local header=()
+  [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")
+
+  local releases_json="" http_code=""
+
+  # For pinned versions, try to fetch the specific release tag first
+  if [[ -n "$pinned_version_in" ]]; then
+    local pinned_encoded="${pinned_version_in//\//%2F}"
+    http_code=$(curl -sSL --max-time 20 -w "%{http_code}" -o /tmp/gl_check.json \
+      "${header[@]}" \
+      "https://gitlab.com/api/v4/projects/$repo_encoded/releases/$pinned_encoded" 2>/dev/null) || true
+    if [[ "$http_code" == "200" ]] && [[ -s /tmp/gl_check.json ]]; then
+      releases_json="[$(</tmp/gl_check.json)]"
+    fi
+    rm -f /tmp/gl_check.json
+  fi
+
+  # Fetch full releases list if needed
+  if [[ -z "$releases_json" ]]; then
+    http_code=$(curl -sSL --max-time 20 -w "%{http_code}" -o /tmp/gl_check.json \
+      "${header[@]}" \
+      "https://gitlab.com/api/v4/projects/$repo_encoded/releases?per_page=100&order_by=released_at&sort=desc" 2>/dev/null) || true
+
+    if [[ "$http_code" == "200" ]] && [[ -s /tmp/gl_check.json ]]; then
+      releases_json=$(</tmp/gl_check.json)
+    elif [[ "$http_code" == "401" ]]; then
+      msg_error "GitLab API authentication failed (HTTP 401)."
+      if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+        msg_error "Your GITLAB_TOKEN appears to be invalid or expired."
+      else
+        msg_error "The repository may require authentication. Try: export GITLAB_TOKEN=\"glpat-your_token\""
+      fi
+      rm -f /tmp/gl_check.json
+      return 22
+    elif [[ "$http_code" == "404" ]]; then
+      msg_error "GitLab project not found (HTTP 404). Ensure '${source}' is correct and publicly accessible."
+      rm -f /tmp/gl_check.json
+      return 22
+    elif [[ "$http_code" == "429" ]]; then
+      msg_error "GitLab API rate limit exceeded (HTTP 429)."
+      msg_error "To increase the limit, export a GitLab token: export GITLAB_TOKEN=\"glpat-your_token_here\""
+      rm -f /tmp/gl_check.json
+      return 22
+    elif [[ "$http_code" == "000" || -z "$http_code" ]]; then
+      msg_error "GitLab API connection failed (no response)."
+      msg_error "Check your network/DNS: curl -sSL https://gitlab.com/api/v4/version"
+      rm -f /tmp/gl_check.json
+      return 7
+    else
+      msg_error "Unable to fetch releases for ${app} (HTTP ${http_code})"
+      rm -f /tmp/gl_check.json
+      return 22
+    fi
+    rm -f /tmp/gl_check.json
+  fi
+
+  mapfile -t raw_tags < <(jq -r '.[] | .tag_name' <<<"$releases_json")
+  if ((${#raw_tags[@]} == 0)); then
+    msg_error "No releases found for ${app} on GitLab"
+    return 250
+  fi
+
+  local clean_tags=()
+  for t in "${raw_tags[@]}"; do
+    # Only strip leading 'v' when followed by a digit (e.g. v1.2.3)
+    if [[ "$t" =~ ^v[0-9] ]]; then
+      clean_tags+=("${t:1}")
+    else
+      clean_tags+=("$t")
+    fi
+  done
+
+  local latest_raw="${raw_tags[0]}"
+  local latest_clean="${clean_tags[0]}"
+
+  # current installed (stored without v)
+  local current=""
+  if [[ -f "$current_file" ]]; then
+    current="$(<"$current_file")"
+  else
+    # Migration: search for any /opt/*_version.txt
+    local legacy_files
+    mapfile -t legacy_files < <(find /opt -maxdepth 1 -type f -name "*_version.txt" 2>/dev/null)
+    if ((${#legacy_files[@]} == 1)); then
+      current="$(<"${legacy_files[0]}")"
+      echo "${current#v}" >"$current_file"
+      rm -f "${legacy_files[0]}"
+    fi
+  fi
+  if [[ "$current" =~ ^v[0-9] ]]; then
+    current="${current:1}"
+  fi
+
+  # Pinned version handling
+  if [[ -n "$pinned_version_in" ]]; then
+    local pin_clean
+    if [[ "$pinned_version_in" =~ ^v[0-9] ]]; then
+      pin_clean="${pinned_version_in:1}"
+    else
+      pin_clean="$pinned_version_in"
+    fi
+    local match_raw=""
+    for i in "${!clean_tags[@]}"; do
+      if [[ "${clean_tags[$i]}" == "$pin_clean" ]]; then
+        match_raw="${raw_tags[$i]}"
+        break
+      fi
+    done
+
+    if [[ -z "$match_raw" ]]; then
+      msg_error "Pinned version ${pinned_version_in} not found upstream"
+      return 250
+    fi
+
+    if [[ "$current" != "$pin_clean" ]]; then
+      CHECK_UPDATE_RELEASE="$match_raw"
+      msg_ok "Update available: ${app} ${current:-not installed} → ${pin_clean}"
+      return 0
+    fi
+
+    if [[ -n "$pin_reason" ]]; then
+      msg_ok "No update available: ${app} (${current}) - update held back: ${pin_reason}"
+    else
+      msg_ok "No update available: ${app} (${current}) - update temporarily held back due to issues with newer releases"
+    fi
+    return 1
+  fi
+
+  # No pinning → use latest
+  if [[ -z "$current" || "$current" != "$latest_clean" ]]; then
+    CHECK_UPDATE_RELEASE="$latest_raw"
+    msg_ok "Update available: ${app} ${current:-not installed} → ${latest_clean}"
+    return 0
+  fi
+
+  msg_ok "No update available: ${app} (${latest_clean})"
+  return 1
+}
+
+function fetch_and_deploy_gl_release() {
+  local app="$1"
+  local repo="$2"
+  local mode="${3:-tarball}"
+  local version="${var_appversion:-${4:-latest}}"
+  local target="${5:-/opt/$app}"
+  local asset_pattern="${6:-}"
+
+  if [[ -z "$app" ]]; then
+    app="${repo##*/}"
+    if [[ -z "$app" ]]; then
+      msg_error "fetch_and_deploy_gl_release requires app name or valid repo"
+      return 1
+    fi
+  fi
+
+  local app_lc=$(echo "${app,,}" | tr -d ' ')
+  local version_file="$HOME/.${app_lc}"
+
+  local api_timeout="--connect-timeout 10 --max-time 60"
+  local download_timeout="--connect-timeout 15 --max-time 900"
+
+  local current_version=""
+  [[ -f "$version_file" ]] && current_version=$(<"$version_file")
+
+  ensure_dependencies jq
+
+  local repo_encoded
+  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$repo" 2>/dev/null ||
+    echo "$repo" | sed 's|/|%2F|g')
+
+  local api_base="https://gitlab.com/api/v4/projects/$repo_encoded/releases"
+  local api_url
+  if [[ "$version" != "latest" ]]; then
+    api_url="$api_base/$version"
+  else
+    api_url="$api_base?per_page=1&order_by=released_at&sort=desc"
+  fi
+
+  local header=()
+  [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")
+
+  local max_retries=3 retry_delay=2 attempt=1 success=false http_code
+
+  while ((attempt <= max_retries)); do
+    http_code=$(curl $api_timeout -sSL -w "%{http_code}" -o /tmp/gl_rel.json "${header[@]}" "$api_url" 2>/dev/null) || true
+    if [[ "$http_code" == "200" ]]; then
+      success=true
+      break
+    elif [[ "$http_code" == "429" ]]; then
+      if ((attempt < max_retries)); then
+        msg_warn "GitLab API rate limit hit, retrying in ${retry_delay}s... (attempt $attempt/$max_retries)"
+        sleep "$retry_delay"
+        retry_delay=$((retry_delay * 2))
+      fi
+    else
+      sleep "$retry_delay"
+    fi
+    ((attempt++))
+  done
+
+  if ! $success; then
+    if [[ "$http_code" == "401" ]]; then
+      msg_error "GitLab API authentication failed (HTTP 401)."
+      if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+        msg_error "Your GITLAB_TOKEN appears to be invalid or expired."
+      else
+        msg_error "The repository may require authentication. Try: export GITLAB_TOKEN=\"glpat-your_token\""
+      fi
+    elif [[ "$http_code" == "404" ]]; then
+      msg_error "GitLab project or release not found (HTTP 404)."
+      msg_error "Ensure '$repo' is correct and the project is accessible."
+    elif [[ "$http_code" == "429" ]]; then
+      msg_error "GitLab API rate limit exceeded (HTTP 429)."
+      msg_error "To increase the limit, export a GitLab token before running the script:"
+      msg_error "  export GITLAB_TOKEN=\"glpat-your_token_here\""
+    elif [[ "$http_code" == "000" || -z "$http_code" ]]; then
+      msg_error "GitLab API connection failed (no response)."
+      msg_error "Check your network/DNS: curl -sSL https://gitlab.com/api/v4/version"
+    else
+      msg_error "Failed to fetch release metadata (HTTP $http_code)"
+    fi
+    return 1
+  fi
+
+  local json tag_name
+  json=$(</tmp/gl_rel.json)
+
+  if [[ "$version" == "latest" ]]; then
+    json=$(echo "$json" | jq '.[0] // empty')
+    if [[ -z "$json" || "$json" == "null" ]]; then
+      msg_error "No releases found for $repo on GitLab"
+      return 1
+    fi
+  fi
+
+  tag_name=$(echo "$json" | jq -r '.tag_name // empty')
+  if [[ -z "$tag_name" ]]; then
+    msg_error "Could not determine tag name from release metadata"
+    return 1
+  fi
+  [[ "$tag_name" =~ ^v[0-9] ]] && version="${tag_name:1}" || version="$tag_name"
+  local version_safe="${version//\//-}"
+
+  if [[ "$current_version" == "$version" ]]; then
+    $STD msg_ok "$app is already up-to-date (v$version)"
+    return 0
+  fi
+
+  local tmpdir
+  tmpdir=$(mktemp -d) || return 1
+  local filename=""
+
+  msg_info "Fetching GitLab release: $app ($version)"
+
+  _gl_asset_urls() {
+    local release_json="$1"
+    echo "$release_json" | jq -r '
+      (.assets.links // [])[] | .direct_asset_url // .url
+    '
+  }
+
+  ### Tarball Mode ###
+  if [[ "$mode" == "tarball" || "$mode" == "source" ]]; then
+    local direct_tarball_url="https://gitlab.com/$repo/-/archive/$tag_name/${app_lc}-${version_safe}.tar.gz"
+    filename="${app_lc}-${version_safe}.tar.gz"
+
+    curl $download_timeout -fsSL "${header[@]}" -o "$tmpdir/$filename" "$direct_tarball_url" || {
+      msg_error "Download failed: $direct_tarball_url"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    mkdir -p "$target"
+    if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
+      rm -rf "${target:?}/"*
+    fi
+
+    tar --no-same-owner -xzf "$tmpdir/$filename" -C "$tmpdir" || {
+      msg_error "Failed to extract tarball"
+      rm -rf "$tmpdir"
+      return 1
+    }
+    local unpack_dir
+    unpack_dir=$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d | head -n1)
+
+    shopt -s dotglob nullglob
+    cp -r "$unpack_dir"/* "$target/"
+    shopt -u dotglob nullglob
+
+  ### Binary Mode ###
+  elif [[ "$mode" == "binary" ]]; then
+    local arch
+    arch=$(dpkg --print-architecture 2>/dev/null || uname -m)
+    [[ "$arch" == "x86_64" ]] && arch="amd64"
+    [[ "$arch" == "aarch64" ]] && arch="arm64"
+
+    local assets url_match=""
+    assets=$(_gl_asset_urls "$json")
+
+    if [[ -n "$asset_pattern" ]]; then
+      for u in $assets; do
+        case "${u##*/}" in
+        $asset_pattern)
+          url_match="$u"
+          break
+          ;;
+        esac
+      done
+    fi
+
+    if [[ -z "$url_match" ]]; then
+      for u in $assets; do
+        if [[ "$u" =~ ($arch|amd64|x86_64|aarch64|arm64).*\.deb$ ]]; then
+          url_match="$u"
+          break
+        fi
+      done
+    fi
+
+    if [[ -z "$url_match" ]]; then
+      for u in $assets; do
+        [[ "$u" =~ \.deb$ ]] && url_match="$u" && break
+      done
+    fi
+
+    if [[ -z "$url_match" ]]; then
+      local fallback_json
+      if fallback_json=$(_gl_scan_older_releases "$repo" "$repo_encoded" "https://gitlab.com" "binary" "$asset_pattern" "$tag_name"); then
+        json="$fallback_json"
+        tag_name=$(echo "$json" | jq -r '.tag_name // empty')
+        [[ "$tag_name" =~ ^v[0-9] ]] && version="${tag_name:1}" || version="$tag_name"
+        msg_info "Fetching GitLab release: $app ($version)"
+        assets=$(_gl_asset_urls "$json")
+        if [[ -n "$asset_pattern" ]]; then
+          for u in $assets; do
+            case "${u##*/}" in $asset_pattern)
+              url_match="$u"
+              break
+              ;;
+            esac
+          done
+        fi
+        if [[ -z "$url_match" ]]; then
+          for u in $assets; do
+            [[ "$u" =~ ($arch|amd64|x86_64|aarch64|arm64).*\.deb$ ]] && url_match="$u" && break
+          done
+        fi
+        if [[ -z "$url_match" ]]; then
+          for u in $assets; do
+            [[ "$u" =~ \.deb$ ]] && url_match="$u" && break
+          done
+        fi
+      fi
+    fi
+
+    if [[ -z "$url_match" ]]; then
+      msg_error "No suitable .deb asset found for $app"
+      rm -rf "$tmpdir"
+      return 1
+    fi
+
+    filename="${url_match##*/}"
+    curl $download_timeout -fsSL "${header[@]}" -o "$tmpdir/$filename" "$url_match" || {
+      msg_error "Download failed: $url_match"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    chmod 644 "$tmpdir/$filename"
+    local dpkg_opts=""
+    [[ "${DPKG_FORCE_CONFOLD:-}" == "1" ]] && dpkg_opts="-o Dpkg::Options::=--force-confold"
+    [[ "${DPKG_FORCE_CONFNEW:-}" == "1" ]] && dpkg_opts="-o Dpkg::Options::=--force-confnew"
+    DEBIAN_FRONTEND=noninteractive SYSTEMD_OFFLINE=1 $STD apt install -y $dpkg_opts "$tmpdir/$filename" || {
+      SYSTEMD_OFFLINE=1 $STD dpkg -i "$tmpdir/$filename" || {
+        msg_error "Both apt and dpkg installation failed"
+        rm -rf "$tmpdir"
+        return 1
+      }
+    }
+
+  ### Prebuild Mode ###
+  elif [[ "$mode" == "prebuild" ]]; then
+    local pattern="${6%\"}"
+    pattern="${pattern#\"}"
+    [[ -z "$pattern" ]] && {
+      msg_error "Mode 'prebuild' requires 6th parameter (asset filename pattern)"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    local asset_url=""
+    for u in $(_gl_asset_urls "$json"); do
+      filename_candidate="${u##*/}"
+      case "$filename_candidate" in
+      $pattern)
+        asset_url="$u"
+        break
+        ;;
+      esac
+    done
+
+    if [[ -z "$asset_url" ]]; then
+      local fallback_json
+      if fallback_json=$(_gl_scan_older_releases "$repo" "$repo_encoded" "https://gitlab.com" "prebuild" "$pattern" "$tag_name"); then
+        json="$fallback_json"
+        tag_name=$(echo "$json" | jq -r '.tag_name // empty')
+        [[ "$tag_name" =~ ^v[0-9] ]] && version="${tag_name:1}" || version="$tag_name"
+        msg_info "Fetching GitLab release: $app ($version)"
+        for u in $(_gl_asset_urls "$json"); do
+          filename_candidate="${u##*/}"
+          case "$filename_candidate" in $pattern)
+            asset_url="$u"
+            break
+            ;;
+          esac
+        done
+      fi
+    fi
+
+    [[ -z "$asset_url" ]] && {
+      msg_error "No asset matching '$pattern' found"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    filename="${asset_url##*/}"
+    curl $download_timeout -fsSL "${header[@]}" -o "$tmpdir/$filename" "$asset_url" || {
+      msg_error "Download failed: $asset_url"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    local unpack_tmp
+    unpack_tmp=$(mktemp -d)
+    mkdir -p "$target"
+    if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
+      rm -rf "${target:?}/"*
+    fi
+
+    if [[ "$filename" == *.zip ]]; then
+      ensure_dependencies unzip
+      unzip -q "$tmpdir/$filename" -d "$unpack_tmp" || {
+        msg_error "Failed to extract ZIP archive"
+        rm -rf "$tmpdir" "$unpack_tmp"
+        return 1
+      }
+    elif [[ "$filename" == *.tar.* || "$filename" == *.tgz || "$filename" == *.txz ]]; then
+      tar --no-same-owner -xf "$tmpdir/$filename" -C "$unpack_tmp" || {
+        msg_error "Failed to extract TAR archive"
+        rm -rf "$tmpdir" "$unpack_tmp"
+        return 1
+      }
+    else
+      msg_error "Unsupported archive format: $filename"
+      rm -rf "$tmpdir" "$unpack_tmp"
+      return 1
+    fi
+
+    local top_entries inner_dir
+    top_entries=$(find "$unpack_tmp" -mindepth 1 -maxdepth 1)
+    if [[ "$(echo "$top_entries" | wc -l)" -eq 1 && -d "$top_entries" ]]; then
+      inner_dir="$top_entries"
+      shopt -s dotglob nullglob
+      if compgen -G "$inner_dir/*" >/dev/null; then
+        cp -r "$inner_dir"/* "$target/" || {
+          msg_error "Failed to copy contents from $inner_dir to $target"
+          rm -rf "$tmpdir" "$unpack_tmp"
+          return 1
+        }
+      else
+        msg_error "Inner directory is empty: $inner_dir"
+        rm -rf "$tmpdir" "$unpack_tmp"
+        return 1
+      fi
+      shopt -u dotglob nullglob
+    else
+      shopt -s dotglob nullglob
+      if compgen -G "$unpack_tmp/*" >/dev/null; then
+        cp -r "$unpack_tmp"/* "$target/" || {
+          msg_error "Failed to copy contents to $target"
+          rm -rf "$tmpdir" "$unpack_tmp"
+          return 1
+        }
+      else
+        msg_error "Unpacked archive is empty"
+        rm -rf "$tmpdir" "$unpack_tmp"
+        return 1
+      fi
+      shopt -u dotglob nullglob
+    fi
+
+  ### Singlefile Mode ###
+  elif [[ "$mode" == "singlefile" ]]; then
+    local pattern="${6%\"}"
+    pattern="${pattern#\"}"
+    [[ -z "$pattern" ]] && {
+      msg_error "Mode 'singlefile' requires 6th parameter (asset filename pattern)"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    local asset_url=""
+    for u in $(_gl_asset_urls "$json"); do
+      filename_candidate="${u##*/}"
+      case "$filename_candidate" in
+      $pattern)
+        asset_url="$u"
+        break
+        ;;
+      esac
+    done
+
+    if [[ -z "$asset_url" ]]; then
+      local fallback_json
+      if fallback_json=$(_gl_scan_older_releases "$repo" "$repo_encoded" "https://gitlab.com" "singlefile" "$pattern" "$tag_name"); then
+        json="$fallback_json"
+        tag_name=$(echo "$json" | jq -r '.tag_name // empty')
+        [[ "$tag_name" =~ ^v[0-9] ]] && version="${tag_name:1}" || version="$tag_name"
+        msg_info "Fetching GitLab release: $app ($version)"
+        for u in $(_gl_asset_urls "$json"); do
+          filename_candidate="${u##*/}"
+          case "$filename_candidate" in $pattern)
+            asset_url="$u"
+            break
+            ;;
+          esac
+        done
+      fi
+    fi
+
+    [[ -z "$asset_url" ]] && {
+      msg_error "No asset matching '$pattern' found"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    filename="${asset_url##*/}"
+    mkdir -p "$target"
+
+    local use_filename="${USE_ORIGINAL_FILENAME:-false}"
+    local target_file="$app"
+    [[ "$use_filename" == "true" ]] && target_file="$filename"
+
+    curl $download_timeout -fsSL "${header[@]}" -o "$target/$target_file" "$asset_url" || {
+      msg_error "Download failed: $asset_url"
+      rm -rf "$tmpdir"
+      return 1
+    }
+
+    if [[ "$target_file" != *.jar && -f "$target/$target_file" ]]; then
+      chmod +x "$target/$target_file"
+    fi
+
+  else
+    msg_error "Unknown mode: $mode"
+    rm -rf "$tmpdir"
+    return 1
+  fi
+
+  echo "$version" >"$version_file"
+  msg_ok "Deployed: $app ($version)"
+  rm -rf "$tmpdir"
+}

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8750,7 +8750,7 @@ check_for_gl_release() {
   ensure_dependencies jq
 
   local repo_encoded
-  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$source" 2>/dev/null ||
+  repo_encoded=$(printf '%s' "$repo" | sed 's|/|%2F|g')
     echo "$source" | sed 's|/|%2F|g')
 
   local header=()

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -8675,8 +8675,7 @@ get_latest_gitlab_release() {
   local strip_v="${2:-true}"
 
   local repo_encoded
-  repo_encoded=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$repo" 2>/dev/null ||
-    echo "$repo" | sed 's|/|%2F|g')
+  repo_encoded=$(printf '%s' "$repo" | sed 's|/|%2F|g')
 
   local header=()
   [[ -n "${GITLAB_TOKEN:-}" ]] && header=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN")


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add utilities to query and deploy GitLab releases: get_latest_gitlab_release, check_for_gl_release, and fetch_and_deploy_gl_release. Features include support for GITLAB_TOKEN, HTTP error handling and retries, jq/curl-based JSON parsing, detection/migration of legacy version files, and setting CHECK_UPDATE_RELEASE when updates are available. fetch_and_deploy_gl_release supports multiple modes (tarball/source, binary, prebuild, singlefile), asset pattern matching, architecture-aware .deb selection, installation via apt/dpkg, archive extraction, and optional clean installs. Helpful messages are emitted for auth/rate-limit/network errors and required dependencies (jq, unzip) are ensured when needed.

=> Needed for: https://github.com/community-scripts/ProxmoxVE/pull/14122

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
