### PR TITLE
homelable: preserve MCP server config across updates

### DIFF
--- a/ct/homelable.sh
+++ b/ct/homelable.sh
@@ -38,6 +38,12 @@ function update_script() {
     msg_info "Backing up Configuration and Data"
     cp /opt/homelable/backend/.env /opt/homelable.env.bak
     cp -r /opt/homelable/data /opt/homelable_data_bak
+    # Preserve the optional MCP server config (installed separately via
+    # Pouzor/homelable scripts/lxc-mcp-install.sh). Its .env and .venv live
+    # under /opt/homelable/mcp and are wiped by the CLEAN_INSTALL deploy below.
+    if [[ -f /opt/homelable/mcp/.env ]]; then
+      cp -a /opt/homelable/mcp/.env /opt/homelable-mcp.env.bak
+    fi
     msg_ok "Backed up Configuration and Data"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homelable" "Pouzor/homelable" "tarball" "latest" "/opt/homelable"
@@ -60,6 +66,19 @@ function update_script() {
     rm -f /opt/homelable.env.bak
     rm -rf /opt/homelable_data_bak
     msg_ok "Restored Configuration and Data"
+
+    if [[ -f /opt/homelable-mcp.env.bak ]]; then
+      msg_info "Restoring MCP Server"
+      cp -a /opt/homelable-mcp.env.bak /opt/homelable/mcp/.env
+      rm -f /opt/homelable-mcp.env.bak
+      MCP_OWNER=$(stat -c '%U' /opt/homelable/mcp/.env)
+      cd /opt/homelable/mcp
+      $STD uv venv --clear /opt/homelable/mcp/.venv
+      $STD uv pip install --python /opt/homelable/mcp/.venv/bin/python -r requirements.txt
+      chown -R "$MCP_OWNER":"$MCP_OWNER" /opt/homelable/mcp
+      systemctl restart homelable-mcp
+      msg_ok "Restored MCP Server"
+    fi
 
     msg_info "Starting Service"
     systemctl start homelable

--- a/ct/homelable.sh
+++ b/ct/homelable.sh
@@ -38,9 +38,6 @@ function update_script() {
     msg_info "Backing up Configuration and Data"
     cp /opt/homelable/backend/.env /opt/homelable.env.bak
     cp -r /opt/homelable/data /opt/homelable_data_bak
-    # Preserve the optional MCP server config (installed separately via
-    # Pouzor/homelable scripts/lxc-mcp-install.sh). Its .env and .venv live
-    # under /opt/homelable/mcp and are wiped by the CLEAN_INSTALL deploy below.
     if [[ -f /opt/homelable/mcp/.env ]]; then
       cp -a /opt/homelable/mcp/.env /opt/homelable-mcp.env.bak
     fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

`ct/homelable.sh`'s `update_script` deploys with `CLEAN_INSTALL=1 fetch_and_deploy_gh_release ... /opt/homelable`, which **wipes the whole `/opt/homelable` directory** before extracting the new release. The surrounding backup/restore only covers `backend/.env` and `data/`.

Homelable ships an **optional MCP server** that is installed separately via the project's own `scripts/lxc-mcp-install.sh` — a script explicitly written for this LXC, which creates `/opt/homelable/mcp/.env` + `/opt/homelable/mcp/.venv` and a `homelable-mcp` systemd unit. Because `mcp/.env` and `mcp/.venv` are gitignored (so absent from the release tarball) and not part of the backup set, **every update silently destroys them**. The dashboard (`:3000`) and backend (`:8000`) keep working, so it goes unnoticed — but the `homelable-mcp` service then runs on deleted inodes and fails at the next restart / reboot.

I hit this twice on my own LXC (CT running the community-scripts install + the MCP added via Pouzor's `lxc-mcp-install.sh`).

**What this PR does** — fully conditional, so installs without the MCP are untouched:

- **Backup:** if `/opt/homelable/mcp/.env` exists, `cp -a` it to `/opt/homelable-mcp.env.bak` (preserving ownership/permissions) before the clean deploy.
- **Restore:** if that backup exists, restore `mcp/.env`, rebuild the venv with the **same `uv` pattern already used for the backend** (`uv venv --clear` + `uv pip install -r requirements.txt`), restore ownership (`chown` to the `.env` owner — handles both `root` and a dedicated `homelable` service user), and `systemctl restart homelable-mcp`.

The MCP source code itself comes back with the release tarball; only the gitignored `.env`/`.venv` need re-provisioning.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards (mirrors the existing backend `uv venv`/`uv pip install` lines and the surrounding backup/restore style).
- [ ] **Tested thoroughly** – The MCP venv-rebuild sequence (`uv venv --clear` + `uv pip install -r requirements.txt` on the real `mcp/requirements.txt`) was validated in a clean Debian 13 container: Python 3.13 venv, `uvicorn` present, all MCP imports resolve. The full update path was **not** run end-to-end through ProxmoxVED. Backup/restore logic is a straightforward conditional `cp`/rebuild. Happy to iterate.
- [x] **No security risks** – No hardcoded secrets; `cp -a` preserves the `.env` permissions; ownership is restored to the original.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
