### PR TITLE
fix(romm): resolve 403 Forbidden error on nginx mod_zip installation

### DIFF
--- a/ct/romm.sh
+++ b/ct/romm.sh
@@ -59,8 +59,13 @@ function update_script() {
     ROMM_BASE=${ROMM_BASE:-/var/lib/romm}
     ln -sfn "$ROMM_BASE"/resources /opt/romm/frontend/dist/assets/romm/resources
     ln -sfn "$ROMM_BASE"/assets /opt/romm/frontend/dist/assets/romm/assets
-    sed -i "s|alias .*/library/;|alias ${ROMM_BASE}/library/;|" /etc/nginx/sites-available/romm
-    systemctl reload nginx
+    if [[ -f /etc/angie/http.d/romm.conf ]]; then
+      sed -i "s|alias .*/library/;|alias ${ROMM_BASE}/library/;|" /etc/angie/http.d/romm.conf
+      systemctl reload angie
+    elif [[ -f /etc/nginx/sites-available/romm ]]; then
+      sed -i "s|alias .*/library/;|alias ${ROMM_BASE}/library/;|" /etc/nginx/sites-available/romm
+      systemctl reload nginx
+    fi
     msg_ok "Updated ROMM"
 
     msg_info "Starting Services"

--- a/ct/romm.sh
+++ b/ct/romm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: MickLesk (CanbiZ) | DevelopmentCats | AlphaLawless
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/ct/romm.sh
+++ b/ct/romm.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-source <(curl -s https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/misc/build.func)
+source <(curl -s https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
 # Copyright (c) 2021-2026 community-scripts ORG
 # Author: MickLesk (CanbiZ) | DevelopmentCats | AlphaLawless
 # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -43,20 +43,18 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
+$STD apt-get install -y libpcre3-dev libpcre2-dev
 cd /tmp
 $STD git clone https://github.com/evanmiller/mod_zip.git
 NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)
 $STD wget -q http://nginx.org/download/nginx-${NGINX_VER}.tar.gz
 $STD tar -zxvf nginx-${NGINX_VER}.tar.gz
 cd nginx-${NGINX_VER}
-$STD ./configure --with-compat --without-http_rewrite_module --add-dynamic-module=/tmp/mod_zip
+$STD ./configure --with-compat --add-dynamic-module=/tmp/mod_zip
 $STD make modules
 
-# Création d'un dossier personnalisé indépendant
 $STD mkdir -p /etc/nginx/custom-modules
 $STD cp objs/ngx_http_zip_module.so /etc/nginx/custom-modules/
-
-# Activation via le chemin absolu
 $STD mkdir -p /etc/nginx/modules-enabled
 echo "load_module /etc/nginx/custom-modules/ngx_http_zip_module.so;" > /etc/nginx/modules-enabled/50-mod-http-zip.conf
 msg_ok "Installed Nginx mod_zip module"

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -51,6 +51,11 @@ $STD tar -zxvf nginx-${NGINX_VER}.tar.gz
 cd nginx-${NGINX_VER}
 $STD ./configure --with-compat --without-http_rewrite_module --add-dynamic-module=/tmp/mod_zip
 $STD make modules
+
+mkdir -p /usr/lib/nginx/modules/
+mkdir -p /usr/share/nginx/modules-available/
+mkdir -p /etc/nginx/modules-enabled/
+
 cp objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
 echo "load_module modules/ngx_http_zip_module.so;" > /usr/share/nginx/modules-available/mod-http-zip.conf
 ln -sf /usr/share/nginx/modules-available/mod-http-zip.conf /etc/nginx/modules-enabled/50-mod-http-zip.conf

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -52,13 +52,13 @@ cd nginx-${NGINX_VER}
 $STD ./configure --with-compat --without-http_rewrite_module --add-dynamic-module=/tmp/mod_zip
 $STD make modules
 
-mkdir -p /usr/lib/nginx/modules/
-mkdir -p /usr/share/nginx/modules-available/
-mkdir -p /etc/nginx/modules-enabled/
+# Création d'un dossier personnalisé indépendant
+$STD mkdir -p /etc/nginx/custom-modules
+$STD cp objs/ngx_http_zip_module.so /etc/nginx/custom-modules/
 
-cp objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
-echo "load_module modules/ngx_http_zip_module.so;" > /usr/share/nginx/modules-available/mod-http-zip.conf
-ln -sf /usr/share/nginx/modules-available/mod-http-zip.conf /etc/nginx/modules-enabled/50-mod-http-zip.conf
+# Activation via le chemin absolu
+$STD mkdir -p /etc/nginx/modules-enabled
+echo "load_module /etc/nginx/custom-modules/ngx_http_zip_module.so;" > /etc/nginx/modules-enabled/50-mod-http-zip.conf
 msg_ok "Installed Nginx mod_zip module"
 
 PYTHON_VERSION="3.13" setup_uv

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -38,17 +38,12 @@ $STD apt install -y \
   redis-tools \
   p7zip-full \
   tzdata \
-  nginx
+  nginx-extras
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
-setup_deb822_repo \
-  "getpagespeed-extras" \
-  "https://extras.getpagespeed.com/deb-archive-keyring.gpg" \
-  "https://extras.getpagespeed.com/debian" \
-  "$(get_os_info codename)" \
-  "main"
-$STD apt-get install -y nginx nginx-module-zip
+# Modification ici : On active le module natif de Debian sans passer par GetPageSpeed
+$STD ln -sf /usr/share/nginx/modules-available/mod-http-zip.load /etc/nginx/modules-enabled/50-mod-http-zip.conf
 msg_ok "Installed Nginx mod_zip module"
 
 PYTHON_VERSION="3.13" setup_uv

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -38,12 +38,22 @@ $STD apt install -y \
   redis-tools \
   p7zip-full \
   tzdata \
-  nginx-extras
+  nginx \
+  libpcre2-dev
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
-# Modification ici : On active le module natif de Debian sans passer par GetPageSpeed
-$STD ln -sf /usr/share/nginx/modules-available/mod-http-zip.load /etc/nginx/modules-enabled/50-mod-http-zip.conf
+cd /tmp
+$STD git clone https://github.com/evanmiller/mod_zip.git
+NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)
+$STD wget -q http://nginx.org/download/nginx-${NGINX_VER}.tar.gz
+$STD tar -zxvf nginx-${NGINX_VER}.tar.gz
+cd nginx-${NGINX_VER}
+$STD ./configure --with-compat --without-http_rewrite_module --add-dynamic-module=/tmp/mod_zip
+$STD make modules
+cp objs/ngx_http_zip_module.so /usr/lib/nginx/modules/
+echo "load_module modules/ngx_http_zip_module.so;" > /usr/share/nginx/modules-available/mod-http-zip.conf
+ln -sf /usr/share/nginx/modules-available/mod-http-zip.conf /etc/nginx/modules-enabled/50-mod-http-zip.conf
 msg_ok "Installed Nginx mod_zip module"
 
 PYTHON_VERSION="3.13" setup_uv

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -43,12 +43,18 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
+$STD apt-get install -y libpcre2-dev
 cd /tmp
