### PR TITLE
core: suppress MOTD for non-interactive shells

### DIFF
--- a/misc/alpine-install.func
+++ b/misc/alpine-install.func
@@ -183,7 +183,8 @@ motd_ssh() {
 
   PROFILE_FILE="/etc/profile.d/00_lxc-details.sh"
 
-  echo "echo -e \"\"" >"$PROFILE_FILE"
+  echo "[ -t 1 ] || return 0" >"$PROFILE_FILE"
+  echo "echo -e \"\"" >>"$PROFILE_FILE"
   echo -e "echo -e \"${BOLD}${APPLICATION} LXC Container${CL}"\" >>"$PROFILE_FILE"
   echo -e "echo -e \"${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\"" >>"$PROFILE_FILE"
   echo "echo \"\"" >>"$PROFILE_FILE"

--- a/misc/build.func
+++ b/misc/build.func
@@ -3643,7 +3643,7 @@ start() {
     run_addon_updates
     update_motd_ip
     cleanup_lxc
-  elif ! command -v whiptail &>/dev/null || ! [ -t 0 ]; then
+  elif ! command -v whiptail &>/dev/null || ! [ -t 0 ] || [[ "$TERM" == "dumb" ]]; then
     msg_info "No interactive terminal detected – defaulting to silent update mode"
     VERBOSE="no"
     set_std_mode

--- a/misc/core.func
+++ b/misc/core.func
@@ -140,10 +140,12 @@ ensure_profile_loaded() {
   [[ -n "${_PROFILE_LOADED:-}" ]] && return
   command -v pveversion &>/dev/null && return
 
-  # Source all profile.d scripts to ensure PATH is complete
+  # Source all profile.d scripts to ensure PATH is complete.
+  # Redirect stdout to suppress banner/MOTD output (e.g. 00_lxc-details.sh)
+  # while still allowing env/PATH exports to take effect.
   if [[ -d /etc/profile.d ]]; then
     for script in /etc/profile.d/*.sh; do
-      [[ -r "$script" ]] && source "$script" || true
+      [[ -r "$script" ]] && source "$script" >/dev/null || true
     done
   fi
 

--- a/misc/install.func
+++ b/misc/install.func
@@ -456,7 +456,8 @@ motd_ssh() {
 
   PROFILE_FILE="/etc/profile.d/00_lxc-details.sh"
 
-  echo "echo -e \"\"" >"$PROFILE_FILE"
+  echo "[ -t 1 ] || return 0" >"$PROFILE_FILE"
+  echo "echo -e \"\"" >>"$PROFILE_FILE"
   echo -e "echo -e \"${BOLD}${APPLICATION} LXC Container${CL}"\" >>"$PROFILE_FILE"
   echo -e "echo -e \"${TAB}${GATEWAY}${YW} Provided by: ${GN}community-scripts ORG ${YW}| GitHub: ${GN}https://github.com/community-scripts/ProxmoxVE${CL}\"" >>"$PROFILE_FILE"
   echo "echo \"\"" >>"$PROFILE_FILE"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Prevent profile scripts from printing the MOTD in non-interactive contexts. Add a tty check ([ -t 1 ] || return 0) to the generated /etc/profile.d/00_lxc-details
=> so the banner only shows for interactive sessions

fix TERM var for update-apps

## 🔗 Related Issue

Fixes #14634
Fixes #14626

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
