### PR TITLE
[arm64] Port scripts between nodered & paperlessngx to support arm64

### DIFF
--- a/ct/npmplus.sh
+++ b/ct/npmplus.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-alpine}"
 var_version="${var_version:-3.23}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/nxwitness.sh
+++ b/ct/nxwitness.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-ubuntu}"
 var_version="${var_version:-24.04}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-0}"
 var_gpu="${var_gpu:-yes}"
 
@@ -32,7 +32,7 @@ function update_script() {
   BASE_URL="https://updates.networkoptix.com/default/index.html"
   RELEASE=$(curl -fsSL "$BASE_URL" | grep -oP '(?<=<b>)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(?=</b>)' | head -n 1)
   DETAIL_PAGE=$(curl -fsSL "$BASE_URL#note_$RELEASE")
-  DOWNLOAD_URL=$(echo "$DETAIL_PAGE" | grep -oP "https://updates.networkoptix.com/default/$RELEASE/linux/nxwitness-server-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-linux_x64\.deb" | head -n 1)
+  DOWNLOAD_URL=$(echo "$DETAIL_PAGE" | grep -oP "https://updates.networkoptix.com/default/$RELEASE/$(arch_resolve "linux" "arm")/nxwitness-server-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-linux_$(arch_resolve "x64" "arm64")\.deb" | head -n 1)
   if [[ ! -f /opt/${APP}_version.txt ]] || [[ "${RELEASE}" != "$(cat /opt/${APP}_version.txt)" ]]; then
     msg_info "Stopping Service"
     systemctl stop networkoptix-root-tool networkoptix-mediaserver
@@ -40,11 +40,11 @@ function update_script() {
 
     msg_info "Updating ${APP} to ${RELEASE}"
     cd /tmp
-    curl -fsSL "$DOWNLOAD_URL" -o ""nxwitness-server-$RELEASE-linux_x64.deb""
+    curl -fsSL "$DOWNLOAD_URL" -o ""nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb""
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NOWARNINGS=yes
-    $STD dpkg -i nxwitness-server-$RELEASE-linux_x64.deb
-    rm -f /tmp/nxwitness-server-$RELEASE-linux_x64.deb
+    $STD dpkg -i nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb
+    rm -f /tmp/nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP}"
 

--- a/ct/oauth2-proxy.sh
+++ b/ct/oauth2-proxy.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -34,7 +34,7 @@ function update_script() {
     systemctl stop oauth2-proxy
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "oauth2-proxy" "oauth2-proxy/oauth2-proxy" "prebuild" "latest" "/opt/oauth2-proxy" "oauth2-proxy*linux-amd64.tar.gz"
+    fetch_and_deploy_gh_release "oauth2-proxy" "oauth2-proxy/oauth2-proxy" "prebuild" "latest" "/opt/oauth2-proxy" "oauth2-proxy*linux-$(arch_resolve).tar.gz"
 
     msg_info "Starting Service"
     systemctl start oauth2-proxy

--- a/ct/ollama.sh
+++ b/ct/ollama.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-40}"
 var_os="${var_os:-ubuntu}"
 var_version="${var_version:-24.04}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_gpu="${var_gpu:-yes}"
 
 header_info "$APP"
@@ -40,7 +40,7 @@ function update_script() {
     OLLAMA_INSTALL_DIR="/usr/local/lib/ollama"
     rm -rf "$OLLAMA_INSTALL_DIR" /usr/local/bin/ollama
     mkdir -p "$OLLAMA_INSTALL_DIR"
-    if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "$OLLAMA_INSTALL_DIR" "ollama-linux-amd64.tar.zst"; then
+    if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "$OLLAMA_INSTALL_DIR" "ollama-linux-$(arch_resolve).tar.zst"; then
       msg_error "Download or deployment failed – check network connectivity and GitHub API availability"
       exit 250
     fi

--- a/ct/omada.sh
+++ b/ct/omada.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-3072}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-12}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -30,7 +30,7 @@ function update_script() {
   fi
 
   msg_info "Updating MongoDB"
-  if lscpu | grep -q 'avx'; then
+  if [[ "$(arch_resolve)" == "arm64" ]] || lscpu | grep -q 'avx'; then
     MONGO_VERSION="8.0"
   else
     msg_error "No AVX detected (CPU-Flag)! We have discontinued support for this. You are welcome to try it manually with a Debian LXC, but due to the many issues with Omada, we currently only support AVX CPUs."

--- a/ct/ombi.sh
+++ b/ct/ombi.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -41,7 +41,7 @@ function update_script() {
     msg_ok "Backup created"
 
     rm -rf /opt/ombi
-    fetch_and_deploy_gh_release "ombi" "Ombi-app/Ombi" "prebuild" "latest" "/opt/ombi" "linux-x64.tar.gz"
+    fetch_and_deploy_gh_release "ombi" "Ombi-app/Ombi" "prebuild" "latest" "/opt/ombi" "linux-$(arch_resolve "x64" "arm64").tar.gz"
     [[ -f /opt/Ombi.db ]] && mv /opt/Ombi.db /opt/ombi
     [[ -f /opt/OmbiExternal.db ]] && mv /opt/OmbiExternal.db /opt/ombi
     [[ -f /opt/OmbiSettings.db ]] && mv /opt/OmbiSettings.db /opt/ombi

--- a/ct/opencloud.sh
+++ b/ct/opencloud.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -43,7 +43,7 @@ function update_script() {
     msg_ok "Updated packages"
 
     rm -f /usr/bin/{OpenCloud,opencloud}
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "${RELEASE}" "/usr/bin" "opencloud-*-linux-amd64"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "${RELEASE}" "/usr/bin" "opencloud-*-linux-$(arch_resolve)"
     mv /usr/bin/OpenCloud /usr/bin/opencloud
 
     if ! grep -q 'POSIX_WATCH' /etc/opencloud/opencloud.env; then

--- a/ct/opengist.sh
+++ b/ct/opengist.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -37,7 +37,7 @@ function update_script() {
     mv /opt/opengist /opt/opengist-backup
     msg_ok "Backup created"
 
-    fetch_and_deploy_gh_release "opengist" "thomiceli/opengist" "prebuild" "latest" "/opt/opengist" "opengist*linux-amd64.tar.gz"
+    fetch_and_deploy_gh_release "opengist" "thomiceli/opengist" "prebuild" "latest" "/opt/opengist" "opengist*linux-$(arch_resolve).tar.gz"
 
     msg_info "Restoring Configuration"
     mv /opt/opengist-backup/config.yml /opt/opengist/config.yml

--- a/ct/openobserve.sh
+++ b/ct/openobserve.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -33,7 +33,7 @@ function update_script() {
     msg_info "Updating OpenObserve"
     systemctl stop openobserve
     RELEASE=$(get_latest_github_release "openobserve/openobserve")
-    tar zxf <(curl -fsSL https://downloads.openobserve.ai/releases/openobserve/v$RELEASE/openobserve-v$RELEASE-linux-amd64.tar.gz) -C /opt/openobserve
+    tar zxf <(curl -fsSL https://downloads.openobserve.ai/releases/openobserve/v$RELEASE/openobserve-v$RELEASE-linux-$(arch_resolve).tar.gz) -C /opt/openobserve
     systemctl start openobserve
     msg_ok "Updated OpenObserve"
     msg_ok "Updated successfully!"

--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -13,7 +13,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-0}"
 var_tun="${var_tun:-yes}"
 

--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-8192}"
 var_disk="${var_disk:-50}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 
@@ -99,7 +99,7 @@ EOF
       msg_ok "Stopped Service"
 
       rm -rf /usr/lib/ollama /usr/bin/ollama
-      if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "/usr/lib/ollama" "ollama-linux-amd64.tar.zst"; then
+      if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "/usr/lib/ollama" "ollama-linux-$(arch_resolve).tar.zst"; then
         msg_error "Ollama download or deployment failed – check network connectivity and GitHub API availability"
       else
         ln -sf /usr/lib/ollama/bin/ollama /usr/bin/ollama

--- a/ct/ots.sh
+++ b/ct/ots.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -34,7 +34,7 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped Services"
 
-    fetch_and_deploy_gh_release "ots" "Luzifer/ots" "prebuild" "latest" "/opt/ots" "ots_linux_amd64.tgz"
+    fetch_and_deploy_gh_release "ots" "Luzifer/ots" "prebuild" "latest" "/opt/ots" "ots_linux_$(arch_resolve).tgz"
 
     msg_info "Starting Services"
     systemctl start ots

--- a/ct/owncast.sh
+++ b/ct/owncast.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 
@@ -34,7 +34,7 @@ function update_script() {
     systemctl stop owncast
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "owncast" "owncast/owncast" "prebuild" "latest" "/opt/owncast" "owncast*linux-64bit.zip"
+    fetch_and_deploy_gh_release "owncast" "owncast/owncast" "prebuild" "latest" "/opt/owncast" "owncast*linux-$(arch_resolve "64bit" "arm64").zip"
 
     msg_info "Starting Service"
     systemctl start owncast

--- a/ct/ownfoil.sh
+++ b/ct/ownfoil.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -13,7 +13,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_tun="${var_tun:-1}"
 
@@ -50,7 +50,7 @@ function update_script() {
     msg_ok "Created backup"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_amd64"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_$(arch_resolve)"
 
     msg_info "Updating Pangolin"
     cd /opt/pangolin

--- a/ct/paperclip.sh
+++ b/ct/paperclip.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-8192}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/install/npmplus-install.sh
+++ b/install/npmplus-install.sh
@@ -31,7 +31,7 @@ get_latest_release() {
 DOCKER_COMPOSE_LATEST_VERSION=$(get_latest_release "docker/compose")
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
 mkdir -p $DOCKER_CONFIG/cli-plugins
-curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_LATEST_VERSION/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+curl -fsSL https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_LATEST_VERSION/docker-compose-linux-$(arch_resolve "x86_64" "aarch64") -o ~/.docker/cli-plugins/docker-compose
 chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 msg_ok "Installed Docker & Compose"
 

--- a/install/nxwitness-install.sh
+++ b/install/nxwitness-install.sh
@@ -30,11 +30,11 @@ cd /tmp
 BASE_URL="https://updates.networkoptix.com/default/index.html"
 RELEASE=$(curl -fsSL "$BASE_URL" | grep -oP '(?<=<b>)[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(?=</b>)' | head -n 1)
 DETAIL_PAGE=$(curl -fsSL "$BASE_URL#note_$RELEASE")
-DOWNLOAD_URL=$(echo "$DETAIL_PAGE" | grep -oP "https://updates.networkoptix.com/default/$RELEASE/linux/nxwitness-server-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-linux_x64\.deb" | head -n 1)
-curl -fsSL "$DOWNLOAD_URL" -o ""nxwitness-server-$RELEASE-linux_x64.deb""
+DOWNLOAD_URL=$(echo "$DETAIL_PAGE" | grep -oP "https://updates.networkoptix.com/default/$RELEASE/$(arch_resolve "linux" "arm")/nxwitness-server-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+-linux_$(arch_resolve "x64" "arm64")\.deb" | head -n 1)
+curl -fsSL "$DOWNLOAD_URL" -o ""nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb""
 export DEBIAN_FRONTEND=noninteractive
-$STD dpkg -i nxwitness-server-$RELEASE-linux_x64.deb
-rm -f /tmp/nxwitness-server-$RELEASE-linux_x64.deb
+$STD dpkg -i nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb
+rm -f /tmp/nxwitness-server-$RELEASE-linux_$(arch_resolve "x64" "arm64").deb
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Setup Nx Witness"
 

--- a/install/oauth2-proxy-install.sh
+++ b/install/oauth2-proxy-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "oauth2-proxy" "oauth2-proxy/oauth2-proxy" "prebuild" "latest" "/opt/oauth2-proxy" "oauth2-proxy*linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "oauth2-proxy" "oauth2-proxy/oauth2-proxy" "prebuild" "latest" "/opt/oauth2-proxy" "oauth2-proxy*linux-$(arch_resolve).tar.gz"
 touch /opt/oauth2-proxy/config.toml
 
 msg_info "Creating Service"

--- a/install/ollama-install.sh
+++ b/install/ollama-install.sh
@@ -20,6 +20,7 @@ $STD apt install -y \
   zstd
 msg_ok "Installed Dependencies"
 
+if [[ "$(arch_resolve)" == "amd64" ]]; then
 msg_info "Setting up Intel® Repositories"
 mkdir -p /usr/share/keyrings
 curl -fsSL https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg 2>/dev/null || true
@@ -60,12 +61,13 @@ msg_ok "Installed Intel® Level Zero"
 msg_info "Installing Intel® oneAPI Base Toolkit (Patience)"
 $STD apt install -y --no-install-recommends intel-basekit-2024.1
 msg_ok "Installed Intel® oneAPI Base Toolkit"
+fi
 
 msg_info "Installing Ollama (Patience)"
 OLLAMA_INSTALL_DIR="/usr/local/lib/ollama"
 BINDIR="/usr/local/bin"
 mkdir -p "$OLLAMA_INSTALL_DIR"
-if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "$OLLAMA_INSTALL_DIR" "ollama-linux-amd64.tar.zst"; then
+if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "$OLLAMA_INSTALL_DIR" "ollama-linux-$(arch_resolve).tar.zst"; then
   msg_error "Failed to download or deploy Ollama – check network connectivity and GitHub API availability"
   exit 250
 fi

--- a/install/omada-install.sh
+++ b/install/omada-install.sh
@@ -19,7 +19,7 @@ msg_ok "Installed Dependencies"
 
 JAVA_VERSION="21" setup_java
 
-if lscpu | grep -q 'avx'; then
+if [[ "$(arch_resolve)" == "arm64" ]] || lscpu | grep -q 'avx'; then
   MONGO_VERSION="8.0" setup_mongodb
 else
   msg_error "No AVX detected (CPU-Flag)! We have discontinued support for this. You are welcome to try it manually with a Debian LXC, but due to the many issues with Omada, we currently only support AVX CPUs."
@@ -28,7 +28,7 @@ fi
 
 if ! dpkg -l | grep -q 'libssl1.1'; then
   msg_info "Installing libssl (if needed)"
-  curl_download "/tmp/libssl.deb" "https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u5_amd64.deb"
+  curl_download "/tmp/libssl.deb" "https://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.1_1.1.1w-0+deb11u8_$(arch_resolve).deb"
   $STD dpkg -i /tmp/libssl.deb
   rm -f /tmp/libssl.deb
   msg_ok "Installed libssl1.1"

--- a/install/ombi-install.sh
+++ b/install/ombi-install.sh
@@ -13,7 +13,11 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "ombi" "Ombi-app/Ombi" "prebuild" "latest" "/opt/ombi" "linux-x64.tar.gz"
+msg_info "Installing Dependencies"
+$STD apt install -y libicu-dev
+msg_ok "Installed Dependencies"
+
+fetch_and_deploy_gh_release "ombi" "Ombi-app/Ombi" "prebuild" "latest" "/opt/ombi" "linux-$(arch_resolve "x64" "arm64").tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/ombi.service

--- a/install/opencloud-install.sh
+++ b/install/opencloud-install.sh
@@ -64,7 +64,7 @@ $STD sudo -u cool coolconfig set-admin-password --user=admin --password="$COOLPA
 echo "$COOLPASS" >~/.coolpass
 msg_ok "Installed Collabora Online"
 
-fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "v7.0.0" "/usr/bin" "opencloud-*-linux-amd64"
+fetch_and_deploy_gh_release "OpenCloud" "opencloud-eu/opencloud" "singlefile" "v7.0.0" "/usr/bin" "opencloud-*-linux-$(arch_resolve)"
 mv /usr/bin/OpenCloud /usr/bin/opencloud
 
 msg_info "Configuring OpenCloud"

--- a/install/opengist-install.sh
+++ b/install/opengist-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y git
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "opengist" "thomiceli/opengist" "prebuild" "latest" "/opt/opengist" "opengist*linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "opengist" "thomiceli/opengist" "prebuild" "latest" "/opt/opengist" "opengist*linux-$(arch_resolve).tar.gz"
 mkdir -p /opt/opengist-data
 sed -i 's|opengist-home:.*|opengist-home: /opt/opengist-data|' /opt/opengist/config.yml
 

--- a/install/openobserve-install.sh
+++ b/install/openobserve-install.sh
@@ -16,7 +16,7 @@ update_os
 msg_info "Installing OpenObserve"
 mkdir -p /opt/openobserve/data
 RELEASE=$(get_latest_github_release "openobserve/openobserve")
-tar zxf <(curl -fsSL https://downloads.openobserve.ai/releases/openobserve/v$RELEASE/openobserve-v$RELEASE-linux-amd64.tar.gz) -C /opt/openobserve
+tar zxf <(curl -fsSL https://downloads.openobserve.ai/releases/openobserve/v$RELEASE/openobserve-v$RELEASE-linux-$(arch_resolve).tar.gz) -C /opt/openobserve
 ROOT_PASS="$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c9)Aa1!"
 
 cat <<EOF >/opt/openobserve/data/.env

--- a/install/openwebui-install.sh
+++ b/install/openwebui-install.sh
@@ -31,6 +31,7 @@ msg_ok "Installed Open WebUI"
 
 read -r -p "${TAB3}Would you like to add Ollama? <y/N> " prompt
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  if [[ "$(arch_resolve)" == "amd64" ]]; then
   msg_info "Setting up Intel® Repositories"
   mkdir -p /usr/share/keyrings
   curl -fsSL https://repositories.intel.com/gpu/intel-graphics.key | gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg 2>/dev/null || true
@@ -71,9 +72,10 @@ EOF
   msg_info "Installing Intel® oneAPI Base Toolkit (Patience)"
   $STD apt install -y --no-install-recommends intel-basekit-2024.1 2>/dev/null || true
   msg_ok "Installed Intel® oneAPI Base Toolkit"
+  fi
 
   msg_info "Installing Ollama"
-  if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "/usr/lib/ollama" "ollama-linux-amd64.tar.zst"; then
+  if ! fetch_and_deploy_gh_release "ollama-com" "ollama/ollama" "prebuild" "latest" "/usr/lib/ollama" "ollama-linux-$(arch_resolve).tar.zst"; then
     msg_error "Failed to download or deploy Ollama – check network connectivity and GitHub API availability"
   else
     ln -sf /usr/lib/ollama/bin/ollama /usr/bin/ollama

--- a/install/ots-install.sh
+++ b/install/ots-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   nginx
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "ots" "Luzifer/ots" "prebuild" "latest" "/opt/ots" "ots_linux_amd64.tgz"
+fetch_and_deploy_gh_release "ots" "Luzifer/ots" "prebuild" "latest" "/opt/ots" "ots_linux_$(arch_resolve).tgz"
 create_self_signed_cert
 
 msg_info "Setup OTS"

--- a/install/owncast-install.sh
+++ b/install/owncast-install.sh
@@ -19,7 +19,7 @@ msg_info "Installing Dependencies (Patience)"
 $STD apt install -y ffmpeg
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "owncast" "owncast/owncast" "prebuild" "latest" "/opt/owncast" "owncast*linux-64bit.zip"
+fetch_and_deploy_gh_release "owncast" "owncast/owncast" "prebuild" "latest" "/opt/owncast" "owncast*linux-$(arch_resolve "64bit" "arm64").zip"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/owncast.service

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -24,8 +24,8 @@ msg_ok "Installed Dependencies"
 NODE_VERSION="24" setup_nodejs
 PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.4}"
 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
-fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_amd64"
-fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_$(arch_resolve)"
+fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_$(arch_resolve).tar.gz"
 
 read -rp "${TAB3}Enter your Pangolin URL (ex: https://pangolin.example.com): " pango_url
 read -rp "${TAB3}Enter your email address: " pango_email

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -765,8 +765,12 @@ manage_tool_repository() {
     distro_codename=$(get_os_info codename)
 
     if [[ "$distro_id" == "debian" && "$(dpkg --print-architecture)" == "arm64" ]]; then
-      distro_id="ubuntu" 
-      suite="noble"
+      case "$distro_codename" in
+      trixie | forky) suite="noble" ;;
+      bookworm) suite="jammy" ;;
+      *) suite="noble" ;;
+      esac
+      distro_id="ubuntu"
       repo_url="https://repo.mongodb.org/apt/ubuntu"
     elif [[ "$distro_id" == "debian" ]]; then
       case "$distro_codename" in


### PR DESCRIPTION
## ✍️ Description
Adds arm64 support to scripts titled between node red and paperless-ngx. This has 37/38 scripts marked as working, with the one that don't work being:

openproject: doesn't publish an arm64 binary

has_arm has been set in db for these scripts.
---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