-$STD git clone https://github.com/evanmiller/mod_zip.git
+
+$STD wget -qO mod_zip.tar.gz https://github.com/evanmiller/mod_zip/archive/refs/heads/master.tar.gz
+$STD tar -xzf mod_zip.tar.gz
+mv mod_zip-master mod_zip
+
 NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)
 $STD wget -q http://nginx.org/download/nginx-${NGINX_VER}.tar.gz
 $STD tar -zxvf nginx-${NGINX_VER}.tar.gz
 cd nginx-${NGINX_VER}
+
 $STD ./configure --with-compat --add-dynamic-module=/tmp/mod_zip
 $STD make modules
 
@@ -57,9 +63,8 @@ $STD cp objs/ngx_http_zip_module.so /etc/nginx/custom-modules/
 $STD mkdir -p /etc/nginx/modules-enabled
 echo "load_module /etc/nginx/custom-modules/ngx_http_zip_module.so;" > /etc/nginx/modules-enabled/50-mod-http-zip.conf
 
-rm -rf /tmp/mod_zip /tmp/nginx-${NGINX_VER} /tmp/nginx-${NGINX_VER}.tar.gz
+rm -rf /tmp/mod_zip* /tmp/nginx-${NGINX_VER}*
 msg_ok "Installed Nginx mod_zip module"
