### PR TITLE
fix(dispatcharr): forward nginx port for M3U URLs on new installs

### DIFF
--- a/install/dispatcharr-install.sh
+++ b/install/dispatcharr-install.sh
@@ -121,6 +121,7 @@ server {
     # All other requests proxy to uWSGI
     location / {
         include proxy_params;
+        proxy_set_header X-Forwarded-Port \$server_port;
         proxy_pass http://127.0.0.1:5656;
     }
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Dispatcharr behind nginx on port 9191 was generating downloaded M3U playlists with proxy stream URLs missing `:9191`, because `proxy_params` does not forward the external port to uWSGI.

Add `proxy_set_header X-Forwarded-Port $server_port` to the nginx `location /` block in the install script so new installs include the port in generated M3U/EPG URLs.


## 🔗 Related Issue

Fixes #14839

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
