### PR TITLE
update-apps: some  improvements

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3230,6 +3230,10 @@ check_container_resources() {
   if [[ "$current_ram" -lt "$var_ram" ]] || [[ "$current_cpu" -lt "$var_cpu" ]]; then
     msg_warn "Under-provisioned: Required ${var_cpu} CPU/${var_ram}MB RAM, Current ${current_cpu} CPU/${current_ram}MB RAM"
     echo -e "${YWB}Please ensure that the ${APP} LXC is configured with at least ${var_cpu} vCPU and ${var_ram} MB RAM for the build process.${CL}\n"
+    if is_unattended; then
+      msg_error "Aborted: under-provisioned LXC in unattended mode (${current_cpu} CPU/${current_ram}MB RAM < ${var_cpu} CPU/${var_ram}MB RAM)"
+      exit 113
+    fi
     echo -ne "${INFO}${HOLD} May cause data loss! ${INFO} Continue update with under-provisioned LXC? <yes/No>  "
     read -r prompt </dev/tty
     if [[ ! ${prompt,,} =~ ^(yes)$ ]]; then
@@ -3253,6 +3257,10 @@ check_container_storage() {
   usage=$((100 * used_size / total_size))
   if ((usage > 80)); then
     msg_warn "Storage is dangerously low (${usage}% used on /boot)"
+    if is_unattended; then
+      msg_error "Aborted: storage too low in unattended mode (${usage}% used on /boot)"
+      exit 114
+    fi
     echo -ne "Continue anyway? <y/N>  "
     read -r prompt </dev/tty
     if [[ ! ${prompt,,} =~ ^(y|yes)$ ]]; then

--- a/misc/core.func
+++ b/misc/core.func
@@ -868,6 +868,12 @@ get_header() {
 # - Returns silently if header not available
 # ------------------------------------------------------------------------------
 header_info() {
+  # Guard against printing the header twice in the same session (e.g. when
+  # the ct script calls header_info at global scope AND again inside
+  # update_script()).
+  [[ "${_HEADER_SHOWN:-0}" == "1" ]] && return 0
+  _HEADER_SHOWN=1
+
   local app_name=$(echo "${APP,,}" | tr -d ' ')
   local header_content
 

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -602,7 +602,11 @@ done
 
 wait
 header_info
-echo -e "${GN}The process is complete, and the containers have been successfully updated.${CL}\n"
+if [[ "$var_dry_run" == "yes" ]]; then
+  echo -e "${GN}Dry-run complete. No containers were modified.${CL}\n"
+else
+  echo -e "${GN}The process is complete, and the containers have been successfully updated.${CL}\n"
+fi
 
 # =============================================================================
 # SUMMARY REPORT

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -505,6 +505,10 @@ for container in $CHOICE; do
     msg_ok "Updated container $container"
   elif [ $exit_code -eq 75 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (requires interactive mode)"
+  elif [ $exit_code -eq 113 ]; then
+    echo -e "${YW}[WARN]${CL} Container $container skipped (under-provisioned: increase CPU/RAM to match template)"
+  elif [ $exit_code -eq 114 ]; then
+    echo -e "${YW}[WARN]${CL} Container $container skipped (storage critically low on /boot)"
   elif [ "$BACKUP_CHOICE" == "yes" ]; then
     msg_error "Update failed for container $container (exit code: $exit_code) — attempting restore"
     msg_info "Restoring LXC $container from backup ($STORAGE_CHOICE)"

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -240,7 +240,28 @@ END {
 ' /etc/pve/storage.cfg)
 }
 
+# Structured result tracking for the final summary report
+# Each entry: "CTID|service|STATUS|details"
+declare -a UPDATE_RESULTS=()
+function log_result() {
+  # log_result <ctid> <service> <STATUS> <details>
+  UPDATE_RESULTS+=("${1}|${2}|${3}|${4}")
+}
+
 header_info
+
+# =============================================================================
+# LOGGING SETUP
+# All output is tee'd (ANSI colours stripped) to a timestamped log file under
+# /usr/local/community-scripts/update_apps/
+# =============================================================================
+LOG_DIR="/usr/local/community-scripts/update_apps"
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/$(date '+%Y%m%d_%H%M%S').log"
+# Redirect stdout+stderr through an ANSI-stripping sed into tee so the
+# terminal keeps colours while the log file stays plain text.
+exec > >(sed 's/\x1B\[[0-9;:]*[mKHfJ]//g' | tee -a "$LOG_FILE") 2>&1
+echo "Update started: $(date '+%Y-%m-%d %H:%M:%S') — log: $LOG_FILE"
 
 # Skip confirmation if var_skip_confirm is set to yes
 if [[ "$var_skip_confirm" != "yes" ]]; then
@@ -413,6 +434,7 @@ for container in $CHOICE; do
   #1.1) If update script not detected, return
   if [ -z "${service}" ]; then
     echo -e "${YW}[WARN]${CL} Update script not found. Skipping to next container"
+    log_result "$container" "(unknown)" "SKIPPED" "No update script found in container"
     continue
   else
     echo -e "${BL}[INFO]${CL} Detected service: ${GN}${service}${CL}"
@@ -469,6 +491,7 @@ for container in $CHOICE; do
   #3.5) Dry-run: report update availability without applying
   if [[ "$var_dry_run" == "yes" ]]; then
     dry_run_container "$container" "$service"
+    log_result "$container" "$service" "DRY-RUN" "Version check only — no changes applied"
     continue
   fi
 
@@ -503,12 +526,16 @@ for container in $CHOICE; do
 
   if [ $exit_code -eq 0 ]; then
     msg_ok "Updated container $container"
+    log_result "$container" "$service" "OK" "Updated successfully"
   elif [ $exit_code -eq 75 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (requires interactive mode)"
+    log_result "$container" "$service" "SKIPPED" "Requires interactive mode (exit 75)"
   elif [ $exit_code -eq 113 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (under-provisioned: increase CPU/RAM to match template)"
+    log_result "$container" "$service" "SKIPPED" "Under-provisioned — increase CPU/RAM to match template"
   elif [ $exit_code -eq 114 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (storage critically low on /boot)"
+    log_result "$container" "$service" "SKIPPED" "Storage critically low on /boot (>80%)"
   elif [ "$BACKUP_CHOICE" == "yes" ]; then
     msg_error "Update failed for container $container (exit code: $exit_code) — attempting restore"
     msg_info "Restoring LXC $container from backup ($STORAGE_CHOICE)"
@@ -517,6 +544,7 @@ for container in $CHOICE; do
     BACKUP_ENTRY=$(pvesm list "$STORAGE_CHOICE" 2>/dev/null | awk -v ctid="$container" '$1 ~ "vzdump-lxc-"ctid"-" || $1 ~ "/ct/"ctid"/" {print $1}' | sort -r | head -n1)
     if [ -z "$BACKUP_ENTRY" ]; then
       msg_error "No backup found in storage $STORAGE_CHOICE for container $container"
+      log_result "$container" "$service" "FAILED" "Update failed (exit $exit_code) — no backup found for restore"
       exit 235
     fi
     msg_info "Restoring from: $BACKUP_ENTRY"
@@ -525,12 +553,15 @@ for container in $CHOICE; do
     if [ $restorestatus -eq 0 ]; then
       pct start $container
       msg_ok "Container $container successfully restored from backup"
+      log_result "$container" "$service" "RESTORED" "Update failed (exit $exit_code) — restored from backup"
     else
       msg_error "Restore failed for container $container"
+      log_result "$container" "$service" "FAILED" "Update failed (exit $exit_code) — restore also failed"
       exit 235
     fi
   else
     msg_error "Update failed for container $container (exit code: $exit_code)"
+    log_result "$container" "$service" "FAILED" "Exit code $exit_code"
     if [[ "$var_continue_on_error" == "yes" ]]; then
       echo -e "${YW}[WARN]${CL} Continuing to next container (var_continue_on_error=yes)"
       continue
@@ -543,6 +574,30 @@ done
 wait
 header_info
 echo -e "${GN}The process is complete, and the containers have been successfully updated.${CL}\n"
+
+# =============================================================================
+# SUMMARY REPORT
+# =============================================================================
+if [ "${#UPDATE_RESULTS[@]}" -gt 0 ]; then
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  printf "  %-8s  %-22s  %-10s  %s\n" "CTID" "Service" "Status" "Details"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  for entry in "${UPDATE_RESULTS[@]}"; do
+    IFS='|' read -r _ctid _svc _status _details <<<"$entry"
+    case "$_status" in
+    OK) _color="${GN}" ;;
+    FAILED) _color="${RD}" ;;
+    RESTORED) _color="${YW}" ;;
+    *) _color="${YW}" ;;
+    esac
+    printf "  %-8s  %-22s  ${_color}%-10s${CL}  %s\n" "$_ctid" "$_svc" "$_status" "$_details"
+  done
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Full log: $LOG_FILE"
+  echo ""
+fi
 if [ "${#containers_needing_reboot[@]}" -gt 0 ]; then
   echo -e "${RD}The following containers require a reboot:${CL}"
   for container_name in "${containers_needing_reboot[@]}"; do

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -473,12 +473,15 @@ for container in $CHOICE; do
   fi
 
   #4) Update service, using the update command
+  # Prepend a no-op 'clear' wrapper to PATH so update scripts calling clear
+  # don't fail without a TTY — works for all shells incl. ash (no export -f)
+  SETUP_CMD="mkdir -p /tmp/.nc; printf '#!/bin/sh\n:\n' > /tmp/.nc/clear; chmod +x /tmp/.nc/clear; export PATH=/tmp/.nc:\$PATH; export TERM=dumb; "
   case "$os" in
-  alpine) pct exec "$container" -- ash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
-  archlinux) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
-  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
-  opensuse) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
+  alpine) pct exec "$container" -- ash -c "${SETUP_CMD}${UPDATE_CMD}" ;;
+  archlinux) pct exec "$container" -- bash -c "${SETUP_CMD}${UPDATE_CMD}" ;;
+  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "${SETUP_CMD}${UPDATE_CMD}" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "${SETUP_CMD}${UPDATE_CMD}" ;;
+  opensuse) pct exec "$container" -- bash -c "${SETUP_CMD}${UPDATE_CMD}" ;;
   esac
   exit_code=$?
 

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -185,8 +185,8 @@ function dry_run_container() {
   latest_version=$(curl -sSL --max-time 10 \
     -H 'Accept: application/vnd.github+json' \
     -H 'X-GitHub-Api-Version: 2022-11-28' \
-    "https://api.github.com/repos/${source_repo}/releases/latest" 2>/dev/null \
-    | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
+    "https://api.github.com/repos/${source_repo}/releases/latest" 2>/dev/null |
+    grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
 
   if [[ -z "$latest_version" ]]; then
     echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): cannot fetch latest version from $source_repo"
@@ -474,11 +474,11 @@ for container in $CHOICE; do
 
   #4) Update service, using the update command
   case "$os" in
-  alpine) pct exec "$container" -- ash -c "export TERM=dumb;$UPDATE_CMD" ;;
-  archlinux) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
-  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
-  opensuse) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
+  alpine) pct exec "$container" -- ash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
+  archlinux) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
+  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
+  opensuse) pct exec "$container" -- bash -c "export TERM=dumb; clear() { :; }; $UPDATE_CMD" ;;
   esac
   exit_code=$?
 

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -156,28 +156,28 @@ function dry_run_container() {
   local container="$1"
   local service="$2"
 
-  # Extract GitHub source URL from the ct script header (# Source: https://github.com/owner/repo)
-  local source_url source_repo
-  source_url=$(echo "$script" | grep '^# Source:' | head -1 | awk '{print $3}')
-  source_repo=$(echo "$source_url" | sed 's|https://github.com/||;s|/$||')
+  # Extract app name and source repo directly from check_for_gh_release call in the ct script
+  # Pattern: check_for_gh_release "appname" "owner/repo"
+  local check_line app_name app_lc source_repo
+  check_line=$(echo "$script" | grep -m1 'check_for_gh_release')
 
-  if [[ -z "$source_repo" || "$source_repo" == "$source_url" ]]; then
-    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): non-GitHub source or not detectable — skipping"
+  if [[ -z "$check_line" ]]; then
+    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): no check_for_gh_release found — skipping"
     return
   fi
 
