### PR TITLE
Technitium DNS: download release before stopping the service on update

### DIFF
--- a/ct/technitiumdns.sh
+++ b/ct/technitiumdns.sh
@@ -47,10 +47,9 @@ function update_script() {
 
   RELEASE=$(curl -fsSL https://technitium.com/dns/ | grep -oP 'Version \K[\d.]+')
   if [[ ! -f ~/.technitium || ${RELEASE} != "$(cat ~/.technitium 2>/dev/null)" ]]; then
-    systemctl stop technitium
     fetch_and_deploy_from_url "https://download.technitium.com/dns/DnsServerPortable.tar.gz" /opt/technitium/dns
     echo "${RELEASE}" >~/.technitium
-    systemctl start technitium
+    systemctl restart technitium
     msg_ok "Updated successfully!"
   else
     msg_ok "No update required.  Technitium DNS is already at v${RELEASE}."


### PR DESCRIPTION
## ✍️ Description

`update_script()` ran `systemctl stop technitium` immediately before downloading the new release:

```bash
systemctl stop technitium
fetch_and_deploy_from_url "https://download.technitium.com/dns/DnsServerPortable.tar.gz" /opt/technitium/dns
```

A Technitium box is very commonly its own DNS resolver. Stopping the service kills name resolution inside the container, and `fetch_and_deploy_from_url` then fails at its `curl` step:

```
curl: (6) Could not resolve host: download.technitium.com
```

The script aborts there — after the earlier block already swapped the .NET runtime — leaving the service down. This is the failure reported in #14382 (closed as a "network error"; it is the script stopping its own resolver).

This downloads and deploys the release **while the service is still running**, then `systemctl restart`. The download succeeds (DNS is up) and downtime is reduced to a single restart instead of the whole download window.

## 🔗 Related Issue

Fixes #14614
Refs #14382, #14045

## 🛠️ Type of Change

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested** – The `curl: (6) Could not resolve host` failure was confirmed on a self-resolving Technitium LXC; the reorder removes the dependency on DNS being up during the download. Deploy-then-restart matches the pattern used by other update scripts. Not yet run end-to-end through a full version bump.
- [x] **No security risks** – No hardcoded secrets or privilege changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
