### PR TITLE
[arm64] Port scripts between mediamtx-nocodb to support arm64

### DIFF
--- a/ct/mediamtx.sh
+++ b/ct/mediamtx.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 
@@ -35,7 +35,7 @@ function update_script() {
     systemctl stop mediamtx
     msg_ok "Service stopped"
 
-    fetch_and_deploy_gh_release "mediamtx" "bluenviron/mediamtx" "prebuild" "latest" "/opt/mediamtx" "mediamtx*linux_amd64.tar.gz"
+    fetch_and_deploy_gh_release "mediamtx" "bluenviron/mediamtx" "prebuild" "latest" "/opt/mediamtx" "mediamtx*linux_$(arch_resolve).tar.gz"
 
     msg_info "Starting service"
     systemctl start mediamtx

--- a/ct/memos.sh
+++ b/ct/memos.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop memos
     msg_ok "Service stopped"
 
-    fetch_and_deploy_gh_release "memos" "usememos/memos" "prebuild" "latest" "/opt/memos" "memos*linux_amd64.tar.gz"
+    fetch_and_deploy_gh_release "memos" "usememos/memos" "prebuild" "latest" "/opt/memos" "memos*linux_$(arch_resolve).tar.gz"
 
     msg_info "Starting service"
     systemctl start memos

--- a/ct/mini-qr.sh
+++ b/ct/mini-qr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-6}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/minthcm.sh
+++ b/ct/minthcm.sh
@@ -12,7 +12,7 @@ var_cpu="${var_cpu:-4}"
 var_ram="${var_ram:-4096}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/mongodb.sh
+++ b/ct/mongodb.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/musicseerr.sh
+++ b/ct/musicseerr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/n8n.sh
+++ b/ct/n8n.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nagios.sh
+++ b/ct/nagios.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nametag.sh
+++ b/ct/nametag.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/navidrome.sh
+++ b/ct/navidrome.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/neko.sh
+++ b/ct/neko.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-12}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-12}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 

--- a/ct/netbird.sh
+++ b/ct/netbird.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_tun="${var_tun:-yes}"
 

--- a/ct/netboot-xyz.sh
+++ b/ct/netboot-xyz.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/netvisor.sh
+++ b/ct/netvisor.sh
@@ -8,11 +8,11 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 APP="Scanopy"
 var_tags="${var_tags:-analytics}"
 var_cpu="${var_cpu:-2}"
-var_ram="${var_ram:-3072}"
+var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-6}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nextexplorer.sh
+++ b/ct/nextexplorer.sh
@@ -13,7 +13,7 @@ var_ram="${var_ram:-3072}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nextpvr.sh
+++ b/ct/nextpvr.sh
@@ -13,7 +13,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-5}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 