-  # Find the app name used in check_for_gh_release to locate the version file (~/.appname)
-  local app_name app_lc
-  app_name=$(echo "$script" | grep -o 'check_for_gh_release "[^"]*"' | head -1 | cut -d'"' -f2)
-  if [[ -z "$app_name" ]]; then
-    app_lc=$(echo "${service,,}" | tr -d ' ')
-  else
-    app_lc=$(echo "${app_name,,}" | tr -d ' ')
+  app_name=$(echo "$check_line" | cut -d'"' -f2)
+  source_repo=$(echo "$check_line" | cut -d'"' -f4)
+  app_lc=$(echo "${app_name,,}" | tr -d ' ')
+
+  if [[ -z "$source_repo" || "$source_repo" != *"/"* ]]; then
+    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): cannot parse source repo — skipping"
+    return
   fi
 
-  # Read installed version from container
+  # Read installed version from container (stored by check_for_gh_release as ~/.<appname>)
   local current_version
-  current_version=$(pct exec "$container" -- bash -c "cat ~/'.${app_lc}' 2>/dev/null" 2>/dev/null || true)
+  current_version=$(pct exec "$container" -- bash -c "cat \$HOME/.${app_lc} 2>/dev/null" 2>/dev/null || true)
   current_version="${current_version#v}"
 
   # Query latest release from GitHub API