-
 PYTHON_VERSION="3.13" setup_uv
 NODE_VERSION="24" setup_nodejs
 setup_mariadb

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -43,7 +43,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
-$STD apt-get install -y libpcre3-dev libpcre2-dev
+$STD apt-get install -y libpcre2-dev
 cd /tmp
 $STD git clone https://github.com/evanmiller/mod_zip.git
 NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -43,7 +43,6 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Nginx mod_zip module"
-$STD apt-get install -y libpcre2-dev
 cd /tmp
 $STD git clone https://github.com/evanmiller/mod_zip.git
 NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -56,6 +56,8 @@ $STD mkdir -p /etc/nginx/custom-modules
 $STD cp objs/ngx_http_zip_module.so /etc/nginx/custom-modules/
 $STD mkdir -p /etc/nginx/modules-enabled
 echo "load_module /etc/nginx/custom-modules/ngx_http_zip_module.so;" > /etc/nginx/modules-enabled/50-mod-http-zip.conf
+
+rm -rf /tmp/mod_zip /tmp/nginx-${NGINX_VER} /tmp/nginx-${NGINX_VER}.tar.gz
 msg_ok "Installed Nginx mod_zip module"
 
 PYTHON_VERSION="3.13" setup_uv

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -37,34 +37,19 @@ $STD apt install -y \
   redis-server \
   redis-tools \
   p7zip-full \
-  tzdata \
-  nginx \
-  libpcre2-dev
+  tzdata
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Nginx mod_zip module"
-$STD apt-get install -y libpcre2-dev
-cd /tmp
-
-$STD wget -qO mod_zip.tar.gz https://github.com/evanmiller/mod_zip/archive/refs/heads/master.tar.gz
-$STD tar -xzf mod_zip.tar.gz
-mv mod_zip-master mod_zip
-
-NGINX_VER=$(nginx -v 2>&1 | cut -d'/' -f2 | cut -d' ' -f1)
-$STD wget -q http://nginx.org/download/nginx-${NGINX_VER}.tar.gz
-$STD tar -zxvf nginx-${NGINX_VER}.tar.gz
-cd nginx-${NGINX_VER}
-
-$STD ./configure --with-compat --add-dynamic-module=/tmp/mod_zip
-$STD make modules
-
-$STD mkdir -p /etc/nginx/custom-modules
-$STD cp objs/ngx_http_zip_module.so /etc/nginx/custom-modules/
-$STD mkdir -p /etc/nginx/modules-enabled
-echo "load_module /etc/nginx/custom-modules/ngx_http_zip_module.so;" > /etc/nginx/modules-enabled/50-mod-http-zip.conf
-
-rm -rf /tmp/mod_zip* /tmp/nginx-${NGINX_VER}*
-msg_ok "Installed Nginx mod_zip module"
+msg_info "Installing Angie with mod_zip module"
+setup_deb822_repo \
+  "angie" \
+  "https://angie.software/keys/angie-signing.gpg" \
+  "https://download.angie.software/angie/debian/$(get_os_info version_id)" \
+  "$(get_os_info codename)" \
+  "main"
+$STD apt-get install -y angie angie-module-zip
+sed -i '1i load_module modules/ngx_http_zip_module.so;' /etc/angie/angie.conf
+msg_ok "Installed Angie with mod_zip module"
 PYTHON_VERSION="3.13" setup_uv
 NODE_VERSION="24" setup_nodejs
 setup_mariadb
@@ -206,8 +191,8 @@ ln -sfn "$ROMM_BASE"/resources /opt/romm/frontend/dist/assets/romm/resources
 ln -sfn "$ROMM_BASE"/assets /opt/romm/frontend/dist/assets/romm/assets
 msg_ok "Set up RomM Frontend"
 
