### PR TITLE
Webtrees: use PHP CLI for initial setup instead of curl to setup wizard

### DIFF
--- a/install/webtrees-install.sh
+++ b/install/webtrees-install.sh
@@ -47,23 +47,21 @@ systemctl enable -q --now php${PHP_VER}-fpm
 systemctl restart caddy
 
 msg_info "Automating Webtrees Setup"
-sleep 5
 WT_ADMIN_PASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c15)
-curl -sS -X POST "http://127.0.0.1/" \
-  -d "step=6" \
-  --data-urlencode "baseurl=http://${LOCAL_IP}" \
-  -d "lang=en-US" \
-  -d "dbtype=mysql" \
-  -d "dbhost=127.0.0.1" \
-  -d "dbport=3306" \
-  -d "dbuser=webtrees" \
-  --data-urlencode "dbpass=${MARIADB_DB_PASS}" \
-  -d "dbname=webtrees" \
-  -d "tblpfx=wt_" \
-  -d "wtname=Administrator" \
-  -d "wtuser=Admin" \
-  --data-urlencode "wtpass=${WT_ADMIN_PASS}" \
-  -d "wtemail=admin@example.com" >/dev/null
+$STD sudo -u www-data php /opt/webtrees/index.php config-ini \
+  --dbhost=127.0.0.1 \
+  --dbport=3306 \
+  --dbuser=webtrees \
+  --dbpass="${MARIADB_DB_PASS}" \
+  --dbname=webtrees \
+  --tblpfx=wt_ \
+  --base-url="http://${LOCAL_IP}"
+$STD sudo -u www-data php /opt/webtrees/index.php user Admin \
+  --create \
+  --real-name="Administrator" \
+  --email="admin@example.com" \
+  --password="${WT_ADMIN_PASS}"
+$STD sudo -u www-data php /opt/webtrees/index.php user-setting Admin canadmin 1
 
 cat <<EOF >>~/webtrees.creds
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Replaced the fragile sleep 5 + curl POST setup wizard approach with php index.php config-ini, php index.php user Admin --create, and php index.php user-setting - as recommended by webtrees upstream author fisharebest.

## 🔗 Related Issue

Fixes #14733

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