@@ -194,7 +194,7 @@ function dry_run_container() {
   fi
 
   if [[ -z "$current_version" ]]; then
-    echo -e "${BL}[DRY-RUN]${CL} Container $container ($service): installed version unknown, latest available: ${latest_version}"
+    echo -e "${BL}[DRY-RUN]${CL} Container $container ($service): installed version unknown, latest: ${latest_version} (${source_repo})"
   elif [[ "$current_version" == "$latest_version" ]]; then
     echo -e "${GN}[DRY-RUN]${CL} Container $container ($service): up to date (${current_version})"
   else

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -252,16 +252,15 @@ header_info
 
 # =============================================================================
 # LOGGING SETUP
-# All output is tee'd (ANSI colours stripped) to a timestamped log file under
-# /usr/local/community-scripts/update_apps/
+# A timestamped log file is written to
+# /usr/local/community-scripts/update_apps/ — the summary report is appended
+# at the end of the run. Real-time output goes only to the terminal to avoid
+# buffering issues with interactive spinners.
 # =============================================================================
 LOG_DIR="/usr/local/community-scripts/update_apps"
 mkdir -p "$LOG_DIR"
 LOG_FILE="${LOG_DIR}/$(date '+%Y%m%d_%H%M%S').log"
-# Redirect stdout+stderr through an ANSI-stripping sed into tee so the
-# terminal keeps colours while the log file stays plain text.
-exec > >(sed 's/\x1B\[[0-9;:]*[mKHfJ]//g' | tee -a "$LOG_FILE") 2>&1
-echo "Update started: $(date '+%Y-%m-%d %H:%M:%S') — log: $LOG_FILE"
+echo "Update started: $(date '+%Y-%m-%d %H:%M:%S')" >"$LOG_FILE"
 
 # Skip confirmation if var_skip_confirm is set to yes
 if [[ "$var_skip_confirm" != "yes" ]]; then
@@ -579,10 +578,14 @@ echo -e "${GN}The process is complete, and the containers have been successfully
 # SUMMARY REPORT
 # =============================================================================
 if [ "${#UPDATE_RESULTS[@]}" -gt 0 ]; then
+  SEPARATOR="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  HEADER=$(printf "  %-8s  %-22s  %-10s  %s" "CTID" "Service" "Status" "Details")
+
+  # terminal output (with colours)
   echo ""
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-  printf "  %-8s  %-22s  %-10s  %s\n" "CTID" "Service" "Status" "Details"
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "$SEPARATOR"
+  echo "$HEADER"
+  echo "$SEPARATOR"
   for entry in "${UPDATE_RESULTS[@]}"; do
     IFS='|' read -r _ctid _svc _status _details <<<"$entry"
     case "$_status" in
@@ -593,10 +596,24 @@ if [ "${#UPDATE_RESULTS[@]}" -gt 0 ]; then
     esac
     printf "  %-8s  %-22s  ${_color}%-10s${CL}  %s\n" "$_ctid" "$_svc" "$_status" "$_details"
   done
-  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "$SEPARATOR"
   echo ""
   echo "Full log: $LOG_FILE"
   echo ""
+
+  # append plain-text summary to log file
+  {
+    echo ""
+    echo "Update finished: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "$SEPARATOR"
+    echo "$HEADER"
+    echo "$SEPARATOR"
+    for entry in "${UPDATE_RESULTS[@]}"; do
+      IFS='|' read -r _ctid _svc _status _details <<<"$entry"
+      printf "  %-8s  %-22s  %-10s  %s\n" "$_ctid" "$_svc" "$_status" "$_details"
+    done
+    echo "$SEPARATOR"
+  } >>"$LOG_FILE"
 fi
 if [ "${#containers_needing_reboot[@]}" -gt 0 ]; then
   echo -e "${RD}The following containers require a reboot:${CL}"

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -163,6 +163,7 @@ function dry_run_container() {
 
   if [[ -z "$check_line" ]]; then
     echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): no check_for_gh_release found — skipping"
+    DRY_RUN_RESULT="no check_for_gh_release found — skipping"
     return
   fi
 
@@ -172,6 +173,7 @@ function dry_run_container() {
 
   if [[ -z "$source_repo" || "$source_repo" != *"/"* ]]; then
     echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): cannot parse source repo — skipping"
+    DRY_RUN_RESULT="cannot parse source repo — skipping"
     return
   fi
 
@@ -190,15 +192,19 @@ function dry_run_container() {
 
   if [[ -z "$latest_version" ]]; then
     echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): cannot fetch latest version from $source_repo"
+    DRY_RUN_RESULT="cannot fetch latest version from $source_repo"
     return
   fi
 
   if [[ -z "$current_version" ]]; then
     echo -e "${BL}[DRY-RUN]${CL} Container $container ($service): installed version unknown, latest: ${latest_version} (${source_repo})"
+    DRY_RUN_RESULT="version unknown — latest: ${latest_version}"
   elif [[ "$current_version" == "$latest_version" ]]; then
     echo -e "${GN}[DRY-RUN]${CL} Container $container ($service): up to date (${current_version})"
+    DRY_RUN_RESULT="up to date (${current_version})"
   else
     echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): update available ${current_version} → ${latest_version}"
