### PR TITLE
Fix InvoiceShelf install/update Yarn package manager mismatch

### DIFF
--- a/ct/invoiceshelf.sh
+++ b/ct/invoiceshelf.sh
@@ -52,8 +52,14 @@ function update_script() {
     msg_info "Updating Application"
     cd /opt/invoiceshelf
     $STD composer install --no-dev --optimize-autoloader
-    $STD yarn install
-    $STD yarn build
+    if command -v corepack >/dev/null 2>&1; then
+      $STD corepack enable
+      $STD corepack yarn install
+      $STD corepack yarn build
+    else
+      $STD yarn install
+      $STD yarn build
+    fi
     $STD php artisan migrate --force
     $STD php artisan optimize:clear
     chown -R www-data:www-data /opt/invoiceshelf

--- a/install/invoiceshelf-install.sh
+++ b/install/invoiceshelf-install.sh
@@ -39,8 +39,14 @@ sed -i "s|^DB_USERNAME=.*|DB_USERNAME=${PG_DB_USER}|" .env
 sed -i "s|^DB_PASSWORD=.*|DB_PASSWORD=${PG_DB_PASS}|" .env
 COMPOSER_ALLOW_SUPERUSER=1 $STD composer install --no-dev --optimize-autoloader --no-interaction
 $STD php artisan key:generate
-$STD yarn install
-$STD yarn build
+if command -v corepack >/dev/null 2>&1; then
+  $STD corepack enable
+  $STD corepack yarn install
+  $STD corepack yarn build
+else
+  $STD yarn install
+  $STD yarn build
+fi
 mkdir -p storage/framework/{cache,sessions,views} storage/logs bootstrap/cache
 chown -R www-data:www-data /opt/invoiceshelf
 chmod -R 775 storage bootstrap/cache


### PR DESCRIPTION
## ✍️ Description

Switch InvoiceShelf frontend install/build steps to Corepack-managed Yarn when available, with a Yarn fallback for compatibility. This fixes failures caused by packageManager metadata expecting Corepack instead of globally installed Yarn classic.

## 🔗 Related Issue

Fixes #15118

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.