### PR TITLE
fix storyteller install failure with yarn 4 corepack

### DIFF
--- a/ct/storyteller.sh
+++ b/ct/storyteller.sh
@@ -48,13 +48,14 @@ function update_script() {
     msg_info "Rebuilding Storyteller"
     cd /opt/storyteller
     export NODE_OPTIONS="--max-old-space-size=4096"
-    $STD yarn install --network-timeout 600000
+    $STD corepack enable
+    $STD corepack yarn install --network-timeout 600000
     $STD gcc -g -fPIC -rdynamic -shared web/sqlite/uuid.c -o web/sqlite/uuid.c.so
     export CI=1
     export NODE_ENV=production
     export NEXT_TELEMETRY_DISABLED=1
     export SQLITE_NATIVE_BINDING=/opt/storyteller/node_modules/better-sqlite3/build/Release/better_sqlite3.node
-    $STD yarn workspaces foreach -Rpt --from @storyteller-platform/web --exclude @storyteller-platform/eslint run build
+    $STD corepack yarn workspaces foreach -Rpt --from @storyteller-platform/web --exclude @storyteller-platform/eslint run build
     mkdir -p /opt/storyteller/web/.next/standalone/web/.next/static
     cp -rT /opt/storyteller/web/.next/static /opt/storyteller/web/.next/standalone/web/.next/static
     if [[ -d /opt/storyteller/web/public ]]; then

--- a/install/storyteller-install.sh
+++ b/install/storyteller-install.sh
@@ -32,7 +32,8 @@ fetch_and_deploy_gl_release "storyteller" "storyteller-platform/storyteller" "ta
 
 msg_info "Setting up Storyteller"
 cd /opt/storyteller
-$STD yarn install --network-timeout 600000
+$STD corepack enable
+$STD corepack yarn install --network-timeout 600000
 $STD gcc -g -fPIC -rdynamic -shared web/sqlite/uuid.c -o web/sqlite/uuid.c.so
 STORYTELLER_SECRET_KEY=$(openssl rand -base64 32)
 cat <<EOF >/opt/storyteller/.env
@@ -58,7 +59,7 @@ export CI=1
 export NODE_ENV=production
 export NEXT_TELEMETRY_DISABLED=1
 export SQLITE_NATIVE_BINDING=/opt/storyteller/node_modules/better-sqlite3/build/Release/better_sqlite3.node
-$STD yarn workspaces foreach -Rpt --from @storyteller-platform/web --exclude @storyteller-platform/eslint run build
+$STD corepack yarn workspaces foreach -Rpt --from @storyteller-platform/web --exclude @storyteller-platform/eslint run build
 mkdir -p /opt/storyteller/web/.next/standalone/web/.next/static
 cp -rT /opt/storyteller/web/.next/static /opt/storyteller/web/.next/standalone/web/.next/static
 if [[ -d /opt/storyteller/web/public ]]; then


### PR DESCRIPTION
## ✍️ Description

Fixes Storyteller install/update failures caused by Yarn classic being used against an upstream project that requires Yarn 4 via `packageManager`.

Changes made:
- enable Corepack before dependency install in Storyteller install and update flows
- run install/build commands with `corepack yarn` so the pinned Yarn version is honored
- keep Node at 22 because no explicit upstream Node 24 engine requirement was found

## 🔗 Related Issue

Fixes #15122

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.