### PR TITLE
add avx2 check to influxdb3

### DIFF
--- a/install/influxdb-install.sh
+++ b/install/influxdb-install.sh
@@ -32,6 +32,10 @@ fi
 
 msg_info "Installing InfluxDB v${INFLUX}"
 if [[ $INFLUX == "3" ]]; then
+  if ! grep -qm1 'avx2' /proc/cpuinfo; then
+    msg_error "InfluxDB v3 requires AVX2 support, which is not available on this system."
+    exit 106
+  fi
   $STD apt install -y influxdb3-core
   systemctl enable -q --now influxdb3-core
 elif [[ $INFLUX == "2" ]]; then


### PR DESCRIPTION
## ✍️ Description
Adds AVX2 check when installing Influxdb 3 to prevent users installing it on incompatible systems.

## 🔗 Related Issue

Fixes #15205 

## ✅ Prerequisites (**X** in brackets)

- [ ] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
