### PR TITLE
Photoprism: Allow env variables with spaces

### DIFF
--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -37,7 +37,9 @@ function update_script() {
     if ! grep -q "photoprism/config/.env" ~/.bashrc 2>/dev/null; then
       msg_info "Adding environment export for CLI tools"
       echo '# Load PhotoPrism environment variables for CLI tools' >>~/.bashrc
-      echo 'export $(grep -v "^#" /opt/photoprism/config/.env | xargs)' >>~/.bashrc
+      echo 'set -a' >>~/.bashrc
+      echo 'source /opt/photoprism/config/.env' >>~/.bashrc
+      echo 'set +a' >>~/.bashrc
       msg_ok "Added environment export"
     fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
In https://github.com/community-scripts/ProxmoxVE/pull/10023/commits/95dd153d81f96abfef26d6b3997dad3ff5469b05 the syntax used to export env variables, using xargs, broke with variables containing spaces, e.g. standard crontab syntax for a variable like PHOTOPRISM_INDEX_SCHEDULE. This small change should solve that.


## 🔗 Related Issue

Fixes #9962 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
