### PR TITLE
[arm64] port scripts titled between papra and qbittorrent to support arm64

### DIFF
--- a/ct/papra.sh
+++ b/ct/papra.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/passbolt.sh
+++ b/ct/passbolt.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/patchmon.sh
+++ b/ct/patchmon.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/paymenter.sh
+++ b/ct/paymenter.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-5}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pelican-panel.sh
+++ b/ct/pelican-panel.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pelican-wings.sh
+++ b/ct/pelican-wings.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/photoprism.sh
+++ b/ct/photoprism.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-3072}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_gpu="${var_gpu:-yes}"
 

--- a/ct/pialert.sh
+++ b/ct/pialert.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/plane.sh
+++ b/ct/plane.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-6144}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/planka.sh
+++ b/ct/planka.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pocketbase.sh
+++ b/ct/pocketbase.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pocketid.sh
+++ b/ct/pocketid.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/powerdns.sh
+++ b/ct/powerdns.sh
@@ -13,7 +13,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/profilarr.sh
+++ b/ct/profilarr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-7}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/projectsend.sh
+++ b/ct/projectsend.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/prometheus-alertmanager.sh
+++ b/ct/prometheus-alertmanager.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/prometheus-blackbox-exporter.sh
+++ b/ct/prometheus-blackbox-exporter.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/prometheus.sh
+++ b/ct/prometheus.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/prowlarr.sh
+++ b/ct/prowlarr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/proxmox-backup-server.sh
+++ b/ct/proxmox-backup-server.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pterodactyl-panel.sh
+++ b/ct/pterodactyl-panel.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pterodactyl-wings.sh
+++ b/ct/pterodactyl-wings.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/qbittorrent.sh
+++ b/ct/qbittorrent.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/install/patchmon-install.sh
+++ b/install/patchmon-install.sh
@@ -21,7 +21,7 @@ PG_VERSION="17" setup_postgresql
 PG_DB_NAME="patchmon_db" PG_DB_USER="patchmon_usr" setup_postgresql_db
 
 RELEASE="v2.0.2"
-fetch_and_deploy_gh_release "PatchMon" "PatchMon/PatchMon" "singlefile" "latest" "/opt/patchmon" "patchmon-server-linux-amd64"
+fetch_and_deploy_gh_release "PatchMon" "PatchMon/PatchMon" "singlefile" "latest" "/opt/patchmon" "patchmon-server-linux-$(arch_resolve)"
 mv /opt/patchmon/PatchMon /opt/patchmon/patchmon-server
 
 msg_info "Configuring PatchMon"

--- a/install/paymenter-install.sh
+++ b/install/paymenter-install.sh
@@ -17,7 +17,8 @@ msg_info "Installing Dependencies"
 $STD apt install -y \
   git \
   nginx \
-  redis-server
+  redis-server \
+  cron
 msg_ok "Installed Dependencies"
 
 setup_mariadb

--- a/install/pelican-panel-install.sh
+++ b/install/pelican-panel-install.sh
@@ -13,6 +13,10 @@ setting_up_container
 network_check
 update_os
 
+msg_info "Installing Dependencies"
+$STD apt install -y cron
+msg_ok "Installed Dependencies"
+
 PHP_VERSION="8.4" PHP_APACHE="YES" PHP_FPM="YES" setup_php
 setup_composer
 setup_mariadb

--- a/install/pelican-wings-install.sh
+++ b/install/pelican-wings-install.sh
@@ -15,7 +15,7 @@ update_os
 
 setup_docker
 
-fetch_and_deploy_gh_release "wings" "pelican-dev/wings" "singlefile" "latest" "/usr/local/bin" "wings_linux_amd64"
+fetch_and_deploy_gh_release "wings" "pelican-dev/wings" "singlefile" "latest" "/usr/local/bin" "wings_linux_$(arch_resolve)"
 mkdir -p /etc/pelican /var/run/wings
 
 msg_info "Creating Service"

--- a/install/photoprism-install.sh
+++ b/install/photoprism-install.sh
@@ -34,13 +34,13 @@ echo 'export $(grep -v "^#" /opt/photoprism/config/.env | xargs)' >>~/.bashrc
 export PATH=/usr/local:$PATH
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "photoprism" "photoprism/photoprism" "prebuild" "latest" "/opt/photoprism" "*linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "photoprism" "photoprism/photoprism" "prebuild" "latest" "/opt/photoprism" "*linux-$(arch_resolve).tar.gz"
 
 msg_info "Installing PhotoPrism (Patience)"
 mkdir -p /opt/photoprism/{cache,config,photos,storage,temp}
 mkdir -p /opt/photoprism/photos/{originals,import}
 mkdir -p /opt/photoprism_backups
