### PR TITLE
OpenCloud: v7.0.0 changes

### DIFF
--- a/ct/opencloud.sh
+++ b/ct/opencloud.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  RELEASE="v6.2.0"
+  RELEASE="v7.0.0"
   if check_for_gh_release "OpenCloud" "opencloud-eu/opencloud" "${RELEASE}" "each release is tested individually before the version is updated. Please do not open issues for this"; then
     msg_info "Stopping services"
     systemctl stop opencloud opencloud-wopi
@@ -54,6 +54,15 @@ function update_script() {
 # STORAGE_USERS_POSIX_WATCH_TYPE=inotifywait\
 # STORAGE_USERS_POSIX_WATCH_FS=true\
 # STORAGE_USERS_POSIX_WATCH_PATH=<path-to-storage-or-bind-mount>' /etc/opencloud/opencloud.env
+    fi
+
+    if ! sed -n '/^sharing:/,/^storage_users:/p' /etc/opencloud/opencloud.yaml | grep -q 'service_account'; then
+      ACCOUNT_ID="$(sed -n '/^activitylog:/,/*.$/p' /etc/opencloud/opencloud.yaml | awk -F'id:' '{print $2}' | tr -d '[:space:]')"
+      ACCOUNT_SECRET="$(sed -n '/^activitylog:/,/*.$/p' /etc/opencloud/opencloud.yaml | awk -F'secret:' '{print $2}' | tr -d '[:space:]')"
+      sed -i "/^sharing:/a\\
+  service_account:\\
+    service_account_id: $ACCOUNT_ID\\
+    service_account_secret: $ACCOUNT_SECRET" /etc/opencloud/opencloud.yaml
     fi
 
     msg_info "Starting services"

--- a/install/opencloud-install.sh
+++ b/install/opencloud-install.sh
@@ -64,7 +64,7 @@ $STD sudo -u cool coolconfig set-admin-password --user=admin --password="$COOLPA
 echo "$COOLPASS" >~/.coolpass
 msg_ok "Installed Collabora Online"
 
-fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "v6.2.0" "/usr/bin" "opencloud-*-linux-amd64"
+fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "v7.0.0" "/usr/bin" "opencloud-*-linux-amd64"
 mv /usr/bin/OpenCloud /usr/bin/opencloud
 
 msg_info "Configuring OpenCloud"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- v7.0.0 has one migration required, hopefully handled by this PR: adding the already-existing `service_account_id` and `service_account_secret` to the `sharing` section of `opencloud.yaml`.
- This worked during a test in my environment, can't say for sure if it will work for everyone.
- Manual solution if this fails:
  - Open `/etc/opencloud/opencloud.yaml` in a text editor
  - Find the keys `service_account`, `service_account_id` and `service_account_secret`, copy the keys and values.
  - Paste it all under the `sharing` key in the same file.
  - Restart Opencloud - `systemctl restart opencloud opencloud-wopi`

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
