### PR TITLE
OpenThread-BR: use correct ipv6 configuration

### DIFF
--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -70,6 +70,27 @@ function update_script() {
   $STD ninja install
   msg_ok "Rebuilt OpenThread Border Router"
 
+  if ! grep -q "net.ipv6.conf.all.accept_ra=2" /etc/sysctl.d/99-otbr.conf; then
+    msg_info "Configuring Network"
+    cat <<EOF >/etc/sysctl.d/99-otbr.conf
+net.ipv6.conf.all.forwarding=1
+net.ipv6.conf.all.accept_ra=2
+net.ipv6.conf.all.accept_ra_rtr_pref=1
+net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+net.ipv6.conf.default.forwarding=1
+net.ipv6.conf.default.accept_ra=2
+net.ipv6.conf.default.accept_ra_rtr_pref=1
+net.ipv6.conf.default.accept_ra_rt_info_max_plen=64
+net.ipv6.conf.eth0.forwarding=1
+net.ipv6.conf.eth0.accept_ra=2
+net.ipv6.conf.eth0.accept_ra_rtr_pref=1
+net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
+net.ipv4.ip_forward=1
+EOF
+    $STD sysctl -p /etc/sysctl.d/99-otbr.conf
+    msg_ok "Configured Network"
+  fi
+
   msg_info "Starting Services"
   systemctl start otbr-agent
   systemctl start otbr-web

--- a/install/openthread-br-install.sh
+++ b/install/openthread-br-install.sh
@@ -67,6 +67,17 @@ msg_ok "Built OpenThread Border Router"
 msg_info "Configuring Network"
 cat <<EOF >/etc/sysctl.d/99-otbr.conf
 net.ipv6.conf.all.forwarding=1
+net.ipv6.conf.all.accept_ra=2
+net.ipv6.conf.all.accept_ra_rtr_pref=1
+net.ipv6.conf.all.accept_ra_rt_info_max_plen=64
+net.ipv6.conf.default.forwarding=1
+net.ipv6.conf.default.accept_ra=2
+net.ipv6.conf.default.accept_ra_rtr_pref=1
+net.ipv6.conf.default.accept_ra_rt_info_max_plen=64
+net.ipv6.conf.eth0.forwarding=1
+net.ipv6.conf.eth0.accept_ra=2
+net.ipv6.conf.eth0.accept_ra_rtr_pref=1
+net.ipv6.conf.eth0.accept_ra_rt_info_max_plen=64
 net.ipv4.ip_forward=1
 EOF
 $STD sysctl -p /etc/sysctl.d/99-otbr.conf


### PR DESCRIPTION
## ✍️ Description
This PR fixes the 100% CPU Load issue with the OpenThread-BR script.
The issue was that `net.ipv6.conf.all.forwarding=1` disabled Route Advertisement. By default PVE should have `net.ipv6.conf.all.accept_ra` set to 1 which therefore gets passed into the LXC. But when enabling forwarding, RA gets disabled unless it is specifically set to 2.
This prevented otbr from noticing that thread nodes switched IP addresses and thus trying to reach them in a forever loop, causing the high CPU load.

Additionally, i added the `accept_ra_rtr_pref` and `accept_ra_rt_info_max_plen` parameters since those are documented as a requirement for OTBR to handle RA correctly. 

I also added all 4 parameters for the interfaces `all`, `default` and `eth0`. The logic when `all` gets used / will be overidden is a bit tricky so i added `eth0` (default when creating the LXC) to make sure the parameters always gets used.
The `default` interface defines that those parameters will also be used for new (currently not existing) interfaces. So if a user adds a second NIC to the LXC, it will use those parameters as well.

All those parameters are namespaced so it won't affect the host kernel (both privileged and unprivileged) 😉 

Here are the docs tho the parameters i added:
https://openthread.io/codelabs/openthread-border-router#ping-from-a-linuxmacos-host

## 🔗 Related Issue

Fixes #14621 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
