### PR TITLE
changedetection: migrate Python install to uv venv

### DIFF
--- a/ct/changedetection.sh
+++ b/ct/changedetection.sh
@@ -34,13 +34,32 @@ function update_script() {
 
   NODE_VERSION="24" setup_nodejs
 
-  msg_info "Updating ${APP}"
-  $STD pip3 install changedetection.io --upgrade --break-system-packages --ignore-installed typing_extensions
-  msg_ok "Updated ${APP}"
+  VENV_PATH="/opt/changedetection/.venv"
+  CHANGEDETECTION_BIN="${VENV_PATH}/bin/changedetection.io"
 
-  msg_info "Updating Playwright"
-  $STD pip3 install playwright --upgrade --break-system-packages
-  msg_ok "Updated Playwright"
+  PYTHON_VERSION="3.13" setup_uv
+
+  if [[ ! -d "$VENV_PATH" || ! -x "$CHANGEDETECTION_BIN" ]]; then
+    msg_info "Migrating to uv/venv"
+    rm -rf "$VENV_PATH"
+    $STD uv venv --clear "$VENV_PATH"
+    $STD "$VENV_PATH/bin/python" -m ensurepip --upgrade
+    $STD "$VENV_PATH/bin/python" -m pip install --upgrade pip
+    $STD "$VENV_PATH/bin/python" -m pip install changedetection.io playwright
+    msg_ok "Migrated to uv/venv"
+  else
+    msg_info "Updating ${APP}"
+    $STD "$VENV_PATH/bin/python" -m pip install --upgrade changedetection.io playwright
+    msg_ok "Updated ${APP}"
+  fi
+
+  SERVICE_FILE="/etc/systemd/system/changedetection.service"
+  if ! grep -q "${VENV_PATH}/bin/changedetection.io" "$SERVICE_FILE"; then
+    msg_info "Updating systemd service"
+    sed -i "s|^ExecStart=.*|ExecStart=${VENV_PATH}/bin/changedetection.io -d /opt/changedetection -p 5000|" "$SERVICE_FILE"
+    $STD systemctl daemon-reload
+    msg_ok "Updated systemd service"
+  fi
 
   if [[ -f /etc/systemd/system/browserless.service ]]; then
     msg_info "Updating Browserless (Patience)"

--- a/install/changedetection-install.sh
+++ b/install/changedetection-install.sh
@@ -43,19 +43,16 @@ $STD apt-get install -y \
   ca-certificates
 msg_ok "Installed Dependencies"
 
-msg_info "Setup Python3"
-$STD apt-get install -y \
-  python3 \
-  python3-dev \
-  python3-pip
-rm -rf /usr/lib/python3.*/EXTERNALLY-MANAGED
-msg_ok "Setup Python3"
+PYTHON_VERSION="3.13" setup_uv
 
 NODE_VERSION="24" setup_nodejs
 
 msg_info "Installing Change Detection"
-mkdir /opt/changedetection
-$STD pip3 install changedetection.io
+mkdir -p /opt/changedetection
+$STD uv venv --clear /opt/changedetection/.venv
+$STD /opt/changedetection/.venv/bin/python -m ensurepip --upgrade
+$STD /opt/changedetection/.venv/bin/python -m pip install --upgrade pip
+$STD /opt/changedetection/.venv/bin/python -m pip install changedetection.io
 cat <<EOF >/opt/changedetection/.env
 WEBDRIVER_URL=http://127.0.0.1:4444/wd/hub
 PLAYWRIGHT_DRIVER_URL=ws://localhost:3000/chrome?launch=eyJkZWZhdWx0Vmlld3BvcnQiOnsiaGVpZ2h0Ijo3MjAsIndpZHRoIjoxMjgwfSwiaGVhZGxlc3MiOmZhbHNlLCJzdGVhbHRoIjp0cnVlfQ==&blockAds=true
@@ -64,7 +61,7 @@ msg_ok "Installed Change Detection"
 
 msg_info "Installing Browserless & Playwright"
 mkdir /opt/browserless
-$STD python3 -m pip install playwright
+$STD /opt/changedetection/.venv/bin/python -m pip install playwright
 $STD git clone https://github.com/browserless/chrome /opt/browserless
 $STD npm ci --include=optional --include=dev --prefix /opt/browserless
 $STD /opt/browserless/node_modules/playwright-core/cli.js install --with-deps &>/dev/null
@@ -121,7 +118,7 @@ Wants=browserless.service
 Type=simple
 EnvironmentFile=/opt/changedetection/.env
 WorkingDirectory=/opt/changedetection
-ExecStart=changedetection.io -d /opt/changedetection -p 5000
+ExecStart=/opt/changedetection/.venv/bin/changedetection.io -d /opt/changedetection -p 5000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## ✍️ Description

Migrates the changedetection Python install from the global interpreter to an isolated `uv` venv (`/opt/changedetection/.venv`), following the existing `setup_uv` + venv-or-migrate pattern already used by `prometheus-pve-exporter` and `esphome`.

**Why:** the current update path runs

```bash
pip3 install changedetection.io --upgrade --break-system-packages --ignore-installed typing_extensions
```

`--ignore-installed` is a global flag (not scoped to `typing_extensions`), so pip installs new versions of **every** resolved dependency without removing the previous ones. Each version bump leaves a stale `*.dist-info` behind; pip then resolves against stale metadata (e.g. downgrades `pydantic-core` to match an old phantom `pydantic` record) and the service crashes **at the next restart** — a deferred failure that looks unrelated to the update. Full diagnosis with real-world evidence (46 packages with duplicate dist-info on a routinely-updated CT) in #14987.

**What this PR does:**

- `install/changedetection-install.sh`: `PYTHON_VERSION="3.13" setup_uv` + venv install; drops the `EXTERNALLY-MANAGED` removal and the apt python3-pip dependency; systemd `ExecStart` points to the venv binary.
- `ct/changedetection.sh` (update): if the venv is missing → one-time automatic migration (create venv, install `changedetection.io` + `playwright`); otherwise plain venv upgrade. The systemd unit is repointed to the venv binary when needed (`sed` on `ExecStart` + `daemon-reload`). No more `--break-system-packages` / `--ignore-installed` — in a venv there is no Debian-owned `typing_extensions` to conflict with, so this also fixes the root cause behind #13548.
- The polluted global site-packages of existing installs is left in place (inert once nothing uses it) — safer than trying to clean system Python.
- Browserless handling is untouched.

**Testing done (transparency):**

- Migration command sequence validated in a fresh Debian 13 container: venv created (Python 3.13.13 via uv), `changedetection.io --help` runs, `pip check` clean.
- The target runtime layout (`/opt/changedetection/.venv` + venv `ExecStart`, with `playwright` installed for the browserless fetcher) is what I run in production on my own CT — that part is battle-tested.
- I did **not** run a full fresh-CT install through the script pipeline (no ProxmoxVED setup here). Happy to iterate if the CI/test run flags anything.

## 🔗 Related Issue

Fixes #14987

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Migration sequence tested in a clean Debian 13 container + target layout running in production (see Testing notes above; no fresh-CT pipeline run).
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
