### PR TITLE
fix(vaultwarden): verify binary after compile and detect version cache desync

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -37,7 +37,64 @@ function update_script() {
     "2" "Set Admin Token")
 
   if [ "$UPD" == "1" ]; then
+    # Version cache written by fetch_and_deploy_gh_release (see misc/tools.func).
+    VW_CACHE="$HOME/.vaultwarden"
+
+    # Resolve the installed binary location (layout differs between installs).
+    if [[ -x /usr/bin/vaultwarden ]]; then
+      VW_BIN="/usr/bin/vaultwarden"
+    elif [[ -x /opt/vaultwarden/bin/vaultwarden ]]; then
+      VW_BIN="/opt/vaultwarden/bin/vaultwarden"
+    else
+      VW_BIN=""
+    fi
+
+    # Returns the installed binary's reported version (x.y.z), empty on failure.
+    vw_installed_version() {
+      [[ -n "$1" && -x "$1" ]] || return 0
+      "$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+    }
+
+    # Abort an in-flight update: invalidate the (possibly stale) version cache so
+    # the next run retries, clean the build dir, bring the previously-running
+    # service back up, and exit non-zero.
+    vw_abort_update() {
+      msg_error "$1"
+      rm -f "$VW_CACHE"
+      cd ~ && rm -rf /tmp/vaultwarden-src
+      msg_info "Starting Service"
+      systemctl start vaultwarden
+      msg_ok "Started Service"
+      exit 1
+    }
+
+    NEEDS_UPDATE=0
     if check_for_gh_release "vaultwarden" "dani-garcia/vaultwarden"; then
+      NEEDS_UPDATE=1
+    else
+      # Cache repair guard. check_for_gh_release reports "up to date" purely from
+      # the cached version in /root/.vaultwarden, which fetch_and_deploy_gh_release
+      # writes when it extracts the source tarball - BEFORE the cargo build that
+      # actually produces the binary. If a previous compile failed mid-flight, the
+      # cache can claim the new version while the old binary is still installed.
+      # Cross-check the cache against the running binary and force an update on a
+      # mismatch instead of silently skipping it.
+      INSTALLED_VER="$(vw_installed_version "$VW_BIN")"
+      CACHED_VER=""
+      [[ -f "$VW_CACHE" ]] && CACHED_VER="$(<"$VW_CACHE")"
+      CACHED_VER="${CACHED_VER#v}"
+
+      if [[ -n "$CACHED_VER" && -n "$INSTALLED_VER" && "$CACHED_VER" != "$INSTALLED_VER" ]]; then
+        msg_warn "Version cache desync: cache reports ${CACHED_VER} but installed binary is ${INSTALLED_VER}"
+        msg_warn "A previous compile likely failed after the cache was written - forcing update"
+        rm -f "$VW_CACHE"
+        NEEDS_UPDATE=1
+      else
+        msg_ok "VaultWarden is already up-to-date"
+      fi
+    fi
+
+    if [[ "$NEEDS_UPDATE" == "1" ]]; then
       msg_info "Stopping Service"
       systemctl stop vaultwarden
       msg_ok "Stopped Service"
@@ -49,19 +106,35 @@ function update_script() {
       VW_VERSION="$VAULT"
       export VW_VERSION
       $STD cargo build --features "sqlite,mysql,postgresql" --release
+
+      # Verify the freshly built artifact BEFORE replacing the running binary, so
+      # an interrupted or silently-failed compile cannot leave a broken install.
+      BUILT_BIN="target/release/vaultwarden"
+      [[ -x "$BUILT_BIN" ]] || vw_abort_update "Build artifact missing or not executable: ${BUILT_BIN}"
+      BUILT_VER="$(vw_installed_version "$BUILT_BIN")"
+      [[ -n "$BUILT_VER" && "$BUILT_VER" == "$VAULT" ]] ||
+        vw_abort_update "Built binary version mismatch: expected ${VAULT}, got ${BUILT_VER:-unknown}"
+
+      # Preserve the existing install layout when copying.
       if [[ -f /usr/bin/vaultwarden ]]; then
-        cp target/release/vaultwarden /usr/bin/
+        INSTALL_TARGET="/usr/bin/vaultwarden"
       else
-        cp target/release/vaultwarden /opt/vaultwarden/bin/
+        INSTALL_TARGET="/opt/vaultwarden/bin/vaultwarden"
       fi
+      cp "$BUILT_BIN" "$INSTALL_TARGET"
+
+      # Re-verify the installed copy before restarting the service.
+      [[ -x "$INSTALL_TARGET" ]] || vw_abort_update "Installed binary is not executable: ${INSTALL_TARGET}"
+      INSTALLED_VER="$(vw_installed_version "$INSTALL_TARGET")"
+      [[ "$INSTALLED_VER" == "$VAULT" ]] ||
+        vw_abort_update "Installed binary version mismatch: expected ${VAULT}, got ${INSTALLED_VER:-unknown}"
+
       cd ~ && rm -rf /tmp/vaultwarden-src
       msg_ok "Updated VaultWarden to ${VAULT}"
 
       msg_info "Starting Service"
       systemctl start vaultwarden
       msg_ok "Started Service"
-    else
-      msg_ok "VaultWarden is already up-to-date"
     fi
 
     if check_for_gh_release "vaultwarden_webvault" "dani-garcia/bw_web_builds"; then


### PR DESCRIPTION
## Summary
The Vaultwarden update path (menu option 1) compiles Vaultwarden from source with `cargo build`. Two related gaps mean a failed or interrupted compile can silently leave a broken or stale instance running. This PR adds build/install verification and a version-cache repair guard.

## Background: how the version cache works
`check_for_gh_release` (in `misc/tools.func`) decides whether an update is needed by comparing GitHub's latest release against a cached version string in `$HOME/.vaultwarden` (i.e. `/root/.vaultwarden`). That cache file is **not** written by the vaultwarden script — it is written by `fetch_and_deploy_gh_release` (`misc/tools.func:4029`) at the moment it extracts the **source tarball** into `/tmp/vaultwarden-src`. Crucially, that happens *before* the script runs `cargo build` to actually produce the binary.

## Bug 1 — Version cache desync after a failed compile
1. `check_for_gh_release` sees an update is available.
2. `fetch_and_deploy_gh_release ... tarball ...` downloads/extracts the source **and writes `/root/.vaultwarden` = new version**.
3. `cargo build` runs. If it fails, is killed (OOM), or the container is interrupted mid-flight, the binary is **never replaced**.
4. On the next run, `check_for_gh_release` reads `/root/.vaultwarden`, sees it already matches latest, reports "up to date", and skips the update permanently — the old/broken binary keeps running silently.

## Bug 2 — No binary verification after compile
After `cargo build`, the script copied `target/release/vaultwarden` into place without checking that the artifact existed, was executable, or reported the expected version. A partial/corrupt/silent build failure went undetected and got installed.

## Fixes
**a. Verify the built artifact before replacing the running binary** — confirm `target/release/vaultwarden` exists and is executable, run `--version`, confirm it matches `$VAULT`. On failure: clear error, do not copy, invalidate `/root/.vaultwarden` so the next run retries, restart the previously-running service, exit non-zero.

**b. Re-verify the installed copy before restart** — after copying to the install target (`/usr/bin/vaultwarden` or `/opt/vaultwarden/bin/vaultwarden`, preserving existing layout), re-run `--version` on the installed binary and confirm it matches `$VAULT` before starting the service. Same abort/rollback on mismatch.

**c. Cache repair guard** — when `check_for_gh_release` reports "up to date", cross-check the cached version in `/root/.vaultwarden` against the running binary's `--version`. On mismatch (the Bug 1 signature) it warns, clears the cache, and proceeds with the update instead of skipping it.

## Scope / non-goals
No changes to the web-vault update path, the Set Admin Token option, the menu structure, the `cargo build` feature flags, or any helper in `misc/`.

## Validation
- `shellcheck ct/vaultwarden.sh` — clean (only the repo-wide SC1090 on the runtime `source <(curl ...)` line).
- `bash -n ct/vaultwarden.sh` — syntax OK.
- `shfmt -i 2 -ci` — no diff.