### PR TITLE
Nginxproxymanager: repair broken certbot pip before update

### DIFF
--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -108,8 +108,13 @@ EOF
   cd /root
   if [ -d /opt/certbot ]; then
     msg_info "Updating Certbot"
-    $STD /opt/certbot/bin/pip install --upgrade pip setuptools wheel
-    $STD /opt/certbot/bin/pip install --upgrade certbot certbot-dns-cloudflare
+    CERTBOT_PYTHON="/opt/certbot/bin/python"
+    if ! "$CERTBOT_PYTHON" -m pip --version &>/dev/null; then
+      msg_info "Repairing Certbot pip"
+      $STD "$CERTBOT_PYTHON" -m ensurepip --upgrade
+    fi
+    $STD "$CERTBOT_PYTHON" -m pip install --upgrade pip setuptools wheel
+    $STD "$CERTBOT_PYTHON" -m pip install --upgrade certbot certbot-dns-cloudflare
     msg_ok "Updated Certbot"
   fi
 


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Use ensurepip when the certbot venv pip module is missing, then upgrade via python -m pip.


## 🔗 Related Issue

Fixes #15206

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
