### PR TITLE
Docuseal: use real SECRET_KEY_BASE for db:migrate on update

### DIFF
--- a/ct/docuseal.sh
+++ b/ct/docuseal.sh
@@ -55,7 +55,7 @@ function update_script() {
     eval "$(rbenv init - bash)" 2>/dev/null || true
     export RAILS_ENV=production
     export NODE_ENV=production
-    export SECRET_KEY_BASE_DUMMY=1
+    mkdir -p /opt/docuseal/tmp
     set -a
     source /opt/docuseal/.env
     set +a


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
SECRET_KEY_BASE_DUMMY forced rails to write tmp/local_secret.txt, which failed with EACCES during update and aborted db:migrate. Drop the dummy flag so the real SECRET_KEY_BASE from .env is used, and ensure tmp exists.

## 🔗 Related Issue

Fixes #15408

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
