### PR TITLE
Degoog: Fix valkey url in update; set mandatory settings password

### DIFF
--- a/ct/degoog.sh
+++ b/ct/degoog.sh
@@ -57,9 +57,11 @@ function update_script() {
     restore_backup
 
     if [[ -f /opt/degoog/.env ]]; then
-      grep -q "^DEGOOG_VALKEY_URL=" /opt/degoog/.env && sed -i "s|^DEGOOG_VALKEY_URL=.*|DEGOOG_VALKEY_URL=redis://valkey:6379|" /opt/degoog/.env || echo "DEGOOG_VALKEY_URL=redis://valkey:6379" >>/opt/degoog/.env
+      grep -q "^DEGOOG_VALKEY_URL=" /opt/degoog/.env && sed -i "s|^DEGOOG_VALKEY_URL=.*|DEGOOG_VALKEY_URL=redis://127.0.0.1:6379|" /opt/degoog/.env || echo "DEGOOG_VALKEY_URL=redis://127.0.0.1:6379" >>/opt/degoog/.env
       grep -q "^DEGOOG_CACHE_MAX_ENTRIES=" /opt/degoog/.env && sed -i "s|^DEGOOG_CACHE_MAX_ENTRIES=.*|DEGOOG_CACHE_MAX_ENTRIES=1000|" /opt/degoog/.env || echo "DEGOOG_CACHE_MAX_ENTRIES=1000" >>/opt/degoog/.env
       grep -q "^DEGOOG_CACHE_TTL_MS=" /opt/degoog/.env && sed -i "s|^DEGOOG_CACHE_TTL_MS=.*|DEGOOG_CACHE_TTL_MS=43200000|" /opt/degoog/.env || echo "DEGOOG_CACHE_TTL_MS=43200000" >>/opt/degoog/.env
+      grep -q "^# DEGOOG_SETTINGS_PASSWORDS" /opt/degoog/.env && sed -i "s|^# DEGOOG_SETTINGS_PASSWORDS=.*|DEGOOG_SETTINGS_PASSWORDS=$(openssl rand -hex 32)|" /opt/degoog/.env &&
+        msg_warn "Mandatory Settings Password created - check /opt/degoog/.env"
     fi
     msg_ok "Restored Configuration & Data"
 

--- a/install/degoog-install.sh
+++ b/install/degoog-install.sh
@@ -33,6 +33,7 @@ fetch_and_deploy_gh_release "degoog" "fccview/degoog" "prebuild" "latest" "/opt/
 msg_info "Setting up degoog"
 mkdir -p /opt/degoog/data/{engines,plugins,themes,store}
 
+SETTINGS_PASS="$(openssl rand -hex 32)"
 cat <<EOF >/opt/degoog/.env
 DEGOOG_PORT=4444
 DEGOOG_ENGINES_DIR=/opt/degoog/data/engines
@@ -43,7 +44,7 @@ DEGOOG_PLUGIN_SETTINGS_FILE=/opt/degoog/data/plugin-settings.json
 DEGOOG_VALKEY_URL=redis://127.0.0.1:6379
 DEGOOG_CACHE_MAX_ENTRIES=1000
 DEGOOG_CACHE_TTL_MS=43200000
-# DEGOOG_SETTINGS_PASSWORDS=changeme
+DEGOOG_SETTINGS_PASSWORDS=${SETTINGS_PASS}
 # DEGOOG_PUBLIC_INSTANCE=false
 # LOGGER=debug
 EOF


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Version 0.22 brings increased security by enforcing that a settings password is configured. See the [release notes](https://github.com/degoog-org/degoog/releases/tag/0.22.0) for details.
- Fix an issue in the update script where it was still using `valkey` as hostname.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
