### PR TITLE
profilarr: Fix ARCH assignment in profilarr.sh to support Profilarr build usage

### DIFF
--- a/ct/profilarr.sh
+++ b/ct/profilarr.sh
@@ -37,8 +37,9 @@ function update_script() {
     exit
   fi
 
+  ARCH=$(uname -m)
+
   if check_for_gh_release "deno" "denoland/deno" "v2.7.5" "Deno is pinned to 2.7.5 because the known WouldBlock: Resource temporarily unavailable (os error 11) Issue"; then
-    ARCH=$(uname -m)
     fetch_and_deploy_gh_release "deno" "denoland/deno" "v2.7.5" "latest" "/usr/local/bin" "deno-${ARCH}-unknown-linux-gnu.zip"
   fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Fix profilarr update error coming from deno compile as ARCH is not set when updating an existing installation, but is used when setting DENO_TARGET.

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
