### PR TITLE
Pelican-Panel: create backup subdirectory before copying storage

### DIFF
--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -46,6 +46,7 @@ function update_script() {
     msg_ok "Stopped Service"
 
     cp -a /opt/pelican-panel/.env /opt/backup
+    mkdir -p /opt/backup/storage/app/
     cp -a /opt/pelican-panel/storage/app/public /opt/backup/storage/app/
     
     SQLITE_INSTALL=$(ls /opt/pelican-panel/database/*.sqlite 1>/dev/null 2>&1 && echo "true" || echo "false")


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The update script tried to cp into /opt/backup/storage/app/ before the directory existed, causing a 'Not a directory' error when /opt/backup was previously a file or the subdirs were missing. Add mkdir -p to ensure the target directory exists.

## 🔗 Related Issue

Fixes #14268

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
