### PR TITLE
Fix OpenResty source release lookup for NPM

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -20,6 +20,85 @@ variables
 color
 catch_errors
 
+get_latest_openresty_release() {
+  local openresty_index
+  local release
+
+  if ! openresty_index=$(curl -fsSL --max-time 20 "https://openresty.org/download/"); then
+    msg_error "Unable to fetch OpenResty download index"
+    return 22
+  fi
+
+  release=$(grep -oE 'openresty-[0-9]+([.][0-9]+)*[.]tar[.]gz' <<<"$openresty_index" |
+    sed -E 's/^openresty-([0-9.]+)[.]tar[.]gz$/\1/' |
+    sort -V |
+    tail -n1)
+
+  if [[ -z "$release" ]]; then
+    msg_error "Unable to determine latest OpenResty release"
+    return 250
+  fi
+
+  echo "$release"
+}
+
+deploy_openresty_source() {
+  local release="$1"
+  local target="${2:-/opt/openresty}"
+  local tmpdir
+  local tarball
+
+  if [[ -z "$release" ]]; then
+    msg_error "OpenResty release is required"
+    return 65
+  fi
+
+  tmpdir=$(mktemp -d) || return 1
+  tarball="${tmpdir}/openresty-${release}.tar.gz"
+
+  msg_info "Fetching OpenResty (${release})"
+  if ! curl_download "$tarball" "https://openresty.org/download/openresty-${release}.tar.gz"; then
+    msg_error "Download failed: https://openresty.org/download/openresty-${release}.tar.gz"
+    rm -rf "$tmpdir"
+    return 250
+  fi
+
+  rm -rf "$target"
+  mkdir -p "$target"
+  if ! tar --no-same-owner --strip-components=1 -xzf "$tarball" -C "$target"; then
+    msg_error "Failed to extract OpenResty source"
+    rm -rf "$tmpdir"
+    return 251
+  fi
+
+  echo "$release" >"$HOME/.openresty"
+  rm -rf "$tmpdir"
+  msg_ok "Fetched OpenResty (${release})"
+}
+
+check_for_openresty_release() {
+  local current_file="$HOME/.openresty"
+  local current=""
+  local latest
+
+  msg_info "Checking for update: openresty"
+
+  latest=$(get_latest_openresty_release) || return
+  if [[ -f "$current_file" ]]; then
+    current="$(<"$current_file")"
+    [[ "$current" =~ ^v[0-9] ]] && current="${current:1}"
+  fi
+
+  if [[ -z "$current" || "$current" != "$latest" ]]; then
+    CHECK_UPDATE_RELEASE="$latest"
+    msg_ok "Update available: openresty ${current:-not installed} -> ${latest}"
+    return 0
+  fi
+
+  msg_ok "No update available: openresty (${latest})"
+  return 1
+}
+
 function update_script() {
   header_info
   check_container_storage
@@ -60,8 +139,8 @@ function update_script() {
   fi
   $STD apt install -y build-essential "$pcre_pkg" libssl-dev zlib1g-dev
 
-  if check_for_gh_release "openresty" "openresty/openresty"; then
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "openresty" "openresty/openresty" "prebuild" "${CHECK_UPDATE_RELEASE}" "/opt/openresty" "openresty-*.tar.gz"
+  if check_for_openresty_release; then
+    deploy_openresty_source "${CHECK_UPDATE_RELEASE}" "/opt/openresty"
 
     msg_info "Building OpenResty"
     cd /opt/openresty

--- a/install/nginxproxymanager-install.sh
+++ b/install/nginxproxymanager-install.sh
@@ -13,6 +13,62 @@ setting_up_container
 network_check
 update_os
 
+get_latest_openresty_release() {
+  local openresty_index
+  local release
+
+  if ! openresty_index=$(curl -fsSL --max-time 20 "https://openresty.org/download/"); then
+    msg_error "Unable to fetch OpenResty download index"
+    return 22
+  fi
+
+  release=$(grep -oE 'openresty-[0-9]+([.][0-9]+)*[.]tar[.]gz' <<<"$openresty_index" |
+    sed -E 's/^openresty-([0-9.]+)[.]tar[.]gz$/\1/' |
+    sort -V |
+    tail -n1)
+
+  if [[ -z "$release" ]]; then
+    msg_error "Unable to determine latest OpenResty release"
+    return 250
+  fi
+
+  echo "$release"
+}
+
+deploy_openresty_source() {
+  local release="$1"
+  local target="${2:-/opt/openresty}"
+  local tmpdir
+  local tarball
+
+  if [[ -z "$release" ]]; then
+    msg_error "OpenResty release is required"
+    return 65
+  fi
+
+  tmpdir=$(mktemp -d) || return 1
+  tarball="${tmpdir}/openresty-${release}.tar.gz"
+
+  msg_info "Fetching OpenResty (${release})"
+  if ! curl_download "$tarball" "https://openresty.org/download/openresty-${release}.tar.gz"; then
+    msg_error "Download failed: https://openresty.org/download/openresty-${release}.tar.gz"
+    rm -rf "$tmpdir"
+    return 250
+  fi
+
+  rm -rf "$target"
+  mkdir -p "$target"
+  if ! tar --no-same-owner --strip-components=1 -xzf "$tarball" -C "$target"; then
+    msg_error "Failed to extract OpenResty source"
+    rm -rf "$tmpdir"
+    return 251
+  fi
+
+  echo "$release" >"$HOME/.openresty"
+  rm -rf "$tmpdir"
+  msg_ok "Fetched OpenResty (${release})"
+}
+
 msg_info "Installing Dependencies"
 $STD apt install -y \
   apache2-utils \
@@ -36,7 +92,8 @@ $STD /opt/certbot/bin/pip install certbot certbot-dns-cloudflare
 ln -sf /opt/certbot/bin/certbot /usr/local/bin/certbot
 msg_ok "Set up Certbot"
 
-fetch_and_deploy_gh_release "openresty" "openresty/openresty" "prebuild" "latest" "/opt/openresty" "openresty-*.tar.gz"
+openresty_release=$(get_latest_openresty_release)
+deploy_openresty_source "$openresty_release" "/opt/openresty"
 
 msg_info "Building OpenResty"
 cd /opt/openresty


### PR DESCRIPTION
## Summary
- fetch OpenResty source releases from https://openresty.org/download/ instead of stale GitHub release metadata
- compare NPM update checks against the same official OpenResty source index
- preserve the existing ~/.openresty version marker for install/update compatibility

Fixes #14924

## Testing
- `bash -n install/nginxproxymanager-install.sh ct/nginxproxymanager.sh`
- `git diff --check`
- parsed https://openresty.org/download/ and resolved latest OpenResty to `1.29.2.5`
- verified an existing `~/.openresty` marker of `1.27.1.2` reports `CHECK_UPDATE_RELEASE=1.29.2.5`
- downloaded and extracted `openresty-1.29.2.5.tar.gz` into a temporary target and confirmed the extracted source recorded `1.29.2.5`
