### PR TITLE
Replace runlike for HA updates with efrecon's run.tpl

### DIFF
--- a/ct/homeassistant.sh
+++ b/ct/homeassistant.sh
@@ -42,9 +42,9 @@ function update_script() {
       docker pull "${CONTAINER_IMAGE}"
       LATEST_IMAGE="$(docker inspect --format "{{.Id}}" --type image "${CONTAINER_IMAGE}")"
       if [[ "${RUNNING_IMAGE}" != "${LATEST_IMAGE}" ]]; then
-        pip install -U runlike
         echo "Updating ${container} image ${CONTAINER_IMAGE}"
-        DOCKER_COMMAND="$(runlike --use-volume-id "${container}")"
+        DOCKER_ARGS="$(docker inspect --format "$(curl -s https://gist.githubusercontent.com/efrecon/8ce9c75d518b6eb863f667442d7bc679/raw/run.tpl)" ${container} | sed 's/docker run //')"
+        DOCKER_COMMAND="docker run -d --name ${container} ${DOCKER_ARGS}"
         docker rm --force "${container}"
         eval "${DOCKER_COMMAND}"
       fi

--- a/install/homeassistant-install.sh
+++ b/install/homeassistant-install.sh
@@ -22,10 +22,6 @@ $STD apt install -y \
 rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
 msg_ok "Setup Python3"
 
-msg_info "Installing runlike"
-$STD pip install runlike
-msg_ok "Installed runlike"
-
 get_latest_release() {
   curl -fsSL https://api.github.com/repos/$1/releases/latest | grep '"tag_name":' | cut -d'"' -f4
 }


### PR DESCRIPTION
## ✍️ Description

The update script for homeassistant uses and updates [runlike](https://github.com/lavie/runlike), which now runs into the Python `externally-managed-environment` error:

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
```

Remove `runlike` and replace it with efrecon's [run.tpl](https://gist.github.com/efrecon/8ce9c75d518b6eb863f667442d7bc679) gist based on docker inspect.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
