### PR TITLE
Prune pnpm store

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -206,6 +206,9 @@ EOF
     $STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
     [[ -f "$INSTALL_DIR"/start.sh ]] && mv "$INSTALL_DIR"/start.sh "$APP_DIR"/bin
 
+    # cleanup
+    $STD pnpm store prune
+
     # plugins
     cd "$SRC_DIR"
     $STD mise trust --ignore ./mise.toml

--- a/ct/seerr.sh
+++ b/ct/seerr.sh
@@ -142,6 +142,7 @@ EOF
     $STD pnpm install --frozen-lockfile
     export NODE_OPTIONS="--max-old-space-size=3072"
     $STD pnpm build
+    $STD pnpm store prune
     msg_ok "Updated Seerr"
 
     msg_info "Restoring Backup"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

I noticed a couple of LXCs were running out of space for no reason. `immich` had 4GB of unused packages.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
