### PR TITLE
Kernel-Clean: detect meta-packages and fix silent removal failures

### DIFF
--- a/tools/pve/kernel-clean.sh
+++ b/tools/pve/kernel-clean.sh
@@ -31,11 +31,11 @@ current_kernel=$(uname -r)
 # Only list fully-installed (ii) versioned kernel packages; the pattern
 # proxmox-kernel-X.Y.Z matches versioned kernels while excluding the
 # two-segment meta-packages (proxmox-kernel-X.Y) and proxmox-kernel-helper.
-available_kernels=$(dpkg --list \
-  | awk '/^ii/ {print $2}' \
-  | grep -E '^proxmox-kernel-[0-9]+\.[0-9]+\.[0-9]' \
-  | grep -v "$current_kernel" \
-  | sort -V)
+available_kernels=$(dpkg --list |
+  awk '/^ii/ {print $2}' |
+  grep -E '^proxmox-kernel-[0-9]+\.[0-9]+\.[0-9]' |
+  grep -v "$current_kernel" |
+  sort -V)
 
 header_info
 
@@ -98,11 +98,11 @@ for kernel in "${kernels_to_remove[@]}"; do
   # no other versioned kernel of the same minor version will remain
   # (the running kernel keeps it alive if it shares the same minor).
   if dpkg -l "$meta" 2>/dev/null | grep -q '^ii'; then
-    remaining=$(dpkg --list \
-      | awk '/^ii/ {print $2}' \
-      | grep -E "^proxmox-kernel-${minor_version}\." \
-      | grep -v "^${kernel}$" \
-      | wc -l)
+    remaining=$(dpkg --list |
+      awk '/^ii/ {print $2}' |
+      grep -E "^proxmox-kernel-${minor_version}\." |
+      grep -v "^${kernel}$" |
+      wc -l)
     if [ "$remaining" -eq 0 ]; then
       pkgs_to_remove+=("$meta")
     fi

--- a/tools/pve/kernel-clean.sh
+++ b/tools/pve/kernel-clean.sh
@@ -28,7 +28,14 @@ declare -f init_tool_telemetry &>/dev/null && init_tool_telemetry "kernel-clean"
 
 # Detect current kernel
 current_kernel=$(uname -r)
-available_kernels=$(dpkg --list | grep 'kernel-.*-pve' | awk '{print $2}' | grep -v "$current_kernel" | sort -V)
+# Only list fully-installed (ii) versioned kernel packages; the pattern
+# proxmox-kernel-X.Y.Z matches versioned kernels while excluding the
+# two-segment meta-packages (proxmox-kernel-X.Y) and proxmox-kernel-helper.
+available_kernels=$(dpkg --list \
+  | awk '/^ii/ {print $2}' \
+  | grep -E '^proxmox-kernel-[0-9]+\.[0-9]+\.[0-9]' \
+  | grep -v "$current_kernel" \
+  | sort -V)
 
 header_info
 
@@ -82,10 +89,28 @@ fi
 # Remove kernels
 for kernel in "${kernels_to_remove[@]}"; do
   echo -e "${YW}Removing $kernel...${CL}"
-  if apt-get purge -y "$kernel" >/dev/null 2>&1; then
-    echo -e "${GN}Successfully removed: $kernel${CL}"
+  # Derive the major.minor meta-package name (e.g. proxmox-kernel-6.14)
+  # from a versioned name like proxmox-kernel-6.14.11-9-pve-signed.
+  minor_version=$(echo "$kernel" | sed -E 's/^proxmox-kernel-([0-9]+\.[0-9]+)\..*/\1/')
+  meta="proxmox-kernel-${minor_version}"
+  pkgs_to_remove=("$kernel")
+  # Include the meta-package in the purge when it is installed and when
+  # no other versioned kernel of the same minor version will remain
+  # (the running kernel keeps it alive if it shares the same minor).
+  if dpkg -l "$meta" 2>/dev/null | grep -q '^ii'; then
+    remaining=$(dpkg --list \
+      | awk '/^ii/ {print $2}' \
+      | grep -E "^proxmox-kernel-${minor_version}\." \
+      | grep -v "^${kernel}$" \
+      | wc -l)
+    if [ "$remaining" -eq 0 ]; then
+      pkgs_to_remove+=("$meta")
+    fi
+  fi
+  if apt-get purge -y "${pkgs_to_remove[@]}" >/dev/null 2>&1; then
+    echo -e "${GN}Successfully removed: ${pkgs_to_remove[*]}${CL}"
   else
-    echo -e "${RD}Failed to remove: $kernel. Check dependencies.${CL}"
+    echo -e "${RD}Failed to remove: ${pkgs_to_remove[*]}. Check dependencies.${CL}"
   fi
 done
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Replace grep 'kernel-.*-pve' with an awk /^ii/ + grep -E '^proxmox-kernel-[0-9]+\.[0-9]+\.[0-9]' pipeline. This filters out rc-state (config-only) packages and the two-segment meta-packages (proxmox-kernel-X.Y) that the old regex missed entirely.

- for each selected kernel, the script now derives the corresponding meta-package name (proxmox-kernel-X.Y) and co-purges it when no other versioned kernel of that minor version remains installed. This prevents apt from blocking or undoing the removal due to the reverse dependency the meta-package holds.


## 🔗 Related Issue

Fixes #14661

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
