### PR TITLE
FileFlows: Handle update API 401, force update, and Node install

### DIFF
--- a/ct/fileflows.sh
+++ b/ct/fileflows.sh
@@ -31,49 +31,85 @@ function update_script() {
     exit
   fi
 
-  update_available=$(curl -fsSL -X 'GET' "http://localhost:19200/api/status/update-available" -H 'accept: application/json' | jq .UpdateAvailable)
-  if [[ "${update_available}" == "true" ]]; then
-    msg_info "Stopping Service"
-    systemctl --all stop 'fileflows*'
-    msg_info "Stopped Service"
+  local proceed=false
 
-    msg_info "Creating Backup"
-    ls /opt/*.tar.gz &>/dev/null && rm -f /opt/*.tar.gz
-    backup_filename="/opt/${APP}_backup_$(date +%F).tar.gz"
-    tar -czf "$backup_filename" -C /opt/fileflows Data
-    msg_ok "Backup Created"
-
-    # FileFlows tracks the latest release, whose .NET target can move (e.g. 8 -> 10);
-    # ensure the current ASP.NET Core Runtime so an existing install doesn't fail to
-    # start after updating to a newer .NET major version.
-    msg_info "Ensuring ASP.NET Core Runtime"
-    if [[ "$(arch_resolve)" == "arm64" ]]; then
-      if [[ ! -x /usr/lib/dotnet10/dotnet ]]; then
-        curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
-        $STD bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/lib/dotnet10
-        ln -sf /usr/lib/dotnet10/dotnet /usr/bin/dotnet
-        rm -f /tmp/dotnet-install.sh
+  if systemctl list-unit-files 'fileflows.service' --no-legend 2>/dev/null | grep -q '^fileflows\.service'; then
+    tmp=$(mktemp)
+    http_code=$(curl -sSL -X 'GET' "http://localhost:19200/api/status/update-available" -H 'accept: application/json' -o "$tmp" -w '%{http_code}' 2>/dev/null) || http_code="000"
+    if [[ "$http_code" == "200" ]]; then
+      update_available=$(jq -r '.UpdateAvailable // false' "$tmp" 2>/dev/null)
+      rm -f "$tmp"
+      if [[ "${update_available}" == "true" ]]; then
+        proceed=true
+      else
+        msg_ok "No update required. ${APP} is already at latest version"
+        exit
       fi
-    elif ! is_package_installed "aspnetcore-runtime-10.0"; then
-      $STD apt remove -y aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 2>/dev/null || true
-      setup_deb822_repo \
-        "microsoft" \
-        "https://packages.microsoft.com/keys/microsoft-2025.asc" \
-        "https://packages.microsoft.com/debian/13/prod/" \
-        "trixie"
-      $STD apt install -y aspnetcore-runtime-10.0
+    else
+      rm -f "$tmp"
+      if [[ "$http_code" == "401" ]]; then
+        msg_warn "Could not check for updates: API returned 401 (security may be enabled)."
+      else
+        msg_warn "Could not check for updates: API unreachable (HTTP ${http_code})."
+      fi
+      if [[ "${FORCE_UPDATE:-}" == "1" ]]; then
+        proceed=true
+      else
+        read -r -p "${TAB3}Force update without version check? [y/N]: " CONFIRM
+        if [[ "$CONFIRM" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+          proceed=true
+        else
+          msg_error "Update aborted."
+          exit
+        fi
+      fi
     fi
-    msg_ok "Ensured ASP.NET Core Runtime"
-
-    fetch_and_deploy_from_url "https://fileflows.com/downloads/zip" "/opt/fileflows"
-
-    msg_info "Starting Service"
-    systemctl --all start 'fileflows*'
-    msg_ok "Started Service"
-    msg_ok "Updated successfully!"
   else
-    msg_ok "No update required. ${APP} is already at latest version"
+    proceed=true
   fi
+
+  if [[ "$proceed" != "true" ]]; then
+    exit
+  fi
+
+  msg_info "Stopping Service"
+  systemctl --all stop 'fileflows*'
+  msg_ok "Stopped Service"
+
+  msg_info "Creating Backup"
+  ls /opt/*.tar.gz &>/dev/null && rm -f /opt/*.tar.gz
+  backup_filename="/opt/${APP}_backup_$(date +%F).tar.gz"
+  tar -czf "$backup_filename" -C /opt/fileflows Data
+  msg_ok "Backup Created"
+
+  # FileFlows tracks the latest release, whose .NET target can move (e.g. 8 -> 10);
+  # ensure the current ASP.NET Core Runtime so an existing install doesn't fail to
+  # start after updating to a newer .NET major version.
+  msg_info "Ensuring ASP.NET Core Runtime"
+  if [[ "$(arch_resolve)" == "arm64" ]]; then
+    if [[ ! -x /usr/lib/dotnet10/dotnet ]]; then
+      curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+      $STD bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/lib/dotnet10
+      ln -sf /usr/lib/dotnet10/dotnet /usr/bin/dotnet
+      rm -f /tmp/dotnet-install.sh
+    fi
+  elif ! is_package_installed "aspnetcore-runtime-10.0"; then
+    $STD apt remove -y aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 2>/dev/null || true
+    setup_deb822_repo \
+      "microsoft" \
+      "https://packages.microsoft.com/keys/microsoft-2025.asc" \
+      "https://packages.microsoft.com/debian/13/prod/" \
+      "trixie"
+    $STD apt install -y aspnetcore-runtime-10.0
+  fi
+  msg_ok "Ensured ASP.NET Core Runtime"
+
+  fetch_and_deploy_from_url "https://fileflows.com/downloads/zip" "/opt/fileflows"
+
+  msg_info "Starting Service"
+  systemctl --all start 'fileflows*'
+  msg_ok "Started Service"
+  msg_ok "Updated successfully!"
 
   exit
 }

--- a/install/fileflows-install.sh
+++ b/install/fileflows-install.sh
@@ -55,9 +55,12 @@ if [[ "$install_server" =~ ^[Ss]$ ]]; then
   msg_ok "Installed FileFlows Server"
 else
   msg_info "Installing FileFlows Node"
+  read -r -p "${TAB3}Enter FileFlows Server URL (e.g. http://192.168.1.10:19200): " server_url
+  while [[ -z "${server_url// /}" ]]; do
+    read -r -p "${TAB3}Enter FileFlows Server URL (e.g. http://192.168.1.10:19200): " server_url
+  done
   cd /opt/fileflows/Node
-  $STD dotnet FileFlows.Node.dll
-  $STD dotnet FileFlows.Node.dll --systemd install --root true
+  $STD dotnet FileFlows.Node.dll --server "$server_url" --systemd install --root true
   systemctl enable -q --now fileflows-node
   msg_ok "Installed FileFlows Node"
 fi


### PR DESCRIPTION
## Summary

- **Server:** Checks `api/status/update-available` with `curl -sSL` (no `-f`) so `catch_errors` does not trap on 401 or unreachable API. On failure, warns and offers a force-update prompt; `FORCE_UPDATE=1` skips the prompt for silent runs. On HTTP 200, keeps existing `UpdateAvailable` gating.
- **Node:** Skips the server-only API check and proceeds directly to stop → backup → deploy → start.
- **Node install:** Prompts for the FileFlows Server URL and passes `--server` to `dotnet FileFlows.Node.dll --systemd install` (removes broken bare Node launch without server config).
- Preserves ASP.NET Core 10 runtime handling from #15702 during updates.

## Related Issue

Fixes #14622

## Test plan

- [x] Bash syntax validated (`bash -n`) for `ct/fileflows.sh` and `install/fileflows-install.sh`
- [ ] Fresh **Server** LXC, security off, up-to-date → `update` reports no update required
- [ ] Fresh **Server** LXC, security on (401) → warning + force prompt; force → successful deploy
- [ ] **Server** with app stopped → same force-update path
- [ ] Fresh **Node** LXC with remote server URL → Node starts; `update` completes without curl 401
- [ ] `FORCE_UPDATE=1` silent update on secured server → skips prompt, deploys

## Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Full LXC deploy tests pending on Proxmox host.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] New script
- [ ] Website update
- [ ] Refactoring / Code Cleanup
- [ ] Documentation update
