### PR TITLE
Whisparr: switch from nightly to stable GitHub release

### DIFF
--- a/install/whisparr-install.sh
+++ b/install/whisparr-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y sqlite3
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_from_url "https://whisparr.servarr.com/v1/update/nightly/updatefile?os=linux&runtime=netcore&arch=x64" /opt/Whisparr
+fetch_and_deploy_gh_release "Whisparr" "Whisparr/Whisparr" "prebuild" "latest" "/opt/Whisparr" "Whisparr.*.linux-x64.tar.gz"
 
 msg_info "Configuring Whisparr"
 mkdir -p /var/lib/whisparr/


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
The CT doesnt need to be changed. The update_script function correctly delegates to Whisparrs built-in updater theres no nightly URL or anything like that in it.

## 🔗 Related Issue

Fixes #14568

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
