### PR TITLE
[arm64] Port scripts between qdrant & snipeit to support arm64

### DIFF
--- a/ct/qdrant.sh
+++ b/ct/qdrant.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-5}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/qui.sh
+++ b/ct/qui.sh
@@ -12,7 +12,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-1024}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop qui
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "qui" "autobrr/qui" "prebuild" "latest" "/tmp/qui" "qui_*_linux_x86_64.tar.gz"
+    fetch_and_deploy_gh_release "qui" "autobrr/qui" "prebuild" "latest" "/tmp/qui" "qui_*_linux_$(arch_resolve "x86_64" "arm64").tar.gz"
 
     msg_info "Updating qui"
     mv /tmp/qui/qui /usr/local/bin/qui

--- a/ct/rabbitmq.sh
+++ b/ct/rabbitmq.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/radarr.sh
+++ b/ct/radarr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -36,7 +36,7 @@ function update_script() {
     msg_ok "Stopped Service"
 
     rm -rf /opt/Radarr
-    fetch_and_deploy_gh_release "Radarr" "Radarr/Radarr" "prebuild" "latest" "/opt/Radarr" "Radarr.master*linux-core-x64.tar.gz"
+    fetch_and_deploy_gh_release "Radarr" "Radarr/Radarr" "prebuild" "latest" "/opt/Radarr" "Radarr.master*linux-core-$(arch_resolve "x64" "arm64").tar.gz"
     chmod 775 /opt/Radarr
 
     msg_info "Starting Service"

--- a/ct/rclone.sh
+++ b/ct/rclone.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_fuse="${var_fuse:-yes}"
 
@@ -34,7 +34,7 @@ function update_script() {
     systemctl stop rclone-web
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "rclone" "rclone/rclone" "prebuild" "latest" "/opt/rclone" "rclone*linux-amd64.zip"
+    fetch_and_deploy_gh_release "rclone" "rclone/rclone" "prebuild" "latest" "/opt/rclone" "rclone*linux-$(arch_resolve).zip"
 
     msg_info "Starting Service"
     systemctl start rclone-web

--- a/ct/rdtclient.sh
+++ b/ct/rdtclient.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/readarr.sh
+++ b/ct/readarr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/readeck.sh
+++ b/ct/readeck.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop readeck
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_codeberg_release "readeck" "readeck/readeck" "singlefile" "latest" "/opt/readeck" "readeck-*-linux-amd64"
+    fetch_and_deploy_codeberg_release "readeck" "readeck/readeck" "singlefile" "latest" "/opt/readeck" "readeck-*-linux-$(arch_resolve)"
 
     msg_info "Starting Service"
     systemctl start readeck

--- a/ct/recyclarr.sh
+++ b/ct/recyclarr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -32,7 +32,7 @@ function update_script() {
 
     msg_info "Updating ${APP}"
 
-    fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-x64.tar.xz"
+    fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-$(arch_resolve "x64" "arm64").tar.xz"
 
     # Migrate includes from configs/ to includes/ (recyclarr v8)
     RECYCLARR_DIR="/root/.config/recyclarr"

--- a/ct/reitti.sh
+++ b/ct/reitti.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-15}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/rustdeskserver.sh
+++ b/ct/rustdeskserver.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-2}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -39,10 +39,10 @@ function update_script() {
     fi
     msg_info "Stopped Service"
 
-    fetch_and_deploy_gh_release "rustdesk-hbbr" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbr*amd64.deb"
-    fetch_and_deploy_gh_release "rustdesk-hbbs" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbs*amd64.deb"
-    fetch_and_deploy_gh_release "rustdesk-utils" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-utils*amd64.deb"
-    fetch_and_deploy_gh_release "rustdesk-api" "lejianwen/rustdesk-api" "binary" "latest" "/opt/rustdesk" "rustdesk-api-server*amd64.deb"
+    fetch_and_deploy_gh_release "rustdesk-hbbr" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbr*$(arch_resolve).deb"
+    fetch_and_deploy_gh_release "rustdesk-hbbs" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbs*$(arch_resolve).deb"
+    fetch_and_deploy_gh_release "rustdesk-utils" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-utils*$(arch_resolve).deb"
+    fetch_and_deploy_gh_release "rustdesk-api" "lejianwen/rustdesk-api" "binary" "latest" "/opt/rustdesk" "rustdesk-api-server*$(arch_resolve).deb"
 
     msg_info "Starting services"
     systemctl start -q rustdesk-*

--- a/ct/sabnzbd.sh
+++ b/ct/sabnzbd.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-5}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -26,7 +26,7 @@ function update_script() {
     check_container_resources
 
     if par2 --version | grep -q "par2cmdline-turbo"; then
-        fetch_and_deploy_gh_release "par2cmdline-turbo" "animetosho/par2cmdline-turbo" "prebuild" "latest" "/usr/bin/" "*-linux-amd64.zip"
+        fetch_and_deploy_gh_release "par2cmdline-turbo" "animetosho/par2cmdline-turbo" "prebuild" "latest" "/usr/bin/" "*-linux-$(arch_resolve).zip"
     fi
 
     if [[ ! -d /opt/sabnzbd ]]; then

--- a/ct/scanopy.sh
+++ b/ct/scanopy.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -70,7 +70,7 @@ function update_script() {
     msg_ok "Created frontend UI"
 
     if [[ -f /etc/systemd/system/scanopy-daemon.service ]]; then
-      fetch_and_deploy_gh_release "Scanopy Daemon" "scanopy/scanopy" "singlefile" "latest" "/usr/local/bin" "scanopy-daemon-linux-amd64"
+      fetch_and_deploy_gh_release "Scanopy Daemon" "scanopy/scanopy" "singlefile" "latest" "/usr/local/bin" "scanopy-daemon-linux-$(arch_resolve)"
       mv "/usr/local/bin/Scanopy Daemon" /usr/local/bin/scanopy-daemon
       rm -f /usr/bin/scanopy-daemon ~/configure_daemon.sh
       sed -i -e 's|usr/bin|usr/local/bin|' \

--- a/ct/scraparr.sh
+++ b/ct/scraparr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/seaweedfs.sh
+++ b/ct/seaweedfs.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-16}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 var_fuse="${var_fuse:-yes}"
 
@@ -36,7 +36,7 @@ function update_script() {
     systemctl stop seaweedfs
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "seaweedfs" "seaweedfs/seaweedfs" "prebuild" "latest" "/opt/seaweedfs" "linux_amd64.tar.gz"
+    fetch_and_deploy_gh_release "seaweedfs" "seaweedfs/seaweedfs" "prebuild" "latest" "/opt/seaweedfs" "linux_$(arch_resolve).tar.gz"
 
     msg_info "Starting Service"
     systemctl start seaweedfs

--- a/ct/seerr.sh
+++ b/ct/seerr.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-12}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/semaphore.sh
+++ b/ct/semaphore.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-ubuntu}"
 var_version="${var_version:-24.04}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -55,7 +55,7 @@ function update_script() {
     systemctl stop semaphore
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_amd64.deb"
+    fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_$(arch_resolve).deb"
 
     if [[ -f /opt/semaphore/semaphore_db.bolt ]]; then
       $STD semaphore migrate --from-boltdb /opt/semaphore/semaphore_db.bolt --config /opt/semaphore/config.json

--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-8}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/shlink.sh
+++ b/ct/shlink.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/ct/signoz.sh
+++ b/ct/signoz.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-4096}"
 var_disk="${var_disk:-20}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -35,9 +35,9 @@ function update_script() {
     systemctl stop signoz-otel-collector
     msg_ok "Stopped Services"
 