+    DRY_RUN_RESULT="update available ${current_version} → ${latest_version}"
   fi
 }
 
@@ -252,15 +258,19 @@ header_info
 
 # =============================================================================
 # LOGGING SETUP
-# A timestamped log file is written to
-# /usr/local/community-scripts/update_apps/ — the summary report is appended
-# at the end of the run. Real-time output goes only to the terminal to avoid
-# buffering issues with interactive spinners.
+# Key events are written directly to a timestamped log file under
+# /usr/local/community-scripts/update_apps/ — this avoids any stdout
+# redirection that would break interactive spinners or whiptail dialogs.
+# The full summary table is appended at the end of the run.
 # =============================================================================
 LOG_DIR="/usr/local/community-scripts/update_apps"
 mkdir -p "$LOG_DIR"
 LOG_FILE="${LOG_DIR}/$(date '+%Y%m%d_%H%M%S').log"
 echo "Update started: $(date '+%Y-%m-%d %H:%M:%S')" >"$LOG_FILE"
+
+function log_write() {
+  echo "[$(date '+%H:%M:%S')] $*" >>"$LOG_FILE"
+}
 
 # Skip confirmation if var_skip_confirm is set to yes
 if [[ "$var_skip_confirm" != "yes" ]]; then
@@ -351,7 +361,10 @@ fi
 header_info
 
 # Determine backup choice based on var_backup
