### PR TITLE
Kimai: Add APP_SECRET env var

### DIFF
--- a/ct/kimai.sh
+++ b/ct/kimai.sh
@@ -41,21 +41,19 @@ function update_script() {
     systemctl stop apache2
     msg_ok "Stopped Apache2"
 
-    msg_info "Backing up Kimai configuration and var directory"
-    mkdir -p "$BACKUP_DIR"
-    [ -d /opt/kimai/var ] && cp -r /opt/kimai/var "$BACKUP_DIR/"
-    [ -f /opt/kimai/.env ] && cp /opt/kimai/.env "$BACKUP_DIR/"
-    [ -f /opt/kimai/config/packages/local.yaml ] && cp /opt/kimai/config/packages/local.yaml "$BACKUP_DIR/"
-    msg_ok "Backup completed"
-
+    create_backup /opt/kimai/var \
+      /opt/kimai/.env \
+      /opt/kimai/config/packages/local.yaml
     fetch_and_deploy_gh_release "kimai" "kimai/kimai" "tarball"
+    restore_backup
 
     msg_info "Updating Kimai"
-    [ -d "$BACKUP_DIR/var" ] && cp -r "$BACKUP_DIR/var" /opt/kimai/
-    [ -f "$BACKUP_DIR/.env" ] && cp "$BACKUP_DIR/.env" /opt/kimai/
-    [ -f "$BACKUP_DIR/local.yaml" ] && cp "$BACKUP_DIR/local.yaml" /opt/kimai/config/packages/
-    rm -rf "$BACKUP_DIR"
-    cd /opt/kimai 
+    if grep -q "^APP_SECRET=$" /opt/kimai/.env; then
+      APP_SECRET=$(openssl rand -hex 48)
+      sed -i "s|^APP_SECRET=.*|APP_SECRET=${APP_SECRET}|" /opt/kimai/.env
+    fi
+
+    cd /opt/kimai
     sed -i '/^admin_lte:/,/^[^[:space:]]/d' config/packages/local.yaml
     $STD composer install --no-dev --optimize-autoloader
     $STD bin/console kimai:update

--- a/install/kimai-install.sh
+++ b/install/kimai-install.sh
@@ -44,12 +44,14 @@ msg_ok "Set up database"
 fetch_and_deploy_gh_release "kimai" "kimai/kimai" "tarball"
 
 msg_info "Setup Kimai"
+APP_SECRET=$(openssl rand -hex 48)
 cd /opt/kimai
 echo "export COMPOSER_ALLOW_SUPERUSER=1" >>~/.bashrc
 source ~/.bashrc
 $STD composer install --no-dev --optimize-autoloader --no-interaction
 cp .env.dist .env
-sed -i "/^DATABASE_URL=/c\DATABASE_URL=mysql://$DB_USER:$DB_PASS@127.0.0.1:3306/$DB_NAME?charset=utf8mb4&serverVersion=mariadb-$MYSQL_VERSION" /opt/kimai/.env
+sed -i "/^DATABASE_URL=.*/c\DATABASE_URL=mysql://$DB_USER:$DB_PASS@127.0.0.1:3306/$DB_NAME?charset=utf8mb4&serverVersion=mariadb-$MYSQL_VERSION" /opt/kimai/.env
+sed -i "s|^APP_SECRET=.*|APP_SECRET=$APP_SECRET|" /opt/kimai/.env
 $STD bin/console kimai:install -n
 $STD expect <<EOF
 set timeout -1


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Application requires APP_SECRET to be set in .env file

## 🔗 Related Issue

Fixes #15189 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
