### PR TITLE
Yamtrack: migrate to uv

### DIFF
--- a/ct/yamtrack.sh
+++ b/ct/yamtrack.sh
@@ -44,8 +44,7 @@ function update_script() {
 
     msg_info "Installing Python Dependencies"
     cd /opt/yamtrack
-    $STD uv venv --clear .venv
-    $STD uv pip install --no-cache-dir -r requirements.txt
+    $STD uv sync --locked
     msg_ok "Installed Python Dependencies"
 
     msg_info "Restoring Data"

--- a/install/yamtrack-install.sh
+++ b/install/yamtrack-install.sh
@@ -27,8 +27,7 @@ fetch_and_deploy_gh_release "yamtrack" "FuzzyGrim/Yamtrack" "tarball"
 
 msg_info "Installing Python Dependencies"
 cd /opt/yamtrack
-$STD uv venv .venv
-$STD uv pip install --no-cache-dir -r requirements.txt
+$STD uv sync --locked
 msg_ok "Installed Python Dependencies"
 
 msg_info "Configuring Yamtrack"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Upstream dropped requirements.txt in v0.25.3 and migrated to pyproject.toml/uv.lock. Replace uv venv + uv pip install with uv sync --locked in both install and update scripts.


## 🔗 Related Issue

Fixes #14730

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
