### PR TITLE
OpenThread-BR: preserve config during update

### DIFF
--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -47,6 +47,10 @@ function update_script() {
   systemctl stop otbr-agent
   msg_ok "Stopped Services"
 
+  msg_info "Backing up Configuration"
+  cp /etc/default/otbr-agent /etc/default/otbr-agent.bak
+  msg_ok "Backed up Configuration"
+
   msg_info "Updating Source"
   $STD git reset --hard origin/main
   $STD git submodule update --depth 1 --init --recursive
@@ -90,6 +94,10 @@ EOF
     $STD sysctl -p /etc/sysctl.d/99-otbr.conf
     msg_ok "Configured Network"
   fi
+
+  msg_info "Restoring Configuration"
+  mv /etc/default/otbr-agent.bak /etc/default/otbr-agent
+  msg_ok "Restored Configuration"
 
   msg_info "Starting Services"
   systemctl start otbr-agent


### PR DESCRIPTION
## ✍️ Description
Backes up and restores the config in `/etc/default/otbr-agent` during an update

## 🔗 Related Issue

Fixes #14892

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
