### PR TITLE
fix: generate policy-compliant OpenObserve root password

### DIFF
--- a/install/openobserve-install.sh
+++ b/install/openobserve-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing OpenObserve"
 mkdir -p /opt/openobserve/data
 RELEASE=$(get_latest_github_release "openobserve/openobserve")
 tar zxf <(curl -fsSL https://downloads.openobserve.ai/releases/openobserve/v$RELEASE/openobserve-v$RELEASE-linux-amd64.tar.gz) -C /opt/openobserve
-ROOT_PASS=$(openssl rand -base64 18 | cut -c1-13)
+ROOT_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c9)Aa1!"
 
 cat <<EOF >/opt/openobserve/data/.env
 ZO_ROOT_USER_EMAIL = "admin@example.com"


### PR DESCRIPTION
## ✍️ Description

OpenObserve install could generate an alphanumeric-only `ZO_ROOT_USER_PASSWORD`, which fails current OpenObserve startup password policy and causes a restart loop. This updates password generation to always include lower/upper/digit/special characters so fresh installs start successfully.

## 🔗 Related Issue

Fixes #15135

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.