-if [[ -n "$var_backup" ]]; then
+# Dry-run never needs a backup — skip the prompt entirely
+if [[ "$var_dry_run" == "yes" ]]; then
+  BACKUP_CHOICE="no"
+elif [[ -n "$var_backup" ]]; then
   BACKUP_CHOICE="$var_backup"
 else
   BACKUP_CHOICE="no"
@@ -361,7 +374,10 @@ else
 fi
 
 # Determine unattended update based on var_unattended
-if [[ -n "$var_unattended" ]]; then
+# Dry-run never executes updates — skip the prompt entirely
+if [[ "$var_dry_run" == "yes" ]]; then
+  UNATTENDED_UPDATE="no"
+elif [[ -n "$var_unattended" ]]; then
   UNATTENDED_UPDATE="$var_unattended"
 else
   UNATTENDED_UPDATE="no"
@@ -412,6 +428,7 @@ fi
 containers_needing_reboot=()
 for container in $CHOICE; do
   echo -e "${BL}[INFO]${CL} Updating container $container"
+  log_write "Container $container: starting"
 
   if [ "$BACKUP_CHOICE" == "yes" ]; then
     backup_container $container
@@ -434,9 +451,11 @@ for container in $CHOICE; do
   if [ -z "${service}" ]; then
     echo -e "${YW}[WARN]${CL} Update script not found. Skipping to next container"
     log_result "$container" "(unknown)" "SKIPPED" "No update script found in container"
+    log_write "Container $container: SKIPPED — no update script found"
     continue
   else
     echo -e "${BL}[INFO]${CL} Detected service: ${GN}${service}${CL}"
+    log_write "Container $container: detected service '$service'"
   fi
 
   #2) Extract service build/update resource requirements from config/installation file
@@ -489,8 +508,10 @@ for container in $CHOICE; do
 
   #3.5) Dry-run: report update availability without applying
   if [[ "$var_dry_run" == "yes" ]]; then
+    DRY_RUN_RESULT=""
     dry_run_container "$container" "$service"
-    log_result "$container" "$service" "DRY-RUN" "Version check only — no changes applied"
+    log_result "$container" "$service" "DRY-RUN" "${DRY_RUN_RESULT:-version check only}"
+    log_write "Container $container ($service): DRY-RUN — ${DRY_RUN_RESULT:-version check only}"
     continue
   fi
 
@@ -526,17 +547,22 @@ for container in $CHOICE; do
   if [ $exit_code -eq 0 ]; then
     msg_ok "Updated container $container"
     log_result "$container" "$service" "OK" "Updated successfully"
