### PR TITLE
infisical: fix update abort due to creds field mismatch (#14868)

### DIFF
--- a/ct/infisical.sh
+++ b/ct/infisical.sh
@@ -35,7 +35,7 @@ function update_script() {
 
   msg_info "Creating backup"
   [[ -f /opt/infisical_backup.sql ]] && rm -f /opt/infisical_backup.sql
-  DB_PASS=$(grep -Po '(?<=^Database Password:\s).*' ~/infisical.creds | head -n1)
+  DB_PASS=$(grep -Po '(?<=^Password:\s).*' ~/infisical.creds | head -n1)
   PGPASSWORD=$DB_PASS pg_dump -U infisical -h localhost -d infisical_db > /opt/infisical_backup.sql
   msg_ok "Created backup"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fix `ct/infisical.sh update` to correctly read PostgreSQL credentials from `~/infisical.creds`. The update flow previously looked for `Database Password:`, but the shared `setup_postgresql_db()` helper writes `Password:`, causing the script to abort during the DB backup and leaving the Infisical service stopped.

## 🔗 Related Issue

Fixes #14868

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.