### PR TITLE
snowshare: use mv instead of cp for uploads backup to prevent disk fill

### DIFF
--- a/ct/snowshare.sh
+++ b/ct/snowshare.sh
@@ -36,13 +36,14 @@ function update_script() {
     msg_ok "Stopped Service"
 
     msg_info "Backing up uploads"
-    [ -d /opt/snowshare/uploads ] && cp -a /opt/snowshare/uploads /opt/.snowshare_uploads_backup
+    rm -rf /opt/.snowshare_uploads_backup
+    [ -d /opt/snowshare/uploads ] && mv /opt/snowshare/uploads /opt/.snowshare_uploads_backup
     msg_ok "Uploads backed up"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "snowshare" "TuroYT/snowshare" "tarball"
 
     msg_info "Restoring uploads"
-    [ -d /opt/.snowshare_uploads_backup ] && rm -rf /opt/snowshare/uploads && cp -a /opt/.snowshare_uploads_backup /opt/snowshare/uploads
+    [ -d /opt/.snowshare_uploads_backup ] && rm -rf /opt/snowshare/uploads && mv /opt/.snowshare_uploads_backup /opt/snowshare/uploads
     msg_ok "Uploads restored"
 
     msg_info "Updating Snowshare"

--- a/ct/snowshare.sh
+++ b/ct/snowshare.sh
@@ -35,16 +35,19 @@ function update_script() {
     systemctl stop snowshare
     msg_ok "Stopped Service"
 
-    msg_info "Backing up uploads"
-    rm -rf /opt/.snowshare_uploads_backup
-    [ -d /opt/snowshare/uploads ] && mv /opt/snowshare/uploads /opt/.snowshare_uploads_backup
-    msg_ok "Uploads backed up"
+    if ! grep -q '^UPLOAD_DIR=' /opt/snowshare.env 2>/dev/null; then
+      msg_info "Migrating uploads to persistent directory"
+      mkdir -p /opt/snowshare_data
+      if [ -d /opt/snowshare/uploads ] && [ -z "$(ls -A /opt/snowshare_data 2>/dev/null)" ]; then
+        mv /opt/snowshare/uploads/* /opt/snowshare_data/ 2>/dev/null || true
+        mv /opt/snowshare/uploads/.[!.]* /opt/snowshare_data/ 2>/dev/null || true
+        rmdir /opt/snowshare/uploads 2>/dev/null || true
+      fi
+      echo "UPLOAD_DIR=/opt/snowshare_data" >>/opt/snowshare.env
+      msg_ok "Migrated uploads to /opt/snowshare_data"
+    fi
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "snowshare" "TuroYT/snowshare" "tarball"
-
-    msg_info "Restoring uploads"
-    [ -d /opt/.snowshare_uploads_backup ] && rm -rf /opt/snowshare/uploads && mv /opt/.snowshare_uploads_backup /opt/snowshare/uploads
-    msg_ok "Uploads restored"
 
     msg_info "Updating Snowshare"
     cd /opt/snowshare

--- a/install/snowshare-install.sh
+++ b/install/snowshare-install.sh
@@ -21,12 +21,14 @@ fetch_and_deploy_gh_release "snowshare" "TuroYT/snowshare" "tarball"
 msg_info "Installing SnowShare"
 cd /opt/snowshare
 $STD npm ci
+mkdir -p /opt/snowshare_data
 cat <<EOF >/opt/snowshare.env
 DATABASE_URL="postgresql://$PG_DB_USER:$PG_DB_PASS@localhost:5432/$PG_DB_NAME"
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="$(openssl rand -base64 32)"
 ALLOW_SIGNUP=true
 NODE_ENV=production
+UPLOAD_DIR=/opt/snowshare_data
 EOF
 set -a
 source /opt/snowshare.env


### PR DESCRIPTION
## ✍️ Description

Replaces cp -a with mv when backing up and restoring /opt/snowshare/uploads during updates. cp -a duplicated the entire uploads directory on each update, which could fill the disk on instances with large uploads and left stale backup directories accumulating across failed updates. mv is atomic on the same filesystem and avoids any data duplication. Also clears any leftover backup directory before the move to prevent nesting on interrupted updates.


## 🔗 Related Issue

Closes TuroYT/snowshare#258

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