+    log_write "Container $container ($service): OK"
   elif [ $exit_code -eq 75 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (requires interactive mode)"
     log_result "$container" "$service" "SKIPPED" "Requires interactive mode (exit 75)"
+    log_write "Container $container ($service): SKIPPED — requires interactive mode"
   elif [ $exit_code -eq 113 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (under-provisioned: increase CPU/RAM to match template)"
     log_result "$container" "$service" "SKIPPED" "Under-provisioned — increase CPU/RAM to match template"
+    log_write "Container $container ($service): SKIPPED — under-provisioned"
   elif [ $exit_code -eq 114 ]; then
     echo -e "${YW}[WARN]${CL} Container $container skipped (storage critically low on /boot)"
     log_result "$container" "$service" "SKIPPED" "Storage critically low on /boot (>80%)"
+    log_write "Container $container ($service): SKIPPED — storage critically low on /boot"
   elif [ "$BACKUP_CHOICE" == "yes" ]; then
     msg_error "Update failed for container $container (exit code: $exit_code) — attempting restore"
+    log_write "Container $container ($service): FAILED (exit $exit_code) — attempting restore"
     msg_info "Restoring LXC $container from backup ($STORAGE_CHOICE)"
     pct stop $container
     LXC_STORAGE=$(pct config $container | awk -F '[:,]' '/rootfs/ {print $2}')
@@ -544,6 +570,7 @@ for container in $CHOICE; do
     if [ -z "$BACKUP_ENTRY" ]; then
       msg_error "No backup found in storage $STORAGE_CHOICE for container $container"
       log_result "$container" "$service" "FAILED" "Update failed (exit $exit_code) — no backup found for restore"
+      log_write "Container $container ($service): FAILED — no backup found for restore"
       exit 235
     fi
     msg_info "Restoring from: $BACKUP_ENTRY"
@@ -553,14 +580,17 @@ for container in $CHOICE; do
       pct start $container
       msg_ok "Container $container successfully restored from backup"
       log_result "$container" "$service" "RESTORED" "Update failed (exit $exit_code) — restored from backup"
+      log_write "Container $container ($service): RESTORED from $BACKUP_ENTRY"
     else
       msg_error "Restore failed for container $container"
       log_result "$container" "$service" "FAILED" "Update failed (exit $exit_code) — restore also failed"
+      log_write "Container $container ($service): FAILED — restore also failed"
       exit 235
     fi
   else
     msg_error "Update failed for container $container (exit code: $exit_code)"
     log_result "$container" "$service" "FAILED" "Exit code $exit_code"
+    log_write "Container $container ($service): FAILED (exit $exit_code)"
     if [[ "$var_continue_on_error" == "yes" ]]; then
       echo -e "${YW}[WARN]${CL} Continuing to next container (var_continue_on_error=yes)"
       continue

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -47,6 +47,12 @@ var_auto_reboot="${var_auto_reboot:-}"
 #   Note: containers with backups always attempt restore on failure regardless of this setting
 var_continue_on_error="${var_continue_on_error:-no}"
 
+# var_dry_run: Check for available updates without applying them
+#   Options: "yes" | "no" (default: no)
+#   Output: lists each container with current vs. latest version
+#   Note: requires the container to be running; does not modify any container
+var_dry_run="${var_dry_run:-no}"
+
 # var_tags: Optionally override the tags used for auto-detection
 #   Options: "community-script|proxmox-helper-scripts" (default)
 var_tags="${var_tags:-community-script|proxmox-helper-scripts}"
@@ -65,6 +71,7 @@ function export_config_json() {
   "var_skip_confirm": "${var_skip_confirm}",
   "var_auto_reboot": "${var_auto_reboot}",
   "var_continue_on_error": "${var_continue_on_error}",
+  "var_dry_run": "${var_dry_run}",
   "var_tags": "${var_tags}"
 }
 EOF
@@ -88,6 +95,7 @@ Environment Variables:
   var_skip_confirm       Skip initial confirmation (yes/no)
   var_auto_reboot        Auto-reboot containers if required (yes/no)
   var_continue_on_error  Continue to next container on update failure (yes/no)
+  var_dry_run            Check for updates without applying them (yes/no)
   var_tags               Optionally override auto-detection tags ("prod|smb|community-script")
 
 Examples:
@@ -102,6 +110,9 @@ Examples:
 
   # Unattended cron-style: skip confirm, continue on error, no backup
   var_backup=no var_container=all_running var_unattended=yes var_skip_confirm=yes var_continue_on_error=yes $(basename "$0")
+
+  # Dry-run: show available updates for all running containers without applying
+  var_container=all_running var_skip_confirm=yes var_dry_run=yes $(basename "$0")
 
   # Export current configuration
   $(basename "$0") --export-config
@@ -139,6 +150,56 @@ function detect_service() {
   pct pull "$1" /usr/bin/update update 2>/dev/null
   service=$(cat update | sed 's|.*/ct/||g' | sed 's|\.sh).*||g')
   popd >/dev/null
+}
+
+function dry_run_container() {
+  local container="$1"
+  local service="$2"
+
+  # Extract GitHub source URL from the ct script header (# Source: https://github.com/owner/repo)
+  local source_url source_repo
+  source_url=$(echo "$script" | grep '^# Source:' | head -1 | awk '{print $3}')
+  source_repo=$(echo "$source_url" | sed 's|https://github.com/||;s|/$||')
+
+  if [[ -z "$source_repo" || "$source_repo" == "$source_url" ]]; then
+    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): non-GitHub source or not detectable — skipping"
+    return
+  fi
+
+  # Find the app name used in check_for_gh_release to locate the version file (~/.appname)
+  local app_name app_lc
+  app_name=$(echo "$script" | grep -o 'check_for_gh_release "[^"]*"' | head -1 | cut -d'"' -f2)
+  if [[ -z "$app_name" ]]; then
+    app_lc=$(echo "${service,,}" | tr -d ' ')
+  else
+    app_lc=$(echo "${app_name,,}" | tr -d ' ')
+  fi
+
+  # Read installed version from container
+  local current_version
+  current_version=$(pct exec "$container" -- bash -c "cat ~/'.${app_lc}' 2>/dev/null" 2>/dev/null || true)
+  current_version="${current_version#v}"
+
+  # Query latest release from GitHub API
+  local latest_version
+  latest_version=$(curl -sSL --max-time 10 \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "https://api.github.com/repos/${source_repo}/releases/latest" 2>/dev/null \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4 | sed 's/^v//')
+
+  if [[ -z "$latest_version" ]]; then
+    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): cannot fetch latest version from $source_repo"
+    return
+  fi
+
+  if [[ -z "$current_version" ]]; then
+    echo -e "${BL}[DRY-RUN]${CL} Container $container ($service): installed version unknown, latest available: ${latest_version}"
+  elif [[ "$current_version" == "$latest_version" ]]; then
+    echo -e "${GN}[DRY-RUN]${CL} Container $container ($service): up to date (${current_version})"
+  else
+    echo -e "${YW}[DRY-RUN]${CL} Container $container ($service): update available ${current_version} → ${latest_version}"
+  fi
 }
 
 function backup_container() {
@@ -401,8 +462,14 @@ for container in $CHOICE; do
   fi
 
   #3) if build resources are different than run resources, then:
-  if [ "$UPDATE_BUILD_RESOURCES" -eq "1" ]; then
+  if [ "$UPDATE_BUILD_RESOURCES" -eq "1" ] && [[ "$var_dry_run" != "yes" ]]; then
     pct set "$container" --cores "$build_cpu" --memory "$build_ram"
+  fi
+
+  #3.5) Dry-run: report update availability without applying
+  if [[ "$var_dry_run" == "yes" ]]; then
+    dry_run_container "$container" "$service"
+    continue
   fi
 
   #4) Update service, using the update command

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -42,6 +42,11 @@ var_skip_confirm="${var_skip_confirm:-no}"
 #   Options: "yes" | "no" | "" (empty = interactive prompt)
 var_auto_reboot="${var_auto_reboot:-}"
 
+# var_continue_on_error: Continue updating remaining containers if one update fails
+#   Options: "yes" | "no" (default: no = stop on first error)
+#   Note: containers with backups always attempt restore on failure regardless of this setting
+var_continue_on_error="${var_continue_on_error:-no}"
+
 # var_tags: Optionally override the tags used for auto-detection
 #   Options: "community-script|proxmox-helper-scripts" (default)
 var_tags="${var_tags:-community-script|proxmox-helper-scripts}"
@@ -59,6 +64,7 @@ function export_config_json() {
   "var_unattended": "${var_unattended}",
   "var_skip_confirm": "${var_skip_confirm}",
   "var_auto_reboot": "${var_auto_reboot}",
+  "var_continue_on_error": "${var_continue_on_error}",
   "var_tags": "${var_tags}"
 }
 EOF
@@ -78,10 +84,11 @@ Environment Variables:
   var_backup          Enable backup before update (yes/no)
   var_backup_storage  Storage location for backups
   var_container       Container selection (all/all_running/all_stopped/101,102,...)
-  var_unattended      Run updates unattended (yes/no)
-  var_skip_confirm    Skip initial confirmation (yes/no)
-  var_auto_reboot     Auto-reboot containers if required (yes/no)
-  var_tags            Optionally override auto-detection tags ("prod|smb|community-script")
+  var_unattended         Run updates unattended (yes/no)
+  var_skip_confirm       Skip initial confirmation (yes/no)
+  var_auto_reboot        Auto-reboot containers if required (yes/no)
+  var_continue_on_error  Continue to next container on update failure (yes/no)
+  var_tags               Optionally override auto-detection tags ("prod|smb|community-script")
 
 Examples:
   # Run interactively
@@ -92,6 +99,9 @@ Examples:
 
   # Update specific containers without backup
   var_backup=no var_container=101,102,105 var_unattended=yes var_skip_confirm=yes $(basename "$0")
+
+  # Unattended cron-style: skip confirm, continue on error, no backup
+  var_backup=no var_container=all_running var_unattended=yes var_skip_confirm=yes var_continue_on_error=yes $(basename "$0")
 
   # Export current configuration
   $(basename "$0") --export-config
@@ -397,11 +407,11 @@ for container in $CHOICE; do
 
   #4) Update service, using the update command
   case "$os" in
-  alpine) pct exec "$container" -- ash -c "$UPDATE_CMD" ;;
-  archlinux) pct exec "$container" -- bash -c "$UPDATE_CMD" ;;
-  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "$UPDATE_CMD" ;;
-  ubuntu | debian | devuan) pct exec "$container" -- bash -c "$UPDATE_CMD" ;;
-  opensuse) pct exec "$container" -- bash -c "$UPDATE_CMD" ;;
+  alpine) pct exec "$container" -- ash -c "export TERM=dumb;$UPDATE_CMD" ;;
+  archlinux) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
+  fedora | rocky | centos | alma) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
+  ubuntu | debian | devuan) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
+  opensuse) pct exec "$container" -- bash -c "export TERM=dumb;$UPDATE_CMD" ;;
   esac
   exit_code=$?
 
