### PR TITLE
fix(hermesagent): set npm_config_yes=true to suppress interactive pro…

### DIFF
--- a/install/hermesagent-install.sh
+++ b/install/hermesagent-install.sh
@@ -47,6 +47,7 @@ fi
 msg_info "Installing Hermes Agent"
 $STD setsid --wait bash -c '
   set -a; source /etc/default/hermes; set +a
+  export npm_config_yes=true
   bash <(curl -fsSL https://hermes-agent.nousresearch.com/install.sh) --skip-setup --hermes-home /home/hermes/.hermes --dir /home/hermes/.hermes/hermes-agent
 '
 chown -R hermes:hermes /home/hermes


### PR DESCRIPTION
## ✍️ Description

Fixes the hermes-agent installer so it won't wait for user input on NPM module installs that were added to the upstream script.

## 🔗 Related Issue

Fixes #14756

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
