### PR TITLE
Fix for cross-seed after node upgrade

### DIFF
--- a/ct/cross-seed.sh
+++ b/ct/cross-seed.sh
@@ -25,7 +25,7 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  NODE_VERSION="26" setup_nodejs
+  NODE_VERSION="24" setup_nodejs
   ensure_dependencies build-essential
 
   if command -v cross-seed &>/dev/null; then

--- a/install/cross-seed-install.sh
+++ b/install/cross-seed-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="26" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 
 msg_info "Setup Cross-Seed"
 $STD npm install cross-seed@latest -g


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Looks like the root cause of the issue listed below is that an optional dependency of `knex` has a node-gyp build step that uses deprecated V8 methods that were removed in node 26. To fix, I bumped node back down to 24. An alternate fix would be to add `--no-optional` to the `npm i`, but seems riskier, and since this is a regression, makes more sense to me to go back to a version that worked. Not sure how you like to document pinned versions of things, but I'm happy to add a comment somewhere explaining why it's pinned (couldn't locate the json files mentioned in the readme).

## 🔗 Related Issue
https://github.com/community-scripts/ProxmoxVE/issues/14907
https://github.com/community-scripts/ProxmoxVE/issues/14914

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
