### PR TITLE
update jdk when updating crafty-controller

### DIFF
--- a/ct/crafty-controller.sh
+++ b/ct/crafty-controller.sh
@@ -46,6 +46,12 @@ function update_script() {
 
     restore_backup
 
+    msg_info "Updating TemurinJDK"
+    setup_java
+    $STD apt install -y temurin-{8,11,17,21,25}-jre
+    $STD update-alternatives --set java /usr/lib/jvm/temurin-25-jre-$(arch_resolve)/bin/java
+    msg_ok "Updated TemurinJDK"
+
     msg_info "Updating Python dependencies"
     chown -R crafty:crafty /opt/crafty-controller
     cd /opt/crafty-controller/crafty/crafty-4


### PR DESCRIPTION
# ✍️ Description
Adds updating/installing jdk vers in the update function of crafty-controller, so that old instances get new versions of jdk

## 🔗 Related Issue

Fixes #15311

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
