### PR TITLE
Vaultwarden: extend version check for VaultWarden update

### DIFF
--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -37,6 +37,11 @@ function update_script() {
     "2" "Set Admin Token")
 
   if [ "$UPD" == "1" ]; then
+    INSTALLED_VERSION="$(cd /opt/vaultwarden && ./bin/vaultwarden --version 2>/dev/null | awk '{print $2}')"
+    if [[ -n "$INSTALLED_VERSION" ]] &&
+      ! grep -qxF "$INSTALLED_VERSION" "$HOME/.vaultwarden" 2>/dev/null; then
+      printf '%s\n' "$INSTALLED_VERSION" >"$HOME/.vaultwarden"
+    fi
     if check_for_gh_release "vaultwarden" "dani-garcia/vaultwarden"; then
       msg_info "Stopping Service"
       systemctl stop vaultwarden

--- a/ct/vaultwarden.sh
+++ b/ct/vaultwarden.sh
@@ -37,7 +37,7 @@ function update_script() {
     "2" "Set Admin Token")
 
   if [ "$UPD" == "1" ]; then
-    INSTALLED_VERSION="$(cd /opt/vaultwarden && ./bin/vaultwarden --version 2>/dev/null | awk '{print $2}')"
+    INSTALLED_VERSION="$(/opt/vaultwarden/bin/vaultwarden --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
     if [[ -n "$INSTALLED_VERSION" ]] &&
       ! grep -qxF "$INSTALLED_VERSION" "$HOME/.vaultwarden" 2>/dev/null; then
       printf '%s\n' "$INSTALLED_VERSION" >"$HOME/.vaultwarden"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
If the update fails and user had an old version the gh_release* function write the correct version inside. Now on update we check the old Version of binary too
1 of 1000 Case.

## 🔗 Related Issue

Fixes #15103

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