-LIBHEIF_URL=$(curl -fsSL "https://dl.photoprism.app/dist/libheif/" | grep -oP "libheif-bookworm-amd64-v[0-9\.]+\.tar\.gz" | sort -V | tail -n 1)
+LIBHEIF_URL=$(curl -fsSL "https://dl.photoprism.app/dist/libheif/" | grep -oP "libheif-bookworm-$(arch_resolve)-v[0-9\.]+\.tar\.gz" | sort -V | tail -n 1)
 curl -fsSL "https://dl.photoprism.app/dist/libheif/$LIBHEIF_URL" -o /tmp/libheif.tar.gz
 tar -xzf /tmp/libheif.tar.gz -C /usr/local
 ldconfig

--- a/install/pialert-install.sh
+++ b/install/pialert-install.sh
@@ -30,7 +30,8 @@ $STD apt -y install \
   wakeonlan \
   fping \
   zip \
-  libtext-csv-perl
+  libtext-csv-perl \
+  cron
 msg_ok "Installed Dependencies"
 
 msg_info "Installing PHP Dependencies"

--- a/install/plane-install.sh
+++ b/install/plane-install.sh
@@ -44,7 +44,7 @@ $STD rabbitmqctl set_permissions -p plane plane ".*" ".*" ".*"
 msg_ok "Configured RabbitMQ"
 
 msg_info "Installing MinIO"
-curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio -o /usr/local/bin/minio
+curl -fsSL https://dl.min.io/server/minio/release/linux-$(arch_resolve)/minio -o /usr/local/bin/minio
 chmod +x /usr/local/bin/minio
 mkdir -p /opt/minio/data
 MINIO_ACCESS_KEY=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c16)
@@ -176,7 +176,7 @@ $STD /opt/plane-venv/bin/python manage.py register_instance "${MACHINE_SIG}"
 msg_ok "Ran Database Migrations"
 
 msg_info "Creating Services and MinIO Bucket"
-curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mcli
+curl -fsSL https://dl.min.io/client/mc/release/linux-$(arch_resolve)/mc -o /usr/local/bin/mcli
 chmod +x /usr/local/bin/mcli
 $STD /usr/local/bin/mcli alias set plane http://localhost:9000 "${MINIO_ACCESS_KEY}" "${MINIO_SECRET_KEY}"
 $STD /usr/local/bin/mcli mb plane/uploads --ignore-existing

--- a/install/pocketbase-install.sh
+++ b/install/pocketbase-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "pocketbase" "pocketbase/pocketbase" "prebuild" "latest" "/opt/pocketbase" "pocketbase*linux_amd64.zip"
+fetch_and_deploy_gh_release "pocketbase" "pocketbase/pocketbase" "prebuild" "latest" "/opt/pocketbase" "pocketbase*linux_$(arch_resolve).zip"
 
 msg_info "Configuring Pocketbase"
 mkdir -p /opt/pocketbase/{pb_public,pb_migrations,pb_hooks}

--- a/install/pocketid-install.sh
+++ b/install/pocketid-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 read -r -p "${TAB3}What public URL do you want to use (e.g. pocketid.mydomain.com)? " public_url
-fetch_and_deploy_gh_release "pocket-id" "pocket-id/pocket-id" "singlefile" "latest" "/opt/pocket-id/" "pocket-id-linux-amd64"
+fetch_and_deploy_gh_release "pocket-id" "pocket-id/pocket-id" "singlefile" "latest" "/opt/pocket-id/" "pocket-id-linux-$(arch_resolve)"
 
 msg_info "Configuring Pocket ID"
 ENCRYPTION_KEY=$(openssl rand -base64 32)

--- a/install/prometheus-alertmanager-install.sh
+++ b/install/prometheus-alertmanager-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "alertmanager" "prometheus/alertmanager" "prebuild" "latest" "/usr/local/bin/" "alertmanager*linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "alertmanager" "prometheus/alertmanager" "prebuild" "latest" "/usr/local/bin/" "alertmanager*linux-$(arch_resolve).tar.gz"
 
 msg_info "Configuring Prometheus Alertmanager"
 mkdir -p /etc/alertmanager /var/lib/alertmanager

--- a/install/prometheus-blackbox-exporter-install.sh
+++ b/install/prometheus-blackbox-exporter-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "blackbox-exporter" "prometheus/blackbox_exporter" "prebuild" "latest" "/opt/blackbox-exporter" "blackbox_exporter-*.linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "blackbox-exporter" "prometheus/blackbox_exporter" "prebuild" "latest" "/opt/blackbox-exporter" "blackbox_exporter-*.linux-$(arch_resolve).tar.gz"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/blackbox-exporter.service

--- a/install/prometheus-install.sh
+++ b/install/prometheus-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "prometheus" "prometheus/prometheus" "prebuild" "latest" "/usr/local/bin" "*linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "prometheus" "prometheus/prometheus" "prebuild" "latest" "/usr/local/bin" "*linux-$(arch_resolve).tar.gz"
 
 msg_info "Installing Prometheus"
 mkdir -p /etc/prometheus