-    fetch_and_deploy_gh_release "signoz" "SigNoz/signoz" "prebuild" "latest" "/opt/signoz" "signoz-community_linux_amd64.tar.gz"
-    fetch_and_deploy_gh_release "signoz-otel-collector" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-otel-collector" "signoz-otel-collector_linux_amd64.tar.gz"
-    fetch_and_deploy_gh_release "signoz-schema-migrator" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-schema-migrator" "signoz-schema-migrator_linux_amd64.tar.gz"
+    fetch_and_deploy_gh_release "signoz" "SigNoz/signoz" "prebuild" "latest" "/opt/signoz" "signoz-community_linux_$(arch_resolve).tar.gz"
+    fetch_and_deploy_gh_release "signoz-otel-collector" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-otel-collector" "signoz-otel-collector_linux_$(arch_resolve).tar.gz"
+    fetch_and_deploy_gh_release "signoz-schema-migrator" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-schema-migrator" "signoz-schema-migrator_linux_$(arch_resolve).tar.gz"
 
     msg_info "Updating SigNoz"
     cd /opt/signoz-schema-migrator/bin 

--- a/ct/silverbullet.sh
+++ b/ct/silverbullet.sh
@@ -12,7 +12,7 @@ var_disk="${var_disk:-2}"
 var_ram="${var_ram:-512}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 
 header_info "${APP}"
 variables
