### PR TITLE
Matomo: flatten nested deploy layout after update

### DIFF
--- a/ct/matomo.sh
+++ b/ct/matomo.sh
@@ -43,6 +43,18 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "matomo" "matomo-org/matomo" "prebuild" "latest" "/opt/matomo" "matomo-*.zip"
 
+    msg_info "Setting up Matomo"
+    # Matomo zips ship matomo/ plus How to install Matomo.html at the root, so prebuild
+    # deploy lands files in /opt/matomo/matomo/ instead of /opt/matomo/ (404 on :80).
+    if [[ -d /opt/matomo/matomo ]]; then
+      rm -rf /opt/matomo/tmp "/opt/matomo/How to install Matomo.html"
+      find /opt/matomo/matomo -mindepth 1 -maxdepth 1 -exec mv -t /opt/matomo {} +
+      rm -rf /opt/matomo/matomo
+    fi
+    mkdir -p /opt/matomo/tmp
+    chmod -R 755 /opt/matomo/tmp
+    msg_ok "Set up Matomo"
+
     msg_info "Restoring Data"
     if [[ -f /opt/matomo_config.bak ]]; then
       mkdir -p /opt/matomo/config
@@ -58,7 +70,16 @@ function update_script() {
     chown -R www-data:www-data /opt/matomo
     msg_ok "Restored Data"
 
+    if [[ -f /opt/matomo/console ]]; then
+      msg_info "Running Matomo database upgrade"
+      cd /opt/matomo
+      $STD sudo -u www-data php console core:update --no-interaction
+      msg_ok "Ran Matomo database upgrade"
+    fi
+
     msg_info "Starting Services"
+    PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
+    systemctl restart "php${PHP_VER}-fpm"
     systemctl start caddy
     msg_ok "Started Services"
     msg_ok "Updated successfully!"

--- a/ct/matomo.sh
+++ b/ct/matomo.sh
@@ -44,8 +44,6 @@ function update_script() {
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "matomo" "matomo-org/matomo" "prebuild" "latest" "/opt/matomo" "matomo-*.zip"
 
     msg_info "Setting up Matomo"
-    # Matomo zips ship matomo/ plus How to install Matomo.html at the root, so prebuild
-    # deploy lands files in /opt/matomo/matomo/ instead of /opt/matomo/ (404 on :80).
     if [[ -d /opt/matomo/matomo ]]; then
       rm -rf /opt/matomo/tmp "/opt/matomo/How to install Matomo.html"
       find /opt/matomo/matomo -mindepth 1 -maxdepth 1 -exec mv -t /opt/matomo {} +
@@ -73,7 +71,7 @@ function update_script() {
     if [[ -f /opt/matomo/console ]]; then
       msg_info "Running Matomo database upgrade"
       cd /opt/matomo
-      $STD sudo -u www-data php console core:update --no-interaction
+      $STD runuser -u www-data -- php console core:update --no-interaction
       msg_ok "Ran Matomo database upgrade"
     fi
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Matomo 5.11.x zips include a root-level HTML file beside the matomo/ folder, so prebuild deploy no longer strips the wrapper and leaves index.php under /opt/matomo/matomo/. Mirror the install flatten step, recreate tmp, run core:update, and restart PHP-FPM with Caddy.

## 🔗 Related Issue

Fixes #15242

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