--- a/install/prowlarr-install.sh
+++ b/install/prowlarr-install.sh
@@ -14,10 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y sqlite3
+$STD apt install -y sqlite3 libicu-dev
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "prowlarr" "Prowlarr/Prowlarr" "prebuild" "latest" "/opt/Prowlarr" "Prowlarr.master*linux-core-x64.tar.gz"
+fetch_and_deploy_gh_release "prowlarr" "Prowlarr/Prowlarr" "prebuild" "latest" "/opt/Prowlarr" "Prowlarr.master*linux-core-$(arch_resolve "x64" "arm64").tar.gz"
 
 msg_info "Configuring Prowlarr"
 mkdir -p /var/lib/prowlarr/

--- a/install/proxmox-backup-server-install.sh
+++ b/install/proxmox-backup-server-install.sh
@@ -13,16 +13,30 @@ setting_up_container
 network_check
 update_os
 
-msg_info "Installing Proxmox Backup Server"
-setup_deb822_repo \
-  "proxmox-backup-server" \
-  "https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg" \
-  "http://download.proxmox.com/debian/pbs" \
-  "trixie" \
-  "pbs-no-subscription"
 export DEBIAN_FRONTEND=noninteractive
 export IFUPDOWN2_NO_IFRELOAD=1
-$STD apt install -y proxmox-backup-server
+if [[ "$(arch_resolve)" == "arm64" ]]; then
+  msg_info "Installing Proxmox Backup Server (unofficial arm64 build)"
+  PBS_TMP="$(mktemp -d)"
+  github_api_call "https://api.github.com/repos/wofferl/proxmox-backup-arm64/releases/latest" "$PBS_TMP/release.json"
+  cd "$PBS_TMP"
+  for url in $(jq -r '.assets[].browser_download_url
+    | select(endswith(".deb"))
+    | select(test("dbgsym|client-static|file-restore") | not)' release.json); do
+    curl_with_retry "$url" "$(basename "$url")"
+  done
+  $STD apt install -y ./*.deb
+  rm -rf "$PBS_TMP"
+else
+  msg_info "Installing Proxmox Backup Server"
+  setup_deb822_repo \
+    "proxmox-backup-server" \
+    "https://enterprise.proxmox.com/debian/proxmox-archive-keyring-trixie.gpg" \
+    "http://download.proxmox.com/debian/pbs" \
+    "trixie" \
+    "pbs-no-subscription"
+  $STD apt install -y proxmox-backup-server
+fi
 msg_ok "Installed Proxmox Backup Server"
 
 motd_ssh

--- a/install/pterodactyl-panel-install.sh
+++ b/install/pterodactyl-panel-install.sh
@@ -18,7 +18,8 @@ $STD apt install -y \
   lsb-release \
   redis \
   apache2 \
-  composer
+  composer \
+  cron
 msg_ok "Installed Dependencies"
 
 setup_mariadb

--- a/install/pterodactyl-wings-install.sh
+++ b/install/pterodactyl-wings-install.sh
@@ -15,7 +15,7 @@ update_os
 
 setup_docker
 
-fetch_and_deploy_gh_release "wings" "pterodactyl/wings" "singlefile" "latest" "/usr/local/bin" "wings_linux_amd64"
+fetch_and_deploy_gh_release "wings" "pterodactyl/wings" "singlefile" "latest" "/usr/local/bin" "wings_linux_$(arch_resolve)"
 mkdir -p /etc/pterodactyl
 
 msg_info "Creating Service"

--- a/install/pulse-install.sh
+++ b/install/pulse-install.sh
@@ -29,7 +29,7 @@ else
 fi
 
 mkdir -p /etc/pulse
-fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-amd64.tar.gz"
+fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz"
 ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
 chown -R pulse:pulse /etc/pulse /opt/pulse
 msg_ok "Installed Pulse"

--- a/install/qbittorrent-install.sh
+++ b/install/qbittorrent-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "qbittorrent" "userdocs/qbittorrent-nox-static" "singlefile" "latest" "/opt/qbittorrent" "x86_64-qbittorrent-nox"
+fetch_and_deploy_gh_release "qbittorrent" "userdocs/qbittorrent-nox-static" "singlefile" "latest" "/opt/qbittorrent" "$(arch_resolve "x86_64" "aarch64")-qbittorrent-nox"
 
 msg_info "Setup qBittorrent-nox"
 mv /opt/qbittorrent/qbittorrent /opt/qbittorrent/qbittorrent-nox


### PR DESCRIPTION
## ✍️ Description
This PR adds support for arm64 for the scripts titled between papra and qbittorrent. The following three scripts are not supported, as they all do not ship arm64 binaries:
- proxmox-datacenter-manager
- proxmox-mail-gateway
- protonmail-bridge

Something that needs to be reviewed is that PBS is using an [unofficial build that supports arm64](https://github.com/wofferl/proxmox-backup-arm64).  I have used this previously on my fork, but I wanted to check about using it here. I'll add a warning about it using an unofficial binary if it gets approved.

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
