### PR TITLE
Technitium DNS: derive Microsoft APT repo/suite/key from container OS

### DIFF
--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -36,11 +36,19 @@ function update_script() {
     $STD apt remove -y aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 2>/dev/null || true
     [ -f /etc/apt/sources.list.d/microsoft-prod.list ] && rm -f /etc/apt/sources.list.d/microsoft-prod.list
     [ -f /usr/share/keyrings/microsoft-prod.gpg ] && rm -f /usr/share/keyrings/microsoft-prod.gpg
+    local os_version os_codename ms_key
+    os_version="$(awk -F= '/^VERSION_ID=/{gsub(/"/,"",$2);print $2}' /etc/os-release)"
+    os_codename="$(awk -F= '/^VERSION_CODENAME=/{gsub(/"/,"",$2);print $2}' /etc/os-release)"
+    if [[ "$os_version" == "12" ]]; then
+      ms_key="https://packages.microsoft.com/keys/microsoft.asc"
+    else
+      ms_key="https://packages.microsoft.com/keys/microsoft-2025.asc"
+    fi
     setup_deb822_repo \
       "microsoft" \
-      "https://packages.microsoft.com/keys/microsoft-2025.asc" \
-      "https://packages.microsoft.com/debian/13/prod/" \
-      "trixie" \
+      "$ms_key" \
+      "https://packages.microsoft.com/debian/${os_version}/prod/" \
+      "${os_codename}" \
       "main"
     $STD apt install -y aspnetcore-runtime-10.0
   fi


### PR DESCRIPTION
## ✍️ Description

`update_script()` sets up the Microsoft .NET APT repository with the Debian release hardcoded to 13:

```bash
setup_deb822_repo \
  "microsoft" \
  "https://packages.microsoft.com/keys/microsoft-2025.asc" \
  "https://packages.microsoft.com/debian/13/prod/" \
  "trixie" \
  "main"
```

`update_script()` runs inside the **existing** container. Technitium LXCs created before `var_version` was raised to `13` are Debian 12 (bookworm); running `update` on them writes a Debian 13 / trixie repo into `/etc/apt/sources.list.d/microsoft.sources`, so apt then pulls trixie-built packages onto bookworm. The Microsoft signing keys are also per-release and disjoint (`debian/12` `InRelease` → `microsoft.asc` / `EB3E94ADBE1229CF`; `debian/13` → `microsoft-2025.asc` / `EE4D7792F748182B`).

This derives the repo URL, suite and signing key from the container's own `/etc/os-release`, so an `update` on a Debian 12 container configures a Debian 12 repo. On Debian 13 the behaviour is unchanged.

## 🔗 Related Issue

Fixes #14613

## 🛠️ Type of Change

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested** – The resulting bookworm repo config (URL/suite/key derived from `/etc/os-release`) was applied and verified on live Debian 12 Technitium LXCs: `apt update` and the `aspnetcore-runtime` install succeed. The Debian 13 branch reproduces the existing values, so no behaviour change there.
- [x] **No security risks** – No hardcoded secrets or privilege changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
