### PR TITLE
[Hotfix]Jotty: use absolute path when creating data dir

### DIFF
--- a/install/jotty-install.sh
+++ b/install/jotty-install.sh
@@ -17,7 +17,7 @@ NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
 fetch_and_deploy_gh_release "jotty" "fccview/jotty" "prebuild" "latest" "/opt/jotty" "jotty_*_prebuild.tar.gz"
 
 msg_info "Setup jotty"
-mkdir -p data/{users,checklists,notes}
+mkdir -p /opt/jotty/data/{users,checklists,notes}
 
 cat <<EOF >/opt/jotty/.env
 NODE_ENV=production


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

The 'data' dir was incorrectly created in `/opt/data` instead of `/opt/jotty/data` during install, resulting in user data being inaccessible after an update (located in `/opt/jotty/data/data`).

## 🔗 Related Issue

Fixes #14334 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
