### PR TITLE
feat(degoog): enable default valkey cache integration

### DIFF
--- a/ct/degoog.sh
+++ b/ct/degoog.sh
@@ -49,6 +49,10 @@ function update_script() {
       msg_ok "Installed Bun"
     fi
 
+    msg_info "Updating Valkey"
+    $STD apt install -y --only-upgrade valkey
+    msg_ok "Updated Valkey"
+
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "degoog" "fccview/degoog" "prebuild" "latest" "/opt/degoog" "degoog_*_prebuild.tar.gz"
 
     msg_info "Restoring Configuration & Data"

--- a/ct/degoog.sh
+++ b/ct/degoog.sh
@@ -50,7 +50,7 @@ function update_script() {
     fi
 
     msg_info "Updating Valkey"
-    $STD apt install -y valkey
+    ensure_dependencies valkey
     msg_ok "Updated Valkey"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "degoog" "fccview/degoog" "prebuild" "latest" "/opt/degoog" "degoog_*_prebuild.tar.gz"

--- a/ct/degoog.sh
+++ b/ct/degoog.sh
@@ -50,7 +50,7 @@ function update_script() {
     fi
 
     msg_info "Updating Valkey"
-    $STD apt install -y --only-upgrade valkey
+    $STD apt install -y valkey
     msg_ok "Updated Valkey"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "degoog" "fccview/degoog" "prebuild" "latest" "/opt/degoog" "degoog_*_prebuild.tar.gz"
@@ -58,6 +58,12 @@ function update_script() {
     msg_info "Restoring Configuration & Data"
     [[ -f /opt/degoog.env.bak ]] && mv /opt/degoog.env.bak /opt/degoog/.env
     [[ -d /opt/degoog_data_backup ]] && mv /opt/degoog_data_backup /opt/degoog/data
+
+    if [[ -f /opt/degoog/.env ]]; then
+      grep -q "^DEGOOG_VALKEY_URL=" /opt/degoog/.env && sed -i "s|^DEGOOG_VALKEY_URL=.*|DEGOOG_VALKEY_URL=redis://valkey:6379|" /opt/degoog/.env || echo "DEGOOG_VALKEY_URL=redis://valkey:6379" >>/opt/degoog/.env
+      grep -q "^DEGOOG_CACHE_MAX_ENTRIES=" /opt/degoog/.env && sed -i "s|^DEGOOG_CACHE_MAX_ENTRIES=.*|DEGOOG_CACHE_MAX_ENTRIES=1000|" /opt/degoog/.env || echo "DEGOOG_CACHE_MAX_ENTRIES=1000" >>/opt/degoog/.env
+      grep -q "^DEGOOG_CACHE_TTL_MS=" /opt/degoog/.env && sed -i "s|^DEGOOG_CACHE_TTL_MS=.*|DEGOOG_CACHE_TTL_MS=43200000|" /opt/degoog/.env || echo "DEGOOG_CACHE_TTL_MS=43200000" >>/opt/degoog/.env
+    fi
     msg_ok "Restored Configuration & Data"
 
     msg_info "Starting Service"

--- a/install/degoog-install.sh
+++ b/install/degoog-install.sh
@@ -16,7 +16,8 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   git \
-  unzip
+  unzip \
+  valkey
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Bun"
@@ -38,6 +39,9 @@ DEGOOG_PLUGINS_DIR=/opt/degoog/data/plugins
 DEGOOG_THEMES_DIR=/opt/degoog/data/themes
 DEGOOG_ALIASES_FILE=/opt/degoog/data/aliases.json
 DEGOOG_PLUGIN_SETTINGS_FILE=/opt/degoog/data/plugin-settings.json
+DEGOOG_VALKEY_URL=redis://valkey:6379
+DEGOOG_CACHE_MAX_ENTRIES=1000
+DEGOOG_CACHE_TTL_MS=43200000
 # DEGOOG_SETTINGS_PASSWORDS=changeme
 # DEGOOG_PUBLIC_INSTANCE=false
 # LOGGER=debug
@@ -62,11 +66,16 @@ EOF
 fi
 msg_ok "Set up degoog"
 
+msg_info "Starting Valkey Service"
+systemctl enable -q --now valkey-server
+msg_ok "Started Valkey Service"
+
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/degoog.service
 [Unit]
 Description=degoog
-After=network.target
+After=network.target valkey-server.service
+Wants=valkey-server.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## ✍️ Description
Enable Valkey-backed caching for Degoog by default during install. The installer now installs and starts `valkey-server`, writes the new cache environment defaults, and adds systemd ordering so Degoog starts with Valkey available.

## 🔗 Related Issue

Fixes #14864

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

