### PR TITLE
Reactive-Resume: fix PDF generation timeout in LXC containers

### DIFF
--- a/install/reactive-resume-install.sh
+++ b/install/reactive-resume-install.sh
@@ -55,7 +55,7 @@ DATABASE_URL=postgresql://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAM
 AUTH_SECRET=${AUTH_SECRET}
 
 # Printer (headless Chromium for PDF generation)
-PRINTER_ENDPOINT=http://localhost:9222
+PRINTER_ENDPOINT=http://127.0.0.1:9222
 
 # Storage: uses local filesystem (/opt/reactive-resume/data) when S3 is not configured
 # S3_ACCESS_KEY_ID=
@@ -92,7 +92,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/chromium --headless --disable-gpu --no-sandbox --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222
+ExecStart=/usr/bin/chromium --headless --disable-gpu --no-sandbox --no-zygote --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222
 Restart=always
 RestartSec=5
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
1. Use 127.0.0.1 instead of localhost for PRINTER_ENDPOINT to avoid potential IPv6 resolution issues in LXC containers where 'localhost' may resolve to ::1 while Chromium only listens on 127.0.0.1.

2. Add --no-zygote flag to the chromium-printer service. In LXC containers the Zygote process (used by Chrome for process forking) can fail silently, causing Puppeteer page rendering to hang until the printer timeout is exceeded.

## 🔗 Related Issue

Fixes #14278

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