@@ -33,7 +33,7 @@ function update_script() {
     systemctl stop silverbullet
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "silverbullet" "silverbulletmd/silverbullet" "prebuild" "latest" "/opt/silverbullet/bin" "silverbullet-server-linux-x86_64.zip"
+    fetch_and_deploy_gh_release "silverbullet" "silverbulletmd/silverbullet" "prebuild" "latest" "/opt/silverbullet/bin" "silverbullet-server-linux-$(arch_resolve "x86_64" "aarch64").zip"
 
     msg_info "Starting Service"
     systemctl start silverbullet

--- a/ct/slskd.sh
+++ b/ct/slskd.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-512}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-no}"
+var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"
@@ -40,7 +40,7 @@ function update_script() {
     cp /opt/slskd/config/slskd.yml /opt/slskd.yml.bak
     msg_ok "Backed up config"
 
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Slskd" "slskd/slskd" "prebuild" "latest" "/opt/slskd" "slskd-*-linux-x64.zip"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Slskd" "slskd/slskd" "prebuild" "latest" "/opt/slskd" "slskd-*-linux-$(arch_resolve "x64" "arm64").zip"
 
     msg_info "Restoring config"
     mv /opt/slskd.yml.bak /opt/slskd/config/slskd.yml

--- a/install/qdrant-install.sh
+++ b/install/qdrant-install.sh
@@ -13,7 +13,11 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "qdrant" "qdrant/qdrant" "binary" "latest" "/usr/bin/qdrant"
+if [[ "$(arch_resolve)" == "arm64" ]]; then
+  fetch_and_deploy_gh_release "qdrant" "qdrant/qdrant" "prebuild" "latest" "/usr/bin" "qdrant-aarch64-unknown-linux-musl.tar.gz"
+else
+  fetch_and_deploy_gh_release "qdrant" "qdrant/qdrant" "binary" "latest" "/usr/bin/qdrant"
+fi
 
 msg_info "Creating Qdrant Configuration"
 mkdir -p /etc/qdrant

--- a/install/qui-install.sh
+++ b/install/qui-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "qui" "autobrr/qui" "prebuild" "latest" "/usr/local/bin" "qui_*_linux_x86_64.tar.gz"
+fetch_and_deploy_gh_release "qui" "autobrr/qui" "prebuild" "latest" "/usr/local/bin" "qui_*_linux_$(arch_resolve "x86_64" "arm64").tar.gz"
 chmod +x /usr/local/bin/qui
 ln -sf /usr/local/bin/qui /usr/bin/qui
 ln -sf /usr/local/bin/qui /opt/qui

--- a/install/radarr-install.sh
+++ b/install/radarr-install.sh
@@ -14,10 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y sqlite3
+$STD apt install -y sqlite3 libicu-dev
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "Radarr" "Radarr/Radarr" "prebuild" "latest" "/opt/Radarr" "Radarr.master*linux-core-x64.tar.gz"
+fetch_and_deploy_gh_release "Radarr" "Radarr/Radarr" "prebuild" "latest" "/opt/Radarr" "Radarr.master*linux-core-$(arch_resolve "x64" "arm64").tar.gz"
 
 msg_info "Configuring Radarr"
 mkdir -p /var/lib/radarr/

--- a/install/rclone-install.sh
+++ b/install/rclone-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y apache2-utils fuse3
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "rclone" "rclone/rclone" "prebuild" "latest" "/opt/rclone" "rclone*linux-amd64.zip"
+fetch_and_deploy_gh_release "rclone" "rclone/rclone" "prebuild" "latest" "/opt/rclone" "rclone*linux-$(arch_resolve).zip"
 
 msg_info "Installing rclone"
 cd /opt/rclone

--- a/install/readarr-install.sh
+++ b/install/readarr-install.sh
@@ -14,14 +14,14 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y sqlite3
+$STD apt install -y sqlite3 libicu-dev
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Readarr"
 mkdir -p /var/lib/readarr/
 chmod 775 /var/lib/readarr/
 cd /var/lib/readarr/
-$STD curl -fsSL 'https://readarr.servarr.com/v1/update/develop/updatefile?os=linux&runtime=netcore&arch=x64' -o readarr.tar.gz
+$STD curl -fsSL "https://readarr.servarr.com/v1/update/develop/updatefile?os=linux&runtime=netcore&arch=$(arch_resolve "x64" "arm64")" -o readarr.tar.gz
 $STD tar -xvzf readarr.tar.gz
 mv Readarr /opt
 chmod 775 /opt/Readarr

--- a/install/readeck-install.sh
+++ b/install/readeck-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_codeberg_release "readeck" "readeck/readeck" "singlefile" "latest" "/opt/readeck" "readeck-*-linux-amd64"
+fetch_and_deploy_codeberg_release "readeck" "readeck/readeck" "singlefile" "latest" "/opt/readeck" "readeck-*-linux-$(arch_resolve)"
 
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/readeck.service

--- a/install/recyclarr-install.sh
+++ b/install/recyclarr-install.sh
@@ -14,10 +14,10 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y git
+$STD apt install -y git libicu-dev cron
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-x64.tar.xz"
+fetch_and_deploy_gh_release "recyclarr" "recyclarr/recyclarr" "prebuild" "latest" "/usr/local/bin" "recyclarr-linux-$(arch_resolve "x64" "arm64").tar.xz"
 
 msg_info "Configuring Recyclarr"
 mkdir -p /root/.config/recyclarr/{configs,includes}

--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -126,9 +126,13 @@ EOF
 chmod 644 /var/lib/romm/config/config.yml
 msg_ok "Created configuration file"
 
-fetch_and_deploy_gh_release "RAHasher" "RetroAchievements/RALibretro" "prebuild" "latest" "/opt/RALibretro" "RAHasher-x64-Linux-*.zip"
-cp /opt/RALibretro/RAHasher /usr/bin/RAHasher
-chmod +x /usr/bin/RAHasher
+if [[ "$(arch_resolve)" != "arm64" ]]; then
+  fetch_and_deploy_gh_release "RAHasher" "RetroAchievements/RALibretro" "prebuild" "latest" "/opt/RALibretro" "RAHasher-x64-Linux-*.zip"
+  cp /opt/RALibretro/RAHasher /usr/bin/RAHasher
+  chmod +x /usr/bin/RAHasher
+else
+  msg_warn "RAHasher (RetroAchievements hashing) has no arm64 build; skipping. RA hash features will be unavailable."
+fi
 
 fetch_and_deploy_gh_release "romm" "rommapp/romm" "tarball"
 

--- a/install/rustdeskserver-install.sh
+++ b/install/rustdeskserver-install.sh
@@ -13,10 +13,10 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "rustdesk-hbbr" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbr*amd64.deb"
-fetch_and_deploy_gh_release "rustdesk-hbbs" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbs*amd64.deb"
-fetch_and_deploy_gh_release "rustdesk-utils" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-utils*amd64.deb"
-fetch_and_deploy_gh_release "rustdesk-api" "lejianwen/rustdesk-api" "binary" "latest" "/opt/rustdesk" "rustdesk-api-server*amd64.deb"
+fetch_and_deploy_gh_release "rustdesk-hbbr" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbr*$(arch_resolve).deb"
+fetch_and_deploy_gh_release "rustdesk-hbbs" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-hbbs*$(arch_resolve).deb"
+fetch_and_deploy_gh_release "rustdesk-utils" "lejianwen/rustdesk-server" "binary" "latest" "/opt/rustdesk" "rustdesk-server-utils*$(arch_resolve).deb"
+fetch_and_deploy_gh_release "rustdesk-api" "lejianwen/rustdesk-api" "binary" "latest" "/opt/rustdesk" "rustdesk-api-server*$(arch_resolve).deb"
 systemctl enable -q --now rustdesk-hbbr
 systemctl enable -q --now rustdesk-hbbs
 systemctl enable -q --now rustdesk-api

--- a/install/sabnzbd-install.sh
+++ b/install/sabnzbd-install.sh
@@ -43,7 +43,7 @@ msg_ok "Installed SABnzbd"
 read -r -p "Would you like to install par2cmdline-turbo? <y/N> " prompt
 if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
   mv /usr/bin/par2 /usr/bin/par2.old
-  fetch_and_deploy_gh_release "par2cmdline-turbo" "animetosho/par2cmdline-turbo" "prebuild" "latest" "/usr/bin/" "*-linux-amd64.zip"
+  fetch_and_deploy_gh_release "par2cmdline-turbo" "animetosho/par2cmdline-turbo" "prebuild" "latest" "/usr/bin/" "*-linux-$(arch_resolve).zip"
 fi
 
 msg_info "Creating Service"

--- a/install/seaweedfs-install.sh
+++ b/install/seaweedfs-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y fuse3
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "seaweedfs" "seaweedfs/seaweedfs" "prebuild" "latest" "/opt/seaweedfs" "linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "seaweedfs" "seaweedfs/seaweedfs" "prebuild" "latest" "/opt/seaweedfs" "linux_$(arch_resolve).tar.gz"
 
 msg_info "Setting up SeaweedFS"
 mkdir -p /opt/seaweedfs-data

--- a/install/semaphore-install.sh
+++ b/install/semaphore-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   ansible
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_amd64.deb"
+fetch_and_deploy_gh_release "semaphore" "semaphoreui/semaphore" "binary" "latest" "/opt/semaphore" "semaphore_*_linux_$(arch_resolve).deb"
 
 msg_info "Configuring Semaphore"
 mkdir -p /opt/semaphore

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -49,6 +49,10 @@ echo ""
 
 read -r -p "${TAB3}Select deployment type [1]: " DEPLOYMENT_TYPE
 DEPLOYMENT_TYPE="${DEPLOYMENT_TYPE:-1}"
+if [[ "$(arch_resolve)" == "arm64" && "$DEPLOYMENT_TYPE" == "2" ]]; then
+  msg_warn "FlareSolverr has no arm64 build; using Shelfmark's internal bypasser instead"
+  DEPLOYMENT_TYPE="1"
+fi
 
 case "$DEPLOYMENT_TYPE" in
 1)

