### PR TITLE
QoL: clean-lxcs exclude matching and set -e cancel handling

### DIFF
--- a/tools/pve/clean-lxcs.sh
+++ b/tools/pve/clean-lxcs.sh
@@ -30,7 +30,7 @@ declare -f init_tool_telemetry &>/dev/null && init_tool_telemetry "clean-lxcs" "
 header_info
 echo "Loading..."
 
-whiptail --backtitle "Proxmox VE Helper Scripts" --title "Proxmox VE LXC Updater" --yesno "This will clean logs, cache and update package lists on selected LXC Containers. Proceed?" 10 58
+whiptail --backtitle "Proxmox VE Helper Scripts" --title "Proxmox VE LXC Updater" --yesno "This will clean logs, cache and update package lists on selected LXC Containers. Proceed?" 10 58 || exit 0
 
 NODE=$(hostname)
 EXCLUDE_MENU=()
@@ -42,17 +42,17 @@ while read -r TAG ITEM; do
   EXCLUDE_MENU+=("$TAG" "$ITEM " "OFF")
 done < <(pct list | awk 'NR>1')
 
-excluded_containers=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Containers on $NODE" --checklist "\nSelect containers to skip from cleaning:\n" \
-  16 $((MSG_MAX_LENGTH + 23)) 6 "${EXCLUDE_MENU[@]}" 3>&1 1>&2 2>&3 | tr -d '"')
-
-if [ $? -ne 0 ]; then
-  exit
+# Capture the selection; abort cleanly if the user cancels the dialog
+# (set -e would otherwise terminate on the failing command substitution).
+if ! excluded_containers=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Containers on $NODE" --checklist "\nSelect containers to skip from cleaning:\n" \
+  16 $((MSG_MAX_LENGTH + 23)) 6 "${EXCLUDE_MENU[@]}" 3>&1 1>&2 2>&3 | tr -d '"'); then
+  exit 0
 fi
 
 function run_lxc_clean() {
   local container=$1
   header_info
-  name=$(pct exec "$container" hostname)
+  name=$(pct exec "$container" -- hostname)
 
   pct exec "$container" -- bash -c '
     BL="\033[36m"; GN="\033[1;92m"; CL="\033[m"
@@ -84,7 +84,14 @@ function run_lxc_clean() {
 }
 
 for container in $(pct list | awk '{if(NR>1) print $1}'); do
-  if [[ " ${excluded_containers[@]} " =~ " $container " ]]; then
+  excluded=0
+  for ex in $excluded_containers; do
+    if [[ "$ex" == "$container" ]]; then
+      excluded=1
+      break
+    fi
+  done
+  if [[ "$excluded" -eq 1 ]]; then
     header_info
     echo -e "${BL}[Info]${GN} Skipping ${BL}$container${CL}"
     sleep 1


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Some little QoL Changes

- rplace the array-style exclude check (`${excluded_containers[@]}` on a plain string) with an explicit per-VMID loop, resolving the ShellCheck SC2199/SC2076 errors and avoiding accidental substring matches
- Abort cleanly when the checklist dialog is cancelled instead of relying on an unreachable `$?` test under `set -eEuo pipefail`.
- Exit gracefully on a declined confirmation prompt.
- Use `pct exec ... -- hostname` for consistent argument handling.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
