### PR TITLE
Excalidraw: Fix build

### DIFF
--- a/ct/excalidraw.sh
+++ b/ct/excalidraw.sh
@@ -30,7 +30,7 @@ function update_script() {
   fi
 
   NODE_VERSION="24" NODE_MODULE="yarn" setup_nodejs
-  
+
   if check_for_gh_release "excalidraw" "excalidraw/excalidraw"; then
     msg_info "Stopping Service"
     systemctl stop excalidraw
@@ -40,6 +40,7 @@ function update_script() {
 
     msg_info "Updating Excalidraw"
     cd /opt/excalidraw
+    $STD yarn config set ignore-engines true
     $STD yarn
     msg_ok "Updated Excalidraw"
 

--- a/install/excalidraw-install.sh
+++ b/install/excalidraw-install.sh
@@ -22,6 +22,7 @@ fetch_and_deploy_gh_release "excalidraw" "excalidraw/excalidraw" "tarball"
 
 msg_info "Configuring Excalidraw"
 cd /opt/excalidraw
+$STD yarn config set ignore-engines true
 $STD yarn
 msg_ok "Setup Excalidraw"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Even though Dockerfile clearly states that base is on Node 24, the app has a monorepo module that acts up. We force `yarn` to ignore engines to bypass this until fix is made upstream.

## 🔗 Related Issue

Fixes #14504 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