@@ -446,8 +456,13 @@ for container in $CHOICE; do
       exit 235
     fi
   else
-    msg_error "Update failed for container $container. Exiting"
-    exit "$exit_code"
+    msg_error "Update failed for container $container (exit code: $exit_code)"
+    if [[ "$var_continue_on_error" == "yes" ]]; then
+      echo -e "${YW}[WARN]${CL} Continuing to next container (var_continue_on_error=yes)"
+      continue
+    else
+      exit "$exit_code"
+    fi
   fi
 done
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
[feat]:  var_dry_run — Check for updates without applying them
Adds a dry-run mode that reads the installed version from each container and queries the GitHub API for the latest release, reporting up-to-date / update available / unknown per container — without touching anything.

<img width="902" height="781" alt="image" src="https://github.com/user-attachments/assets/1b231076-867b-4bb4-bc3c-2eb572334665" />

<img width="937" height="681" alt="image" src="https://github.com/user-attachments/assets/cd3c7ad9-4fc9-4421-a7af-5b576afa5b7d" />

-----

[feat]: var_continue_on_error — Don't abort on first failure
New flag to skip a failed container and continue updating the remaining ones instead of exiting immediately.

-----


[feat]: Run summary report + log file
After all updates a summary table (CTID / Service / Status / Details) is printed to the terminal and appended as plain text to a timestamped log file in /usr/local/community-scripts/update_apps/.
<img width="739" height="388" alt="image" src="https://github.com/user-attachments/assets/7ac3c3d3-390a-4546-91ee-a68238d5b229" />

-----

[fix]: clear calls crashing update scripts without a TTY
Update scripts that call clear (e.g. adguard, hoodik) failed with exit 1 when run via pct exec (no TTY). A no-op /tmp/.nc/clear wrapper is prepended to PATH before executing the update command, affecting all shells including ash (Alpine).
<img width="596" height="165" alt="image" src="https://github.com/user-attachments/assets/76571d5f-e9dc-44ab-a47c-6855c233ae1b" />

-----


[fix]: Under-provisioned prompt blocking unattended runs
check_container_resources() and check_container_storage() in build.func now check is_unattended() before trying to read </dev/tty. In unattended mode they auto-abort with exit 113/114 instead of hanging.

-----


[fix]: Exit codes 113/114 treated as warnings, not errors
Under-provisioned (113) and storage-too-low (114) skips are now handled the same as exit 75 — logged as SKIPPED with a descriptive message, no backup restore triggered.

-----


[chore] --export-config includes new vars, --help updated
var_continue_on_error and var_dry_run are included in the JSON config export and the help text, with two new usage examples (cron-style and dry-run).



## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
