### PR TITLE
fix(termix-install.sh): add tmpfiles.d persistence and systemd PIDFile path

### DIFF
--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -101,6 +101,13 @@ sed -i 's|/app/nginx|/opt/termix/nginx|g' /etc/nginx/nginx.conf
 sed -i 's|listen ${PORT};|listen 80;|g' /etc/nginx/nginx.conf
 
 mkdir -p /tmp/nginx
+echo "d /tmp/nginx 0755 nobody nobody -" > /etc/tmpfiles.d/nginx-termix.conf
+mkdir -p /etc/systemd/system/nginx.service.d/
+cat > /etc/systemd/system/nginx.service.d/pidfile.conf << EOF
+[Service]
+PIDFile=/tmp/nginx/nginx.pid
+EOF
+systemctl daemon-reload
 rm -f /etc/nginx/sites-enabled/default
 nginx -t
 systemctl reload nginx


### PR DESCRIPTION
Extends the fix from #14312. The mkdir -p /tmp/nginx alone is insufficient for two reasons:

1. /tmp/nginx does not persist across reboots /tmp is ephemeral and cleared on LXC reboot, meaning nginx fails to start on every reboot after the initial install/update with the same error as #14306: open() "/tmp/nginx/nginx.pid" failed (2: No such file or directory) A tmpfiles.d entry recreates the directory automatically at boot. The directory is owned by nobody:nobody as the Termix nginx.conf (sourced from the upstream Docker image) runs the worker process as nobody rather than the Debian default of www-data.

2. Systemd PIDFile mismatch causes start timeout Even with /tmp/nginx present, systemctl start nginx times out because the systemd unit expects the PID file at /run/nginx.pid but nginx.conf writes it to /tmp/nginx/nginx.pid: nginx.service: Can't open PID file '/run/nginx.pid' (yet?) after start: No such file or directory nginx.service: start operation timed out. Terminating. A systemd drop-in overrides the PIDFile path to match what nginx.conf actually uses. Both issues confirmed on a live 2.2.0 update via the helper script update tool, and verified as fixed across reboot. Closes #14306

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description


## 🔗 Related Issue

Fixes #14312 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