--- a/install/signoz-install.sh
+++ b/install/signoz-install.sh
@@ -28,7 +28,7 @@ Types: deb
 URIs: https://packages.clickhouse.com/deb
 Suites: stable
 Components: main
-Architectures: amd64
+Architectures: $(arch_resolve)
 Signed-By: /usr/share/keyrings/clickhouse-keyring.gpg
 EOF
 $STD apt update
@@ -108,7 +108,7 @@ EOF
 systemctl enable -q --now clickhouse-server
 msg_ok "Configured ClickHouse"
 
-fetch_and_deploy_gh_release "signoz-schema-migrator" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-schema-migrator" "signoz-schema-migrator_linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "signoz-schema-migrator" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-schema-migrator" "signoz-schema-migrator_linux_$(arch_resolve).tar.gz"
 
 msg_info "Running ClickHouse migrations"
 cd /opt/signoz-schema-migrator/bin
@@ -116,7 +116,7 @@ $STD ./signoz-schema-migrator sync --dsn="tcp://localhost:9000?password=" --repl
 $STD ./signoz-schema-migrator async --dsn="tcp://localhost:9000?password=" --replication=true --up=
 msg_ok "ClickHouse Migrations Completed"
 
-fetch_and_deploy_gh_release "signoz" "SigNoz/signoz" "prebuild" "latest" "/opt/signoz" "signoz-community_linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "signoz" "SigNoz/signoz" "prebuild" "latest" "/opt/signoz" "signoz-community_linux_$(arch_resolve).tar.gz"
 
 msg_info "Setting up SigNoz"
 mkdir -p /var/lib/signoz
