### PR TITLE
fix: close lxc build function

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -5820,7 +5820,7 @@ create_lxc_container() {
       ;;
     *) return 2 ;;
     esac
-  ;;
+  }
 
   ARCH="$(dpkg --print-architecture)"
 


### PR DESCRIPTION
## ✍️ Description
Fixes a syntax error in misc/build.func by replacing ;; with the missing function-closing } after offer_lxc_stack_upgrade_and_maybe_retry().

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
