### PR TITLE
Profilarr: pin Deno version to v2.7.5

### DIFF
--- a/ct/profilarr.sh
+++ b/ct/profilarr.sh
@@ -36,9 +36,9 @@ function update_script() {
     exit
   fi
 
-  if check_for_gh_release "deno" "denoland/deno"; then
+  if check_for_gh_release "deno" "denoland/deno" "v2.7.5" "Deno is pinned to 2.7.5 because the known WouldBlock: Resource temporarily unavailable (os error 11) Issue"; then
     ARCH=$(uname -m)
-    fetch_and_deploy_gh_release "deno" "denoland/deno" "prebuild" "latest" "/usr/local/bin" "deno-${ARCH}-unknown-linux-gnu.zip"
+    fetch_and_deploy_gh_release "deno" "denoland/deno" "v2.7.5" "latest" "/usr/local/bin" "deno-${ARCH}-unknown-linux-gnu.zip"
   fi
 
   if check_for_gh_release "profilarr" "Dictionarry-Hub/profilarr"; then

--- a/install/profilarr-install.sh
+++ b/install/profilarr-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 ARCH=$(uname -m)
-fetch_and_deploy_gh_release "deno" "denoland/deno" "prebuild" "latest" "/usr/local/bin" "deno-${ARCH}-unknown-linux-gnu.zip"
+fetch_and_deploy_gh_release "deno" "denoland/deno" "prebuild" "v2.7.5" "/usr/local/bin" "deno-${ARCH}-unknown-linux-gnu.zip"
 fetch_and_deploy_gh_release "profilarr" "Dictionarry-Hub/profilarr" "tarball"
 PROFILARR_VERSION=$(cat ~/.profilarr)
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
https://github.com/community-scripts/ProxmoxVE/issues/14551

Fix Uncaught WouldBlock: Resource temporarily unavailable (os error 11) Issue

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
