### PR TITLE
[FileFlows] Fix service handling by using systemctl --all with quoted glob

### DIFF
--- a/ct/fileflows.sh
+++ b/ct/fileflows.sh
@@ -34,7 +34,7 @@ function update_script() {
   update_available=$(curl -fsSL -X 'GET' "http://localhost:19200/api/status/update-available" -H 'accept: application/json' | jq .UpdateAvailable)
   if [[ "${update_available}" == "true" ]]; then
     msg_info "Stopping Service"
-    systemctl stop fileflows*
+    systemctl --all stop 'fileflows*'
     msg_info "Stopped Service"
 
     msg_info "Creating Backup"
@@ -46,7 +46,7 @@ function update_script() {
     fetch_and_deploy_from_url "https://fileflows.com/downloads/zip" "/opt/fileflows"
 
     msg_info "Starting Service"
-    systemctl start fileflows*
+    systemctl --all start 'fileflows*'
     msg_ok "Started Service"
     msg_ok "Updated successfully!"
   else


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

This PR fixes an issue in the FileFlows update script where the service is not properly stopped or restarted during the update process. The root cause is the use of:

```bash
systemctl stop fileflows*
systemctl start fileflows*
```

Systemd does not expand shell-style globs as expected, which results in warnings and prevents all FileFlows-related units from being handled correctly.  
The fix replaces these calls with proper systemd globbing using `--all` and a quoted pattern:

```bash
systemctl --all stop 'fileflows*'
systemctl --all start 'fileflows*'
```

This ensures that all FileFlows services are properly stopped and started during the update process.

## 🔗 Related Issue

Fixes #14836

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
