### PR TITLE
update: esphome to install and run ESPHome Device Builder

### DIFF
--- a/ct/esphome.sh
+++ b/ct/esphome.sh
@@ -24,13 +24,14 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /etc/systemd/system/esphomeDashboard.service ]]; then
+  if [[ ! -f /etc/systemd/system/esphome-device-builder.service && ! -f /etc/systemd/system/esphomeDashboard.service ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
 
   msg_info "Stopping Service"
-  systemctl stop esphomeDashboard
+  systemctl stop esphome-device-builder 2>/dev/null || true
+  systemctl stop esphomeDashboard 2>/dev/null || true
   msg_ok "Stopped Service"
 
   VENV_PATH="/opt/esphome/.venv"
@@ -46,33 +47,36 @@ function update_script() {
     $STD uv venv --clear "$VENV_PATH"
     $STD "$VENV_PATH/bin/python" -m ensurepip --upgrade
     $STD "$VENV_PATH/bin/python" -m pip install --upgrade pip
-    $STD "$VENV_PATH/bin/python" -m pip install esphome tornado esptool
+    $STD "$VENV_PATH/bin/python" -m pip install esphome esphome-device-builder esptool
     msg_ok "Migrated to uv/venv"
   else
-    msg_info "Updating ESPHome"
+    msg_info "Updating ESPHome Device Builder"
     PYTHON_VERSION="3.12" setup_uv
-    $STD "$VENV_PATH/bin/python" -m pip install --upgrade esphome tornado esptool
-    msg_ok "Updated ESPHome"
+    $STD "$VENV_PATH/bin/python" -m pip install --upgrade esphome esphome-device-builder esptool
+    msg_ok "Updated ESPHome Device Builder"
   fi
-  SERVICE_FILE="/etc/systemd/system/esphomeDashboard.service"
-  if ! grep -q "${VENV_PATH}/bin/esphome" "$SERVICE_FILE"; then
-    msg_info "Updating systemd service"
-    cat <<EOF >"$SERVICE_FILE"
+
+  msg_info "Migrating to ESPHome Device Builder service"
+  if [[ -f /etc/systemd/system/esphomeDashboard.service ]]; then
+    systemctl disable -q esphomeDashboard 2>/dev/null || true
+    rm -f /etc/systemd/system/esphomeDashboard.service
+  fi
+  cat <<EOF >/etc/systemd/system/esphome-device-builder.service
 [Unit]
-Description=ESPHome Dashboard
+Description=ESPHome Device Builder
 After=network.target
 
 [Service]
-ExecStart=${VENV_PATH}/bin/esphome dashboard /root/config/
+ExecStart=${VENV_PATH}/bin/esphome-device-builder /root/config/
 Restart=always
 User=root
 
 [Install]
 WantedBy=multi-user.target
 EOF
-    $STD systemctl daemon-reload
-    msg_ok "Updated systemd service"
-  fi
+  $STD systemctl daemon-reload
+  $STD systemctl enable esphome-device-builder
+  msg_ok "Migrated to ESPHome Device Builder service"
 
   msg_info "Linking esphome to /usr/local/bin"
   rm -f /usr/local/bin/esphome
@@ -80,7 +84,7 @@ EOF
   msg_ok "Linked esphome binary"
 
   msg_info "Starting Service"
-  systemctl start esphomeDashboard
+  systemctl start esphome-device-builder
   msg_ok "Started Service"
   msg_ok "Updated successfully!"
   exit

--- a/install/esphome-install.sh
+++ b/install/esphome-install.sh
@@ -26,8 +26,8 @@ cd /opt/esphome
 $STD uv venv --clear /opt/esphome/.venv
 $STD /opt/esphome/.venv/bin/python -m ensurepip --upgrade
 $STD /opt/esphome/.venv/bin/python -m pip install --upgrade pip
-$STD /opt/esphome/.venv/bin/python -m pip install esphome tornado esptool
-msg_ok "Setup and Installed ESPHome"
+$STD /opt/esphome/.venv/bin/python -m pip install esphome esphome-device-builder esptool
+msg_ok "Setup and Installed ESPHome Device Builder"
 
 msg_info "Linking esphome to /usr/local/bin"
 rm -f /usr/local/bin/esphome
@@ -36,13 +36,13 @@ msg_ok "Linked esphome binary"
 
 msg_info "Creating Service"
 mkdir -p /root/config
-cat <<EOF >/etc/systemd/system/esphomeDashboard.service
+cat <<EOF >/etc/systemd/system/esphome-device-builder.service
 [Unit]
-Description=ESPHome Dashboard
+Description=ESPHome Device Builder
 After=network.target
 
 [Service]
-ExecStart=/opt/esphome/.venv/bin/esphome dashboard /root/config/
+ExecStart=/opt/esphome/.venv/bin/esphome-device-builder /root/config/
 Restart=always
 User=root
 
@@ -50,7 +50,7 @@ User=root
 WantedBy=multi-user.target
 EOF
 
-systemctl enable -q --now esphomeDashboard
+systemctl enable -q --now esphome-device-builder
 msg_ok "Created Service"
 
 motd_ssh


### PR DESCRIPTION
## ✍️ Description

Update the ESPHome script to install `esphome-device-builder` alongside `esphome` and run it as the service in place of the classic `esphome dashboard`. The Device Builder reached its 1.0 release and ships as the default builder in the official ESPHome add-on as of ESPHome 2026.6.0, so this brings the LXC script in line with upstream.

The service is renamed from `esphomeDashboard.service` to `esphome-device-builder.service`. On update, existing installs are migrated automatically: the old service is stopped, disabled, and its unit file removed; `esphome-device-builder` is installed; and the new unit is created and started. The dashboard still serves on port 6052, so access is unchanged. `tornado` is dropped from the dependency set since the Device Builder runs on aiohttp.

## 🔗 Related Issue

Fixes #14671

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.