### PR TITLE
Purge openresty

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -28,7 +28,6 @@ function update_script() {
     exit
   fi
 
-
   if command -v node &>/dev/null; then
     CURRENT_NODE_VERSION=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
     if [[ "$CURRENT_NODE_VERSION" != "22" ]]; then
@@ -48,7 +47,7 @@ function update_script() {
     msg_info "Migrating from packaged OpenResty to source"
     rm -f /etc/apt/trusted.gpg.d/openresty-archive-keyring.gpg /etc/apt/trusted.gpg.d/openresty.gpg
     rm -f /etc/apt/sources.list.d/openresty.list /etc/apt/sources.list.d/openresty.sources
-    $STD apt remove -y openresty
+    $STD apt purge -y openresty
     $STD apt autoremove -y
     rm -f ~/.openresty
     msg_ok "Migrated from packaged OpenResty to source"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Just removing `openresty` leaves behind the configuration and makes `if dpkg -s openresty &>/dev/null 2>&1; then` always true, making it reinstall openresty every time.

## 🔗 Related Issue

https://github.com/community-scripts/ProxmoxVE/discussions/14352

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
