### PR TITLE
fix(termix-install.sh): fix tmpfiles, nobody's group is nogroup.

### DIFF
--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -101,7 +101,7 @@ sed -i 's|/app/nginx|/opt/termix/nginx|g' /etc/nginx/nginx.conf
 sed -i 's|listen ${PORT};|listen 80;|g' /etc/nginx/nginx.conf
 
 mkdir -p /tmp/nginx
-echo "d /tmp/nginx 0755 nobody nobody -" > /etc/tmpfiles.d/nginx-termix.conf
+echo "d /tmp/nginx 0755 nobody nogroup -" > /etc/tmpfiles.d/nginx-termix.conf
 mkdir -p /etc/systemd/system/nginx.service.d/
 cat > /etc/systemd/system/nginx.service.d/pidfile.conf << EOF
 [Service]


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

I had issue after the latest update, the `/tmp/nginx` directory wasn't created, `systemd-tmpfiles-setup.service` was complaining that it could not find the `nobody` group. After checking the `nobody` user, I saw that its group is `nogroup`, not `nobody`.


## 🔗 Related Issue

Fixes PR#14350


## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected. -> I manually did the change on the file.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
