### PR TITLE
fix(vm/opnsense): replace undefined msg_warn in alloc retry

### DIFF
--- a/vm/opnsense-vm.sh
+++ b/vm/opnsense-vm.sh
@@ -746,7 +746,7 @@ alloc_delay=5
 while :; do
   alloc_err=$(pvesm alloc $STORAGE $VMID $DISK0 4M 2>&1 >/dev/null) && break
   if [[ "$alloc_err" == *"got timeout"* && $alloc_attempt -lt $alloc_max ]]; then
-    msg_warn "pvesm alloc hit zfs timeout (attempt $alloc_attempt/$alloc_max), retrying in ${alloc_delay}s..."
+    msg_info "pvesm alloc hit zfs timeout (attempt $alloc_attempt/$alloc_max), retrying in ${alloc_delay}s..."
     pvesm free "${DISK0_REF}" &>/dev/null || true
     sleep "$alloc_delay"
     alloc_attempt=$((alloc_attempt + 1))


### PR DESCRIPTION
## ✍️ Description

Fixes a runtime regression in `vm/opnsense-vm.sh` retry logic introduced for #14127.

`msg_warn` is called in the `pvesm alloc` timeout retry path but is not defined in this script/runtime, which causes:

`msg_warn: command not found`

This change replaces that call with `msg_info`, which is already defined and keeps retry feedback visible.

## 🔗 Related Issue

Fixes #14127

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
