### PR TITLE
tools.func: fix setup_docker - don't abort update on docker pull failure

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4614,11 +4614,11 @@ EOF
       local image=$(echo "$container" | awk '{print $2}')
       local current_digest=$(docker inspect "$name" --format='{{.Image}}' 2>/dev/null | cut -d':' -f2 | cut -c1-12)
 
-      # Pull latest image digest
-      docker pull "$image" >/dev/null 2>&1
+      # Pull latest image digest (ignore failures, e.g. local-only images or registry/permission issues)
+      docker pull "$image" >/dev/null 2>&1 || true
       local latest_digest=$(docker inspect "$image" --format='{{.Id}}' 2>/dev/null | cut -d':' -f2 | cut -c1-12)
 
-      if [ "$current_digest" != "$latest_digest" ]; then
+      if [ -n "$latest_digest" ] && [ "$current_digest" != "$latest_digest" ]; then
         containers_with_updates+=("$name")
         container_info+=("${index}) ${name} (${image})")
         ((index++))
@@ -7561,8 +7561,8 @@ setup_nodejs() {
   }
 
   # Install global Node modules
-  if [[ -n "$NODE_MODULE" ]] || (( node_major >= 25 )); then
-    if (( node_major >= 25 )) && [[ ",${NODE_MODULE}," != *",corepack,"* ]] && [[ "$NODE_MODULE" != corepack* ]]; then
+  if [[ -n "$NODE_MODULE" ]] || ((node_major >= 25)); then
+    if ((node_major >= 25)) && [[ ",${NODE_MODULE}," != *",corepack,"* ]] && [[ "$NODE_MODULE" != corepack* ]]; then
       NODE_MODULE="${NODE_MODULE:+$NODE_MODULE,}corepack"
     fi
 
@@ -7624,12 +7624,12 @@ setup_nodejs() {
         fi
       fi
     done
-    if (( failed_modules > 0 )); then
+    if ((failed_modules > 0)); then
       msg_warn "$failed_modules Node.js module(s) failed: $NODE_MODULE"
     fi
   fi
 
-  if [[ "$NODE_COREPACK_ENABLE" == "1" ]] && (( wants_corepack )) && command -v corepack >/dev/null 2>&1; then
+  if [[ "$NODE_COREPACK_ENABLE" == "1" ]] && ((wants_corepack)) && command -v corepack >/dev/null 2>&1; then
     msg_info "Enabling corepack"
     if $STD corepack enable 2>/dev/null; then
       msg_ok "Enabled corepack"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
During the container update check, a failing 'docker pull' (local-only images, registry or permission errors) aborted the whole script under errexit. Ignore pull failures and skip containers whose digest could not be resolved.


+ some LR fixes via vs code 

## 🔗 Related Issue

Fixes #15388

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
