### PR TITLE
grist: restore install:ee step

### DIFF
--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -54,6 +54,7 @@ function update_script() {
     [[ -f /opt/grist_bak/landing.db ]] && cp /opt/grist_bak/landing.db /opt/grist/landing.db
     cd /opt/grist
     $STD yarn install
+    $STD yarn run install:ee -y
     $STD yarn run build:prod
     $STD yarn run install:python
     msg_ok "Updated Grist"

--- a/install/grist-install.sh
+++ b/install/grist-install.sh
@@ -28,6 +28,7 @@ export CYPRESS_INSTALL_BINARY=0
 export NODE_OPTIONS="--max-old-space-size=2048"
 cd /opt/grist
 $STD yarn install
+$STD yarn run install:ee -y
 $STD yarn run build:prod
 $STD yarn run install:python
 cat <<EOF >/opt/grist/.env


### PR DESCRIPTION
## ✍️ Description

Re-applies the `install:ee` step removed in #13526. The step was removed during a transition that made it look like the EE material had been deleted. Verified against `grist-core` v1.7.13.

## 🔗 Related Issue

- #11203
- #11239
- #11744
- #13521
- #13526

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
