### PR TITLE
kernel-clean: support range syntax in selection prompt

### DIFF
--- a/tools/pve/kernel-clean.sh
+++ b/tools/pve/kernel-clean.sh
@@ -41,13 +41,23 @@ echo -e "${GN}Currently running kernel: ${current_kernel}${CL}"
 echo -e "${YW}Available kernels for removal:${CL}"
 echo "$available_kernels" | nl -w 2 -s '. '
 
-echo -e "\n${YW}Select kernels to remove (comma-separated, e.g., 1,2):${CL}"
+echo -e "\n${YW}Select kernels to remove (e.g. 1,3 or 1-5 or 1-3,7):${CL}"
 read -r selected
 
-# Parse selection
-IFS=',' read -r -a selected_indices <<<"$selected"
-kernels_to_remove=()
+# Parse selection: supports single indices, ranges (e.g., 1-5), and combinations (e.g., 1,3-5,7)
+selected_indices=()
+IFS=',' read -r -a tokens <<<"$selected"
+for token in "${tokens[@]}"; do
+  if [[ "$token" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    for ((i = BASH_REMATCH[1]; i <= BASH_REMATCH[2]; i++)); do
+      selected_indices+=("$i")
+    done
+  else
+    selected_indices+=("$token")
+  fi
+done
 
+kernels_to_remove=()
 for index in "${selected_indices[@]}"; do
   kernel=$(echo "$available_kernels" | sed -n "${index}p")
   if [ -n "$kernel" ]; then


### PR DESCRIPTION
## ✍️ Description

Extend the kernel selection prompt to accept ranges (e.g. 1-5) and mixed expressions (e.g. 1,3-5,7) in addition to the existing comma-separated syntax. Useful when many old kernels are listed and typing each index by hand becomes tedious.

<img width="480" height="358" alt="Screenshot 2026-05-22 190128" src="https://github.com/user-attachments/assets/ba559b39-816d-432a-9920-f289e45e293d" />

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