--- a/ct/nginx-ui.sh
+++ b/ct/nginx-ui.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -39,7 +39,7 @@ function update_script() {
     cp /usr/local/etc/nginx-ui/app.ini /tmp/nginx-ui-app.ini.bak
     msg_ok "Backed up Configuration"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nginx-ui" "0xJacky/nginx-ui" "prebuild" "latest" "/opt/nginx-ui" "nginx-ui-linux-64.tar.gz"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nginx-ui" "0xJacky/nginx-ui" "prebuild" "latest" "/opt/nginx-ui" "nginx-ui-linux-$(arch_resolve "64" "arm64-v8a").tar.gz"
 
     msg_info "Updating Binary"
     cp /opt/nginx-ui/nginx-ui /usr/local/bin/nginx-ui

--- a/ct/nginxproxymanager.sh
+++ b/ct/nginxproxymanager.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-12}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nightscout.sh
+++ b/ct/nightscout.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nocodb.sh
+++ b/ct/nocodb.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -35,7 +35,7 @@ function update_script() {
     systemctl stop nocodb
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "latest" "/opt/nocodb/" "Noco-linux-x64"
+    fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "latest" "/opt/nocodb/" "Noco-linux-$(arch_resolve "x64" "arm64")"
 
     msg_info "Starting Service"
     systemctl start nocodb

--- a/install/mediamtx-install.sh
+++ b/install/mediamtx-install.sh
@@ -18,7 +18,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y ffmpeg
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "mediamtx" "bluenviron/mediamtx" "prebuild" "latest" "/opt/mediamtx" "mediamtx*linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "mediamtx" "bluenviron/mediamtx" "prebuild" "latest" "/opt/mediamtx" "mediamtx*linux_$(arch_resolve).tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/mediamtx.service

--- a/install/memos-install.sh
+++ b/install/memos-install.sh
@@ -14,7 +14,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "memos" "usememos/memos" "prebuild" "latest" "/opt/memos" "memos*linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "memos" "usememos/memos" "prebuild" "latest" "/opt/memos" "memos*linux_$(arch_resolve).tar.gz"
 mkdir -p /opt/memos_data
 
 msg_info "Creating Service"

--- a/install/minthcm-install.sh
+++ b/install/minthcm-install.sh
@@ -13,6 +13,10 @@ setting_up_container
 network_check
 update_os
 
+msg_info "Installing Dependencies"
+$STD apt install -y cron
+msg_ok "Installed Dependencies"
+
 PHP_VERSION="8.2"
 PHP_APACHE="YES" PHP_MODULE="mysql,redis" PHP_FPM="YES" setup_php
 setup_composer

--- a/install/mongodb-install.sh
+++ b/install/mongodb-install.sh
@@ -13,11 +13,15 @@ setting_up_container
 network_check
 update_os
 
-read -p "${TAB3}Do you want to install MongoDB 8.0 instead of 7.0? [y/N]: " install_mongodb_8
-if [[ "$install_mongodb_8" =~ ^[Yy]$ ]]; then
+if [[ "$(arch_resolve)" == "arm64" ]]; then
   MONGO_VERSION="8.0" setup_mongodb
 else
-  MONGO_VERSION="7.0" setup_mongodb
+  read -p "${TAB3}Do you want to install MongoDB 8.0 instead of 7.0? [y/N]: " install_mongodb_8
+  if [[ "$install_mongodb_8" =~ ^[Yy]$ ]]; then
+    MONGO_VERSION="8.0" setup_mongodb
+  else
+    MONGO_VERSION="7.0" setup_mongodb
+  fi
 fi
 sed -i 's/bindIp: 127.0.0.1/bindIp: 0.0.0.0/' /etc/mongod.conf
 

--- a/install/nextpvr-install.sh
+++ b/install/nextpvr-install.sh
@@ -25,6 +25,7 @@ $STD apt install -y \
   libdvbv5-0 \
   dtv-scan-tables \
   libc6-dev \
+  libicu-dev \
   ffmpeg
 msg_ok "Installed Dependencies"
 

--- a/install/nginx-ui-install.sh
+++ b/install/nginx-ui-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   logrotate
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "nginx-ui" "0xJacky/nginx-ui" "prebuild" "latest" "/opt/nginx-ui" "nginx-ui-linux-64.tar.gz"
+fetch_and_deploy_gh_release "nginx-ui" "0xJacky/nginx-ui" "prebuild" "latest" "/opt/nginx-ui" "nginx-ui-linux-$(arch_resolve "64" "arm64-v8a").tar.gz"
 
 msg_info "Installing Nginx UI"
 cp /opt/nginx-ui/nginx-ui /usr/local/bin/nginx-ui

--- a/install/nocodb-install.sh
+++ b/install/nocodb-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "latest" "/opt/nocodb/" "Noco-linux-x64"
+fetch_and_deploy_gh_release "nocodb" "nocodb/nocodb" "singlefile" "latest" "/opt/nocodb/" "Noco-linux-$(arch_resolve "x64" "arm64")"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/nocodb.service


### PR DESCRIPTION
## ✍️ Description
Adds arm64 support to scripts titled between mediamtx and nocodb. This has 36/38 scripts marked as working, with the two that don't work being:
- minarca: the server package only supports amd64
- mysql: doesn't publish an arm64 binary

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
