### PR TITLE
Fix: Add missing 'fi' and ';;' in var_sdn_vnet case statement in buil…

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -1270,6 +1270,8 @@ load_vars_file() {
         var_sdn_vnet)
           if [[ -n "$var_val" ]] && ! validate_sdn_vnet "$var_val"; then
             msg_warn "SDN vnet '$var_val' from $file not found, ignoring"
+          fi
+          ;;
         var_http_proxy)
           if [[ -n "$var_val" ]] && ! [[ "$var_val" =~ ^https?://[^[:space:]]+(:[0-9]+)?/?$ ]]; then
             msg_warn "Invalid HTTP proxy URL '$var_val' in $file, ignoring"


### PR DESCRIPTION
## ✍️ Description

Fixed a syntax error in `misc/build.func` where the `var_sdn_vnet` case statement was missing the closing `fi` and `;;` statements. This caused all scripts that source this file (like `ct/trek.sh` and `ct/hermesagent.sh`) to fail with:

/dev/fd/63: line 1273: syntax error near unexpected token `)'

**Changes made:**
- Added missing `fi` to properly close the if statement (line 1273)
- Added missing `;;` to properly close the case statement (line 1274)

## 🔗 Related Issue

Fixes #15382

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to README, AppName.md, CONTRIBUTING.md, or other docs.