### PR TITLE
Pangolin: bump to 1.18.4, fix missing statusHistory migration

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -84,7 +84,6 @@ function update_script() {
     SQLITE_DB="/opt/pangolin/config/db/db.sqlite"
     if [[ -f "$SQLITE_DB" ]]; then
       if ! sqlite3 "$SQLITE_DB" ".tables" 2>/dev/null | tr ' ' '\n' | grep -qx "statusHistory"; then
-        msg_info "Detected missing statusHistory table, resetting migration state"
         sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations;" 2>/dev/null || true
       fi
     fi

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -6,7 +6,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 # Source: https://pangolin.net/ | Github: https://github.com/fosrl/pangolin
 
 APP="Pangolin"
-PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.3}"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.4}"
 var_tags="${var_tags:-proxy}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
@@ -81,6 +81,13 @@ function update_script() {
 
     msg_info "Running database migrations"
     cd /opt/pangolin
+    SQLITE_DB="/opt/pangolin/config/db/db.sqlite"
+    if [[ -f "$SQLITE_DB" ]]; then
+      if ! sqlite3 "$SQLITE_DB" ".tables" 2>/dev/null | tr ' ' '\n' | grep -qx "statusHistory"; then
+        msg_info "Detected missing statusHistory table, resetting migration state"
+        sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations;" 2>/dev/null || true
+      fi
+    fi
     ENVIRONMENT=prod $STD node dist/migrations.mjs
     msg_ok "Ran database migrations"
 

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -22,7 +22,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.3}"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.4}"
 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_amd64"
 fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_amd64.tar.gz"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
sometimes the tool cant migrate himself, need the statusHistory fix inside.
Bump to 1.18.4

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
