### PR TITLE
fix(fireshare): rebuild client on update to fix nginx 500

### DIFF
--- a/ct/fireshare.sh
+++ b/ct/fireshare.sh
@@ -53,6 +53,12 @@ function update_script() {
     export VIDEO_DIRECTORY=/opt/fireshare-videos
     export PROCESSED_DIRECTORY=/opt/fireshare-processed
     $STD uv run flask db upgrade
+
+    msg_info "Building Fireshare Client"
+    cd /opt/fireshare/app/client
+    $STD npm install
+    $STD npm run build
+    msg_ok "Built Fireshare Client"
     msg_ok "Updated Fireshare"
 
     msg_info "Starting Service"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fireshare LXC updates redeploy the app and refresh the Python backend but did not rebuild the React client. Nginx continues to serve `/opt/fireshare/app/client/build`, which is missing or stale after `CLEAN_INSTALL=1 fetch_and_deploy_gh_release`, resulting in **500 Internal Server Error** after `update` (reported in #14812).

This adds `npm install` and `npm run build` in `update_script()`, matching the install script and peer scripts such as flatnotes.

## 🔗 Related Issue

Fixes #14812

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
