### PR TITLE
tools.func: fix meilisearch import-dump background process handling

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -7588,7 +7588,7 @@ function setup_meilisearch() {
 
           # Start meilisearch with --import-dump flag
           # This is a one-time import that happens during startup
-          /usr/bin/meilisearch --config-file-path /etc/meilisearch.toml --import-dump "$DUMP_FILE" &
+          /usr/bin/meilisearch --config-file-path /etc/meilisearch.toml --import-dump "$DUMP_FILE" >/dev/null 2>&1 &
           local MEILI_PID=$!
 
           # Wait for meilisearch to become healthy (import happens during startup)
@@ -7611,6 +7611,7 @@ function setup_meilisearch() {
 
           # Stop the manual process
           kill $MEILI_PID 2>/dev/null || true
+          wait $MEILI_PID 2>/dev/null || true
           sleep 2
 
           # Start via systemd for proper management


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Two fixes:
- Redirect background process output to /dev/null to suppress meilisearch startup log noise in the update output
- Add 'wait $MEILI_PID' after 'kill $MEILI_PID' so bash properly reaps the child process without printing a job status notification

## 🔗 Related Issue

Fixes #14276

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
