### PR TITLE
Nginxproxymanager: restore NPM nginx.conf after OpenResty rebuid

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -92,6 +92,11 @@ ExecStart=/usr/local/openresty/nginx/sbin/nginx -g 'daemon off;'
 [Install]
 WantedBy=multi-user.target
 EOF
+    if [ -f /opt/nginxproxymanager/docker/rootfs/etc/nginx/nginx.conf ]; then
+      cp /opt/nginxproxymanager/docker/rootfs/etc/nginx/nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+      sed -i 's+^daemon+#daemon+g' /usr/local/openresty/nginx/conf/nginx.conf
+      sed -i 's+include conf.d+include /etc/nginx/conf.d+g' /usr/local/openresty/nginx/conf/nginx.conf
+    fi
     sed -i 's/user npm/user root/g; s/^pid/#pid/g' /usr/local/openresty/nginx/conf/nginx.conf
     systemctl daemon-reload
     systemctl unmask openresty 2>/dev/null || true


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
When OpenResty is rebuilt via 'make install', it overwrites /usr/local/openresty/nginx/conf/nginx.conf with the stock OpenResty default config, dropping all NPM-specific include directives. This causes port 81 to stop listening and conf.d configs to be ignored.

After the build, restore the NPM nginx.conf from the deployed source, re-apply daemon/include-path patches, then apply user/pid fixes.

## 🔗 Related Issue

Fixes #14396

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
