### PR TITLE
fix(build.func): close var_sdn_vnet case block

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1270,6 +1270,9 @@ load_vars_file() {
         var_sdn_vnet)
           if [[ -n "$var_val" ]] && ! validate_sdn_vnet "$var_val"; then
             msg_warn "SDN vnet '$var_val' from $file not found, ignoring"
+            continue
+          fi
+          ;;
         var_http_proxy)
           if [[ -n "$var_val" ]] && ! [[ "$var_val" =~ ^https?://[^[:space:]]+(:[0-9]+)?/?$ ]]; then
             msg_warn "Invalid HTTP proxy URL '$var_val' in $file, ignoring"


### PR DESCRIPTION
Commit e193adad5 added the `var_sdn_vnet` case entry to `load_vars_file()` but omitted `continue`, `fi`, and `;;`, leaving the block unclosed. This caused bash to throw `syntax error near unexpected token ')'` when sourcing `build.func`, breaking all LXC installs. Added the three missing lines to match the pattern of every other case entry in the same block.