### PR TITLE
trek: update install and upgrade workflow for v3.1.0

### DIFF
--- a/ct/trek.sh
+++ b/ct/trek.sh
@@ -32,48 +32,81 @@ function update_script() {
 
   NODE_VERSION="24" setup_nodejs
 
-  if check_for_gh_release "trek" "mauriceboe/TREK" "v3.0.22"; then
+  if check_for_gh_release "trek" "mauriceboe/TREK"; then
+    MIGRATION=0
+    grep -qF "ExecStart=/usr/bin/node --import tsx src/index.ts" \
+      /etc/systemd/system/trek.service && MIGRATION=1
+
     msg_info "Stopping Service"
     systemctl stop trek
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/trek/server/.env /opt/trek.env.bak
-    mv /opt/trek/data /opt/trek-data.bak
-    mv /opt/trek/uploads /opt/trek-uploads.bak
-    msg_ok "Backed up Data"
+    ensure_dependencies "libkitinerary-bin"
+
+    create_backup /opt/trek/server/.env \
+      /opt/trek/data \
+      /opt/trek/uploads
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "trek" "mauriceboe/TREK" "tarball"
 
-    msg_info "Building Client"
-    cd /opt/trek/client
+    msg_info "Building TREK"
+    cd /opt/trek
     $STD npm ci
-    $STD npm run build
-    mkdir -p /opt/trek/server/public
-    cp -r /opt/trek/client/dist/* /opt/trek/server/public/
-    cp -r /opt/trek/client/public/fonts /opt/trek/server/public/fonts 2>/dev/null || true
-    msg_ok "Built Client"
+    $STD npm run build --workspace=shared
+    $STD npm run build --workspace=client
+    $STD npm run build --workspace=server
+    msg_ok "Built TREK"
 
-    msg_info "Installing Server Dependencies"
-    cd /opt/trek/server
-    $STD npm ci
-    msg_ok "Installed Server Dependencies"
+    msg_info "Setting up TREK Workspace"
+    rm -rf /opt/trek/server/public
+    mkdir -p /opt/trek/server/public/fonts
+    cp -a /opt/trek/client/dist/. /opt/trek/server/public/
+    cp -a /opt/trek/client/public/fonts/. /opt/trek/server/public/fonts/
 
-    msg_info "Restoring Data"
-    mv /opt/trek-data.bak /opt/trek/data
-    mv /opt/trek-uploads.bak /opt/trek/uploads
+    restore_backup
+
     rm -rf /opt/trek/server/data /opt/trek/server/uploads
     ln -s /opt/trek/data /opt/trek/server/data
     ln -s /opt/trek/uploads /opt/trek/server/uploads
-    cp /opt/trek.env.bak /opt/trek/server/.env
-    rm -f /opt/trek.env.bak
-    msg_ok "Restored Data"
+
+    rm -rf /opt/trek/node_modules
+    cd /opt/trek
+    $STD npm ci --workspace=server --omit=dev
+    msg_ok "Set up TREK Workspace"
+
+    if [[ "$MIGRATION" == "1" ]]; then
+      msg_info "Migrating TREK Service"
+      cat <<EOF >/etc/systemd/system/trek.service
+[Unit]
+Description=TREK Travel Planner
+Documentation=https://github.com/mauriceboe/TREK
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/trek/server
+EnvironmentFile=/opt/trek/server/.env
+Environment=XDG_CACHE_HOME=/tmp/trek-kf6-cache
+Environment=QT_QPA_PLATFORM=offscreen
+ExecStart=/usr/bin/node --require tsconfig-paths/register dist/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+      systemctl daemon-reload
+      msg_ok "Migrated TREK Service"
+    fi
 
     msg_info "Starting Service"
     systemctl start trek
     msg_ok "Started Service"
     msg_ok "Updated Successfully!"
   fi
+
   exit
 }
 

--- a/install/trek-install.sh
+++ b/install/trek-install.sh
@@ -58,6 +58,7 @@ ADMIN_EMAIL="admin@trek.local"
 ADMIN_PASSWORD=$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9' | head -c 16)
 cat <<EOF >/opt/trek/server/.env
 NODE_ENV=production
+HOST=0.0.0.0
 PORT=3000
 ENCRYPTION_KEY=${ENCRYPTION_KEY}
 ADMIN_EMAIL=${ADMIN_EMAIL}
@@ -68,6 +69,7 @@ DEFAULT_LANGUAGE=en
 ALLOWED_ORIGINS=
 COOKIE_SECURE=false
 FORCE_HTTPS=false
+TRUST_PROXY=1
 EOF
 chmod 600 /opt/trek/server/.env
 msg_ok "Configured TREK"

--- a/install/trek-install.sh
+++ b/install/trek-install.sh
@@ -14,28 +14,45 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y build-essential
+$STD apt install -y \
+  build-essential \
+  libkitinerary-bin
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-fetch_and_deploy_gh_release "trek" "mauriceboe/TREK" "tarball" "v3.0.22"
+fetch_and_deploy_gh_release "trek" "mauriceboe/TREK" "tarball"
 
-msg_info "Building Client"
-cd /opt/trek/client
+msg_info "Setup TREK"
+cd /opt/trek
 $STD npm ci
-$STD npm run build
-msg_ok "Built Client"
+$STD npm run build --workspace=shared
+$STD npm run build --workspace=client
+$STD npm run build --workspace=server
+msg_ok "Setup TREK"
 
-msg_info "Setting up Server"
-cd /opt/trek/server
-$STD npm ci
+msg_info "Setting up TREK Workspace"
+rm -rf /opt/trek/server/public
 mkdir -p /opt/trek/server/public
-cp -r /opt/trek/client/dist/* /opt/trek/server/public/
-cp -r /opt/trek/client/public/fonts /opt/trek/server/public/fonts 2>/dev/null || true
-mkdir -p /opt/trek/{data/logs,uploads/{files,covers,avatars,photos}}
-rm -rf /opt/trek/server/data /opt/trek/server/uploads
+cp -a /opt/trek/client/dist/. /opt/trek/server/public/
+if [[ -d /opt/trek/client/public/fonts ]]; then
+  mkdir -p /opt/trek/server/public/fonts
+  cp -a /opt/trek/client/public/fonts/. /opt/trek/server/public/fonts/
+fi
+mkdir -p \
+  /opt/trek/data/logs \
+  /opt/trek/uploads/files \
+  /opt/trek/uploads/covers \
+  /opt/trek/uploads/avatars \
+  /opt/trek/uploads/photos
+rm -rf /opt/trek/server/data
+rm -rf /opt/trek/server/uploads
 ln -s /opt/trek/data /opt/trek/server/data
 ln -s /opt/trek/uploads /opt/trek/server/uploads
+cd /opt/trek
+$STD npm prune --omit=dev
+msg_ok "Set up TREK Workspace"
+
+msg_info "Configuring TREK"
 ENCRYPTION_KEY=$(openssl rand -hex 32)
 ADMIN_EMAIL="admin@trek.local"
 ADMIN_PASSWORD=$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9' | head -c 16)
@@ -45,26 +62,32 @@ PORT=3000
 ENCRYPTION_KEY=${ENCRYPTION_KEY}
 ADMIN_EMAIL=${ADMIN_EMAIL}
 ADMIN_PASSWORD=${ADMIN_PASSWORD}
+TZ=UTC
+LOG_LEVEL=info
+DEFAULT_LANGUAGE=en
+ALLOWED_ORIGINS=
 COOKIE_SECURE=false
 FORCE_HTTPS=false
-LOG_LEVEL=info
-TZ=UTC
 EOF
 chmod 600 /opt/trek/server/.env
-msg_ok "Set up Server"
+msg_ok "Configured TREK"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/trek.service
 [Unit]
 Description=TREK Travel Planner
-After=network.target
+Documentation=https://github.com/mauriceboe/TREK
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
 User=root
 WorkingDirectory=/opt/trek/server
 EnvironmentFile=/opt/trek/server/.env
-ExecStart=/usr/bin/node --import tsx src/index.ts
+Environment=XDG_CACHE_HOME=/tmp/trek-kf6-cache
+Environment=QT_QPA_PLATFORM=offscreen
+ExecStart=/usr/bin/node --require tsconfig-paths/register dist/index.js
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Remove the hardcoded release tag and fetch the latest TREK release (pinned version). 
- Consolidate builds to npm workspaces (shared, client, server), copy client dist into server/public, and install/prune server deps for production. 
- add libkitinerary dependency
- Implement backup/restore during upgrades and add migration logic that detects the old systemd ExecStart; when present, rewrite trek.service to run the compiled dist via node --require tsconfig-paths/register
- add XDG_CACHE_HOME and QT_QPA_PLATFORM env vars, and switch to network-online.target. Installer changes also create data/uploads directories, set additional .env defaults (TZ, LOG_LEVEL, DEFAULT_LANGUAGE, ALLOWED_ORIGINS), and adjust workspace setup steps.
- add proxy .env in newer installs, old installs work fine without these env

tested on VED with clean install 

## 🔗 Related Issue

Fixes #15155 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