-msg_info "Configuring Nginx"
-cat <<'EOF' >/etc/nginx/sites-available/romm
+msg_info "Configuring Angie"
+cat <<'EOF' >/etc/angie/http.d/romm.conf
 upstream romm_backend {
     server 127.0.0.1:5000;
 }
@@ -277,13 +262,11 @@ server {
 }
 EOF
 
-sed -i "s|alias /var/lib/romm/library/;|alias ${ROMM_BASE}/library/;|" /etc/nginx/sites-available/romm
-rm -f /etc/nginx/sites-enabled/default
-rm -f /etc/nginx/conf.d/default.conf
-ln -sf /etc/nginx/sites-available/romm /etc/nginx/sites-enabled/romm
-systemctl restart nginx
-systemctl enable -q --now nginx
-msg_ok "Configured Nginx"
+sed -i "s|alias /var/lib/romm/library/;|alias ${ROMM_BASE}/library/;|" /etc/angie/http.d/romm.conf
+rm -f /etc/angie/http.d/default.conf
+systemctl restart angie
+systemctl enable -q --now angie
+msg_ok "Configured Angie"
 
 msg_info "Creating Services"
 cat <<EOF >/etc/systemd/system/romm-backend.service

--- a/misc/build.func
+++ b/misc/build.func
@@ -4613,7 +4613,7 @@ EOF
     export CONTAINER_INSTALLING=true
 
     local _install_script
-    _install_script="$(curl -fsSL "https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/install/${var_install}.sh")"
+    _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh")"
     lxc-attach -n "$CTID" -- bash -c "$_install_script"
     local lxc_exit=$?
 
@@ -5010,7 +5010,7 @@ EOF
           set +Eeuo pipefail
           trap - ERR
           local _install_script
-          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/install/${var_install}.sh")"
+          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh")"
           lxc-attach -n "$CTID" -- bash -c "$_install_script"
           local apt_retry_exit=$?
           set -Eeuo pipefail

--- a/misc/build.func
+++ b/misc/build.func
@@ -4613,7 +4613,7 @@ EOF
     export CONTAINER_INSTALLING=true
 
     local _install_script
-    _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh")"
+    _install_script="$(curl -fsSL "https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/install/${var_install}.sh")"
     lxc-attach -n "$CTID" -- bash -c "$_install_script"
     local lxc_exit=$?
 
@@ -5010,7 +5010,7 @@ EOF
           set +Eeuo pipefail
           trap - ERR
           local _install_script
-          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/install/${var_install}.sh")"
+          _install_script="$(curl -fsSL "https://raw.githubusercontent.com/hug-efrei/ProxmoxVE/main/install/${var_install}.sh")"
           lxc-attach -n "$CTID" -- bash -c "$_install_script"
           local apt_retry_exit=$?
           set -Eeuo pipefail


### PR DESCRIPTION
## ✍️ Description
The installation of the RomM LXC currently fails with an `Exit code 100 / 403 Forbidden` error. This happens because the `getpagespeed` repository (previously used to fetch `nginx-module-zip`) now requires a paid subscription, which blocks the automated `apt-get install` step. 

Furthermore, Debian 13 (Trixie) introduces a strict conflict between `libpcre3-dev` and `libpcre2-dev` which caused dependency issues.

**Solution applied:**
- Removed the `setup_deb822_repo` block for `getpagespeed-extras`.
- Added `libpcre2-dev` to the base dependencies (resolving the Debian 13 conflict).
- The script now automatically clones `evanmiller/mod_zip` and downloads the exact Nginx source code matching the currently installed version.
- Compiles the dynamic module (`ngx_http_zip_module.so`) using `--with-compat`.
- Places the compiled module in a custom directory (`/etc/nginx/custom-modules/`) to safely bypass Debian's default symlink quirks for `/usr/lib/nginx/modules/`.
- Added a `rm -rf` cleanup step for `/tmp` to keep the container footprint small.

Tested successfully on Proxmox VE 9.2.3 using the latest Debian 13 LXC template.

## 🔗 Related Issue

Fixes #15188

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.