### PR TITLE
ISponsorblockTV: detect CPU capabilities to select compatible binary

### DIFF
--- a/ct/isponsorblocktv.sh
+++ b/ct/isponsorblocktv.sh
@@ -36,7 +36,11 @@ function update_script() {
     systemctl stop isponsorblocktv
     msg_ok "Stopped Service"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "isponsorblocktv" "dmunozv04/iSponsorBlockTV" "singlefile" "latest" "/opt/isponsorblocktv" "iSponsorBlockTV-x86_64-linux"
+    ISBTV_BINARY="iSponsorBlockTV-x86_64-linux-v1"
+    if grep -q ' avx ' /proc/cpuinfo 2>/dev/null && grep -q ' avx2 ' /proc/cpuinfo 2>/dev/null && grep -q ' movbe ' /proc/cpuinfo 2>/dev/null; then
+      ISBTV_BINARY="iSponsorBlockTV-x86_64-linux"
+    fi
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "isponsorblocktv" "dmunozv04/iSponsorBlockTV" "singlefile" "latest" "/opt/isponsorblocktv" "${ISBTV_BINARY}"
 
     msg_info "Starting Service"
     systemctl start isponsorblocktv

--- a/install/isponsorblocktv-install.sh
+++ b/install/isponsorblocktv-install.sh
@@ -13,12 +13,12 @@ setting_up_container
 network_check
 update_os
 
-if ! grep -q ' avx ' /proc/cpuinfo 2>/dev/null; then
-  msg_error "CPU does not support AVX instructions (required by iSponsorBlockTV/PyApp)"
-  exit 106
+ISBTV_BINARY="iSponsorBlockTV-x86_64-linux-v1"
+if grep -q ' avx ' /proc/cpuinfo 2>/dev/null && grep -q ' avx2 ' /proc/cpuinfo 2>/dev/null && grep -q ' movbe ' /proc/cpuinfo 2>/dev/null; then
+  ISBTV_BINARY="iSponsorBlockTV-x86_64-linux"
 fi
 
-fetch_and_deploy_gh_release "isponsorblocktv" "dmunozv04/iSponsorBlockTV" "singlefile" "latest" "/opt/isponsorblocktv" "iSponsorBlockTV-x86_64-linux"
+fetch_and_deploy_gh_release "isponsorblocktv" "dmunozv04/iSponsorBlockTV" "singlefile" "latest" "/opt/isponsorblocktv" "${ISBTV_BINARY}"
 
 msg_info "Setting up iSponsorBlockTV"
 install -d /var/lib/isponsorblocktv


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- iSponsorBlockTV-x86_64-linux     → modern CPUs (AVX/AVX2/MOVBE)
- iSponsorBlockTV-x86_64-linux-v1  → any x86_64 CPU (fallback)


## 🔗 Related Issue

Fixes #14660

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