@@ -153,7 +153,7 @@ EOF
 systemctl enable -q --now signoz
 msg_ok "Setup Signoz"
 
-fetch_and_deploy_gh_release "signoz-otel-collector" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-otel-collector" "signoz-otel-collector_linux_amd64.tar.gz"
+fetch_and_deploy_gh_release "signoz-otel-collector" "SigNoz/signoz-otel-collector" "prebuild" "latest" "/opt/signoz-otel-collector" "signoz-otel-collector_linux_$(arch_resolve).tar.gz"
 
 msg_info "Setting up SigNoz OTel Collector"
 mkdir -p /var/lib/signoz-otel-collector

--- a/install/silverbullet-install.sh
+++ b/install/silverbullet-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "silverbullet" "silverbulletmd/silverbullet" "prebuild" "latest" "/opt/silverbullet/bin" "silverbullet-server-linux-x86_64.zip"
+fetch_and_deploy_gh_release "silverbullet" "silverbulletmd/silverbullet" "prebuild" "latest" "/opt/silverbullet/bin" "silverbullet-server-linux-$(arch_resolve "x86_64" "aarch64").zip"
 mkdir -p /opt/silverbullet/space
 
 msg_info "Creating Service"

--- a/install/slskd-install.sh
+++ b/install/slskd-install.sh
@@ -13,7 +13,11 @@ setting_up_container
 network_check
 update_os
 
-fetch_and_deploy_gh_release "Slskd" "slskd/slskd" "prebuild" "latest" "/opt/slskd" "slskd-*-linux-x64.zip"
+msg_info "Installing Dependencies"
+$STD apt install -y libicu-dev
+msg_ok "Installed Dependencies"
+
+fetch_and_deploy_gh_release "Slskd" "slskd/slskd" "prebuild" "latest" "/opt/slskd" "slskd-*-linux-$(arch_resolve "x64" "arm64").zip"
 
 msg_info "Configuring Slskd"
 JWT_KEY=$(openssl rand -base64 44)


### PR DESCRIPTION
## ✍️ Description
Adds arm64 support to scripts titled between mediamtx and nocodb. This has 35/38 scripts marked as working, with the three that don't work being:

reactive-resume: script is disabled
romm: got a 403 error while testing - will need to come back and test again later
rustypaste: only ships amd64 binary

has_arm has been set in db

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [x] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
