### PR TITLE
AMD IGPU support

### DIFF
--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -89,7 +89,6 @@ msg_ok "Created ollama User and adjusted Groups"
 setup_hwaccel "ollama"
 
 msg_info "Creating Service"
-
 cat <<EOF >/etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service
@@ -100,7 +99,6 @@ Type=exec
 ExecStart=/usr/local/bin/ollama serve
 Environment=HOME=$HOME
 Environment=OLLAMA_INTEL_GPU=true
-Environment=OLLAMA_IGPU_ENABLE=1
 Environment=OLLAMA_HOST=0.0.0.0
 Environment=OLLAMA_NUM_GPU=999
 Environment=SYCL_CACHE_PERSISTENT=1

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -69,6 +69,13 @@ if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest
   msg_error "Failed to download or deploy Ollama – check network connectivity and GitHub API availability"
   exit 250
 fi
+# If /dev/kfd exists assume an AMD GPU is installed, and install ROCM support for ollama
+if [[ -e /dev/kfd ]]; then
+  if ! fetch_and_deploy_gh_release "ollama-rocm-com" "ollama/ollama" "prebuild" "latest" "$OLLAMA_INSTALL_DIR/lib" "ollama-linux-amd64-rocm.tar.zst"; then
+    msg_error "Failed to download or deploy Ollama AMD ROCM suport – check network connectivity and GitHub API availability"
+    exit 250
+  fi
+fi
 ln -sf "$OLLAMA_INSTALL_DIR/bin/ollama" "$BINDIR/ollama"
 msg_ok "Installed Ollama"
 
@@ -82,7 +89,30 @@ msg_ok "Created ollama User and adjusted Groups"
 setup_hwaccel "ollama"
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/ollama.service
+if [[ -e /dev/kfd ]]; then
+  cat <<EOF >/etc/systemd/system/ollama.service
+[Unit]
+Description=Ollama Service
+After=network-online.target
+
+[Service]
+Type=exec
+ExecStart=/usr/local/bin/ollama serve
+Environment=HOME=$HOME
+Environment=OLLAMA_INTEL_GPU=true
+Environment=OLLAMA_IGPU_ENABLE=1
+Environment=OLLAMA_HOST=0.0.0.0
+Environment=OLLAMA_NUM_GPU=999
+Environment=SYCL_CACHE_PERSISTENT=1
+Environment=ZES_ENABLE_SYSMAN=1
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+else
+    cat <<EOF >/etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service
 After=network-online.target
@@ -102,6 +132,7 @@ RestartSec=3
 [Install]
 WantedBy=multi-user.target
 EOF
+fi
 systemctl enable -q --now ollama
 msg_ok "Created Service"
 

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -89,8 +89,8 @@ msg_ok "Created ollama User and adjusted Groups"
 setup_hwaccel "ollama"
 
 msg_info "Creating Service"
-if [[ -e /dev/kfd ]]; then
-  cat <<EOF >/etc/systemd/system/ollama.service
+
+cat <<EOF >/etc/systemd/system/ollama.service
 [Unit]
 Description=Ollama Service
 After=network-online.target
@@ -111,27 +111,9 @@ RestartSec=3
 [Install]
 WantedBy=multi-user.target
 EOF
-else
-    cat <<EOF >/etc/systemd/system/ollama.service
-[Unit]
-Description=Ollama Service
-After=network-online.target
-
-[Service]
-Type=exec
-ExecStart=/usr/local/bin/ollama serve
-Environment=HOME=$HOME
-Environment=OLLAMA_INTEL_GPU=true
-Environment=OLLAMA_HOST=0.0.0.0
-Environment=OLLAMA_NUM_GPU=999
-Environment=SYCL_CACHE_PERSISTENT=1
-Environment=ZES_ENABLE_SYSMAN=1
-Restart=always
-RestartSec=3
-
-[Install]
-WantedBy=multi-user.target
-EOF
+if [[ -e /dev/kfd ]]; then
+  sed -i '/Environment=OLLAMA_INTEL_GPU=true/a Environment=OLLAMA_IGPU_ENABLE=1' \
+      /etc/systemd/system/ollama.service
 fi
 systemctl enable -q --now ollama
 msg_ok "Created Service"

--- a/misc/build.func
+++ b/misc/build.func
@@ -3982,7 +3982,7 @@ $PCT_OPTIONS_STRING"
       if [[ -d /dev/dri ]]; then
         # Only add if not already claimed by Intel
         if [[ ${#INTEL_DEVICES[@]} -eq 0 ]]; then
-          for d in /dev/dri/renderD* /dev/dri/card*; do
+          for d in /dev/dri/renderD* /dev/dri/card* /dev/kfd; do
             [[ -e "$d" ]] && AMD_DEVICES+=("$d")
           done
         fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Add support for AMD IGPU

Present /dev/kfd to guest to enable ROCM
Add Ollama ROCM support if /dev/kfd detected
Enable IGPU support if /dev/kfd detected 

## 🔗 Related Issue

Fixes #

Test results from clean build:
root@test:~# journalctl -u ollama.service 
Jun 04 15:20:27 test systemd[1]: Starting ollama.service - Ollama Service...
Jun 04 15:20:27 test systemd[1]: Started ollama.service - Ollama Service.
Jun 04 15:20:27 test ollama[13646]: Couldn't find '/root/.ollama/id_ed25519'. Generating new private key.
Jun 04 15:20:27 test ollama[13646]: Your new public key is:
Jun 04 15:20:27 test ollama[13646]: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJbZKgpxNuq2JLtN9kgoBSdgug0MJ9CWdjDvpPr+HTNt
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.356-04:00 level=INFO source=routes.go:1919 msg="server config" env="map[CUDA_VISIBLE_DEVICES: GGML_VK_VISIBLE_DEVICES: GPU_DEVICE_ORDINAL: HIP_VISIBLE_DEVICES: HSA_OVERRIDE_GFX_VERSION: HTTPS_PROXY: HTTP_PROXY: LLAMA_ARG_FIT: LLAMA_ARG_FIT_TARGET: NO_PROXY: OLLA>
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.356-04:00 level=INFO source=routes.go:1921 msg="Ollama cloud disabled: false"
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.356-04:00 level=INFO source=images.go:864 msg="total blobs: 0"
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.356-04:00 level=INFO source=images.go:871 msg="total unused blobs removed: 0"
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.357-04:00 level=INFO source=routes.go:1981 msg="Listening on [::]:11434 (version 0.30.4)"
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.358-04:00 level=INFO source=model_list_cache.go:111 msg="model list cache hydration complete" models=0 failures=0 elapsed=399.36µs
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.360-04:00 level=INFO source=runner.go:60 msg="discovering available GPUs..."
Jun 04 15:20:27 test ollama[13646]: time=2026-06-04T15:20:27.426-04:00 level=INFO source=model_recommendations.go:177 msg="model recommendations cache sleep scheduled" wait=3h16m6.031955002s consecutive_failures=0
Jun 04 15:20:28 test ollama[13646]: time=2026-06-04T15:20:28.175-04:00 level=INFO source=types.go:32 msg="inference compute" id=0 filter_id=0 library=ROCm compute=gfx1150 name=ROCm0 description="AMD Radeon 890M Graphics" libdirs=ollama,rocm_v7_2 driver=0.0 pci_id=0000:c6:00.0 type=iGPU total="32.0 GiB" available="3.9 GiB"
Jun 04 15:20:28 test ollama[13646]: time=2026-06-04T15:20:28.175-04:00 level=INFO source=routes.go:2031 msg="vram-based default context" total_vram="32.0 GiB" default_num_ctx=32768

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
