### PR TITLE
fix (workflow): YAML syntax error in pocketbase stub generation

### DIFF
--- a/.github/workflows/delete-pocketbase-entry-on-removal.yml
+++ b/.github/workflows/delete-pocketbase-entry-on-removal.yml
@@ -266,22 +266,21 @@ jobs:
 
               const stubPath = path.join('ct', slug + '.sh');
               const content = [
-                `#!/usr/bin/env bash
-                source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
-                # Copyright (c) 2021-2026 community-scripts ORG
-                # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
-
-                APP="${appName.replace(/"/g, '\\"')}"
-
-                header_info "$APP"
-                variables
-                color
-
-                msg_error "This script is no longer available in community-scripts."
-                msg_error "${deletedMessage.replace(/"/g, '\\"')}"
-                msg_warn "More info: https://community-scripts.org/scripts/${slug}"
-                exit 1
-                `;
+                "#!/usr/bin/env bash",
+                "source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)",
+                "# Copyright (c) 2021-2026 community-scripts ORG",
+                "# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE",
+                "",
+                `APP="${appName.replace(/"/g, '\\"')}"`,
+                "",
+                'header_info "$APP"',
+                'variables',
+                'color',
+                "",
+                'msg_error "This script is no longer available in community-scripts."',
+                `msg_error "${deletedMessage.replace(/"/g, '\\"')}"`,
+                `msg_warn "More info: https://community-scripts.org/scripts/${slug}"`,
+                "exit 1"
               ].join('\n') + '\n';
               fs.writeFileSync(stubPath, content);
               console.log('Generated stub: ' + stubPath);

--- a/.github/workflows/delete-pocketbase-entry-on-removal.yml
+++ b/.github/workflows/delete-pocketbase-entry-on-removal.yml
@@ -265,23 +265,24 @@ jobs:
                 : 'This script was removed and cannot be installed or updated.';
 
               const stubPath = path.join('ct', slug + '.sh');
-              const content =
-`#!/usr/bin/env bash
-source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
-# Copyright (c) 2021-2026 community-scripts ORG
-# License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
+              const content = [
+                `#!/usr/bin/env bash
+                source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/misc/build.func)
+                # Copyright (c) 2021-2026 community-scripts ORG
+                # License: MIT | https://github.com/community-scripts/ProxmoxVE/raw/main/LICENSE
 
-APP="${appName.replace(/"/g, '\\"')}"
+                APP="${appName.replace(/"/g, '\\"')}"
 
-header_info "$APP"
-variables
-color
+                header_info "$APP"
+                variables
+                color
 
-msg_error "This script is no longer available in community-scripts."
-msg_error "${deletedMessage.replace(/"/g, '\\"')}"
-msg_warn "More info: https://community-scripts.org/scripts/${slug}"
-exit 1
-`;
+                msg_error "This script is no longer available in community-scripts."
+                msg_error "${deletedMessage.replace(/"/g, '\\"')}"
+                msg_warn "More info: https://community-scripts.org/scripts/${slug}"
+                exit 1
+                `;
+              ].join('\n') + '\n';
               fs.writeFileSync(stubPath, content);
               console.log('Generated stub: ' + stubPath);
             }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

### Problem

In the .github/workflows/delete-pocketbase-entry-on-removal.yml workflow, the "Generate CT stubs for deleted scripts" step fails with a YAML syntax error on line 269:

```Text
Invalid workflow file
You have an error in your yaml syntax on line 269
```
Because this code is nested inside a YAML block scalar `(run: |)`, placing a non-empty line at column 0 prematurely terminates the block scalar.

### Solution:

To satisfy both the YAML parser (which requires leading indentation) and the script (which requires the shebang to begin at the beginning with no indentation), the PR refactors the script portion to use a string array joined by newlines.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
