### PR TITLE
fix(odoo): ensure lxml html clean after Odoo deb install

### DIFF
--- a/ct/fireshare.sh
+++ b/ct/fireshare.sh
@@ -53,6 +53,12 @@ function update_script() {
     export VIDEO_DIRECTORY=/opt/fireshare-videos
     export PROCESSED_DIRECTORY=/opt/fireshare-processed
     $STD uv run flask db upgrade
+
+    msg_info "Building Fireshare Client"
+    cd /opt/fireshare/app/client
+    $STD npm install
+    $STD npm run build
+    msg_ok "Built Fireshare Client"
     msg_ok "Updated Fireshare"
 
     msg_info "Starting Service"

--- a/ct/odoo.sh
+++ b/ct/odoo.sh
@@ -20,6 +20,22 @@ variables
 color
 catch_errors
 
+ensure_lxml_html_clean() {
+  ensure_dependencies python3-lxml
+  if apt-cache show python3-lxml-html-clean &>/dev/null; then
+    ensure_dependencies python3-lxml-html-clean
+  else
+    curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
+    $STD dpkg -i /opt/python3-lxml-html-clean.deb
+    $STD apt-get install -f -y
+    rm -f /opt/python3-lxml-html-clean.deb
+  fi
+  if ! python3 -c "import lxml_html_clean; from lxml.html import clean" 2>/dev/null; then
+    msg_error "lxml.html.clean is not available (python3-lxml-html-clean required)"
+    exit 1
+  fi
+}
+
 function update_script() {
   header_info
   check_container_storage
@@ -29,12 +45,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  ensure_dependencies python3-lxml
-  if ! [[ $(dpkg -s python3-lxml-html-clean 2>/dev/null) ]]; then
-    curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
-    $STD dpkg -i /opt/python3-lxml-html-clean.deb
-    rm -f /opt/python3-lxml-html-clean.deb
-  fi
+  ensure_lxml_html_clean
 
   RELEASE=$(curl -fsSL https://nightly.odoo.com/ | grep -oE 'href="[0-9]+\.[0-9]+/nightly"' | head -n1 | cut -d'"' -f2 | cut -d/ -f1)
   LATEST_VERSION=$(curl -fsSL "https://nightly.odoo.com/${RELEASE}/nightly/deb/" |
@@ -51,6 +62,7 @@ function update_script() {
     msg_info "Updating ${APP} to ${LATEST_VERSION}"
     curl -fsSL https://nightly.odoo.com/${RELEASE}/nightly/deb/odoo_${RELEASE}.latest_all.deb -o /opt/odoo.deb
     $STD apt install -y /opt/odoo.deb
+    ensure_lxml_html_clean
     rm -f /opt/odoo.deb
     echo "$LATEST_VERSION" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to ${LATEST_VERSION}"

--- a/install/odoo-install.sh
+++ b/install/odoo-install.sh
@@ -13,10 +13,25 @@ setting_up_container
 network_check
 update_os
 
+ensure_lxml_html_clean() {
+  ensure_dependencies python3-lxml
+  if apt-cache show python3-lxml-html-clean &>/dev/null; then
+    ensure_dependencies python3-lxml-html-clean
+  else
+    curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
+    $STD dpkg -i /opt/python3-lxml-html-clean.deb
+    $STD apt-get install -f -y
+    rm -f /opt/python3-lxml-html-clean.deb
+  fi
+  if ! python3 -c "import lxml_html_clean; from lxml.html import clean" 2>/dev/null; then
+    msg_error "lxml.html.clean is not available (python3-lxml-html-clean required)"
+    exit 1
+  fi
+}
+
 msg_info "Installing Dependencies"
-$STD apt install -y python3-lxml wkhtmltopdf
-curl -fsSL "http://archive.ubuntu.com/ubuntu/pool/universe/l/lxml-html-clean/python3-lxml-html-clean_0.1.1-1_all.deb" -o /opt/python3-lxml-html-clean.deb
-$STD dpkg -i /opt/python3-lxml-html-clean.deb
+$STD apt install -y wkhtmltopdf
+ensure_lxml_html_clean
 msg_ok "Installed Dependencies"
 
 PG_VERSION="18" setup_postgresql
@@ -31,6 +46,7 @@ LATEST_VERSION=$(curl -fsSL "https://nightly.odoo.com/${RELEASE}/nightly/deb/" |
 msg_info "Setup Odoo $RELEASE"
 curl -fsSL https://nightly.odoo.com/${RELEASE}/nightly/deb/odoo_${RELEASE}.latest_all.deb -o /opt/odoo.deb
 $STD apt install -y /opt/odoo.deb
+ensure_lxml_html_clean
 msg_ok "Setup Odoo $RELEASE"
 
 msg_info "Setup PostgreSQL Database"
@@ -59,7 +75,6 @@ sed -i \
   /etc/odoo/odoo.conf
 $STD sudo -u odoo odoo -c /etc/odoo/odoo.conf -d odoo -i base --stop-after-init
 rm -f /opt/odoo.deb
-rm -f /opt/python3-lxml-html-clean.deb
 echo "${LATEST_VERSION}" >/opt/${APPLICATION}_version.txt
 msg_ok "Configured Odoo"
 


### PR DESCRIPTION
## ✍️ Description

Ensures `python3-lxml-html-clean` is present and verified **after** the Odoo nightly `.deb` is installed, not only before it. Adds `apt-get install -f` for manual `.deb` installs on Bookworm and a Python import check so install/update fails loudly instead of leaving a broken `odoo` service.


## 🔗 Related Issue

Fixes #14780

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.
---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

