### PR TITLE
fix(workflow): only flag node drift when local is behind upstream

### DIFF
--- a/.github/workflows/check-node-versions.yml
+++ b/.github/workflows/check-node-versions.yml
@@ -336,14 +336,18 @@ jobs:
               issue_scripts+=("$slug|$our_version|$upstream_major|$upstream_hint|$repo")
               drift_count=$((drift_count + 1))
             elif [[ -n "$upstream_major" && "$our_version" != "$upstream_major" ]]; then
-              # Check if engines.node is a minimum constraint that our version satisfies
-              if [[ -z "$DF_NODE_MAJOR" && "$ENGINES_IS_MINIMUM" == "true" ]] && \
-                 version_satisfies_engines "$our_version" "$ENGINES_MIN_MAJOR" "$ENGINES_IS_MINIMUM"; then
-                status="✅ (engines: $ENGINES_NODE_RAW — ours: $our_version satisfies)"
+              if (( our_version < upstream_major )); then
+                # Check if engines.node is a minimum constraint that our version satisfies
+                if [[ -z "$DF_NODE_MAJOR" && "$ENGINES_IS_MINIMUM" == "true" ]] && \
+                   version_satisfies_engines "$our_version" "$ENGINES_MIN_MAJOR" "$ENGINES_IS_MINIMUM"; then
+                  status="✅ (engines: $ENGINES_NODE_RAW — ours: $our_version satisfies)"
+                else
+                  status="🔸 Drift → upstream=$upstream_major ($upstream_hint)"
+                  issue_scripts+=("$slug|$our_version|$upstream_major|$upstream_hint|$repo")
+                  drift_count=$((drift_count + 1))
+                fi
               else
-                status="🔸 Drift → upstream=$upstream_major ($upstream_hint)"
-                issue_scripts+=("$slug|$our_version|$upstream_major|$upstream_hint|$repo")
-                drift_count=$((drift_count + 1))
+                status="✅ Ahead of upstream ($upstream_major via $upstream_hint)"
               fi
             fi
 


### PR DESCRIPTION
## ✍️ Description

Update the Node.js version drift workflow so scripts are only flagged when our version is lower than upstream. This removes false-positive drift reports when our version is already equal or ahead.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to README, AppName.md, CONTRIBUTING.md, or other docs.