### PR TITLE
fix(the-lounge): install Node.js 22 before deb package

### DIFF
--- a/ct/the-lounge.sh
+++ b/ct/the-lounge.sh
@@ -33,6 +33,7 @@ function update_script() {
     systemctl stop thelounge
     msg_ok "Stopped Service"
 
+    NODE_VERSION="22" setup_nodejs
     fetch_and_deploy_gh_release "thelounge" "thelounge/thelounge-deb" "binary"
 
     msg_info "Starting Service"

--- a/install/the-lounge-install.sh
+++ b/install/the-lounge-install.sh
@@ -13,6 +13,7 @@ setting_up_container
 network_check
 update_os
 
+NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "thelounge" "thelounge/thelounge-deb" "binary"
 systemctl enable -q --now thelounge
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

The Lounge v4.5.0 requires nodejs (>= 22.13.0), which is not available from Debian 13 default repos. Install Node.js 22 via NodeSource before deploying the thelounge-deb package in both install and update scripts.

## 🔗 Related Issue

Fixes #14631 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
