### PR TITLE
Fix Kan build failure (TS7016 nodemailer)

### DIFF
--- a/ct/kan.sh
+++ b/ct/kan.sh
@@ -50,7 +50,7 @@ function update_script() {
     cd /opt/kan
     set -a && source /opt/kan/.env && set +a
     export NEXT_PUBLIC_USE_STANDALONE_OUTPUT=true
-    $STD pnpm install --ignore-scripts
+    $STD pnpm install --ignore-scripts --prod=false
     export CI=true
     find /opt/kan/packages /opt/kan/apps -name 'tsconfig.json' -exec sed -i 's|"@kan/tsconfig/|"../../tooling/typescript/|g' {} +
     $STD pnpm build --filter=@kan/web

--- a/install/kan-install.sh
+++ b/install/kan-install.sh
@@ -45,7 +45,7 @@ msg_info "Building Application"
 cd /opt/kan
 set -a && source /opt/kan/.env && set +a
 export NEXT_PUBLIC_USE_STANDALONE_OUTPUT=true NEXT_PUBLIC_BASE_URL BETTER_AUTH_TRUSTED_ORIGINS NEXT_PUBLIC_ALLOW_CREDENTIALS BETTER_AUTH_SECRET
-$STD pnpm install --ignore-scripts
+$STD pnpm install --ignore-scripts --prod=false
 export CI=true
 find /opt/kan/packages /opt/kan/apps -name 'tsconfig.json' -exec sed -i 's|"@kan/tsconfig/|"../../tooling/typescript/|g' {} +
 $STD pnpm build --filter=@kan/web


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Kan install/update fails at `pnpm build --filter=@kan/web` because `@kan/email` cannot compile: TypeScript reports TS7016 for `nodemailer` (missing declaration file).

The upstream Kan repo already includes `@types/nodemailer` in devDependencies. Our scripts source `/opt/kan/.env` (which sets `NODE_ENV=production`) before `pnpm install`, so pnpm skips devDependencies.

This PR adds `--prod=false` to `pnpm install` in `install/kan-install.sh` and `ct/kan.sh` so dev deps (including `@types/nodemailer`, `typescript`, and workspace tooling) are installed for the build. Runtime still uses `NODE_ENV=production` via systemd `EnvironmentFile`.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
