### PR TITLE
fix(firefly): set Data Importer APP_URL for subdirectory install

### DIFF
--- a/install/firefly-install.sh
+++ b/install/firefly-install.sh
@@ -37,7 +37,13 @@ msg_ok "Configured Firefly III"
 
 msg_info "Configuring Data Importer"
 cp /opt/firefly/dataimporter/.env.example /opt/firefly/dataimporter/.env
-sed -i "s#FIREFLY_III_URL=#FIREFLY_III_URL=http://${LOCAL_IP}#g" /opt/firefly/dataimporter/.env
+sed -i \
+  -e "s#FIREFLY_III_URL=#FIREFLY_III_URL=http://${LOCAL_IP}#g" \
+  -e "s|^APP_URL=.*|APP_URL=http://${LOCAL_IP}/dataimporter|" \
+  -e "s|^ASSET_URL=.*|ASSET_URL=/dataimporter|" \
+  /opt/firefly/dataimporter/.env
+cd /opt/firefly/dataimporter
+$STD php artisan config:clear
 chown -R www-data:www-data /opt/firefly
 msg_ok "Configured Data Importer"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

When the Firefly III Data Importer is served under the Apache `/dataimporter/` alias, Laravel's `route('index')` was generated against the default `APP_URL` (`http://localhost`), so **Start Over** redirected to `/` instead of `/dataimporter/` and users hit a 404.

This PR sets `APP_URL` and `ASSET_URL` in the Data Importer `.env` during install and runs `php artisan config:clear` so URL generation matches the subdirectory deployment.

## 🔗 Related Issue

Fixes #14830

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
