### PR TITLE
Manyfold: regenerate Rails credentials on update to fix encryption mimatch

### DIFF
--- a/ct/manyfold.sh
+++ b/ct/manyfold.sh
@@ -40,8 +40,6 @@ function update_script() {
     CURRENT_VERSION=$(grep -oP 'APP_VERSION=\K[^ ]+' /opt/manyfold/.env || echo "unknown")
     cp -r /opt/manyfold/app/storage /opt/manyfold_storage_backup 2>/dev/null || true
     cp -r /opt/manyfold/app/tmp /opt/manyfold_tmp_backup 2>/dev/null || true
-    cp /opt/manyfold/app/config/credentials.yml.enc /opt/manyfold_credentials.yml.enc 2>/dev/null || true
-    cp /opt/manyfold/app/config/master.key /opt/manyfold_master.key 2>/dev/null || true
     $STD tar -czf "/opt/manyfold_${CURRENT_VERSION}_backup.tar.gz" -C /opt/manyfold app
     msg_ok "Backed up Data"
 
@@ -57,14 +55,12 @@ function update_script() {
     RUBY_VERSION=${RUBY_INSTALL_VERSION} RUBY_INSTALL_RAILS="true" HOME=/home/manyfold setup_ruby
 
     msg_info "Restoring Data"
-    rm -rf /opt/manyfold/app/{storage,tmp,config/credentials.yml.enc,config/master.key}
+    rm -rf /opt/manyfold/app/{storage,tmp}
     cp -r /opt/manyfold_storage_backup /opt/manyfold/app/storage 2>/dev/null || true
     cp -r /opt/manyfold_tmp_backup /opt/manyfold/app/tmp 2>/dev/null || true
-    cp /opt/manyfold_credentials.yml.enc /opt/manyfold/app/config/credentials.yml.enc 2>/dev/null || true
-    cp /opt/manyfold_master.key /opt/manyfold/app/config/master.key 2>/dev/null || true
     chown -R manyfold:manyfold {/home/manyfold,/opt/manyfold}
     chown -R manyfold:manyfold /opt/manyfold/app/storage /opt/manyfold/app/tmp /opt/manyfold/app/config
-    rm -rf /opt/manyfold_storage_backup /opt/manyfold_tmp_backup /opt/manyfold_credentials.yml.enc /opt/manyfold_master.key
+    rm -rf /opt/manyfold_storage_backup /opt/manyfold_tmp_backup
     msg_ok "Restored Data"
 
     msg_info "Installing Manyfold"
@@ -80,6 +76,8 @@ function update_script() {
             bundle install
             corepack prepare '"$YARN_VERSION"' --activate
             corepack use '"$YARN_VERSION"'
+            rm -f config/credentials.yml.enc config/master.key
+            EDITOR=/bin/true bin/rails credentials:edit
             bin/rails db:migrate
             bin/rails assets:precompile
         '


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Removed backup/restore of credentials.yml.enc and master.key (incompatible after Rails version upgrades); instead regenerates fresh credentials with EDITOR=/bin/true bin/rails credentials:edit before db:migrate

## 🔗 Related Issue

Fixes #14778

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
