### PR TITLE
QoL: kernel-clean: Validate kernel selection input

### DIFF
--- a/tools/pve/kernel-clean.sh
+++ b/tools/pve/kernel-clean.sh
@@ -55,12 +55,23 @@ read -r selected
 selected_indices=()
 IFS=',' read -r -a tokens <<<"$selected"
 for token in "${tokens[@]}"; do
+  # Strip surrounding whitespace and skip empty tokens
+  token="${token//[[:space:]]/}"
+  [ -z "$token" ] && continue
   if [[ "$token" =~ ^([0-9]+)-([0-9]+)$ ]]; then
-    for ((i = BASH_REMATCH[1]; i <= BASH_REMATCH[2]; i++)); do
+    start=${BASH_REMATCH[1]}
+    end=${BASH_REMATCH[2]}
+    if ((start > end)); then
+      echo -e "${RD}Ignoring invalid range '${token}' (start greater than end).${CL}"
+      continue
+    fi
+    for ((i = start; i <= end; i++)); do
       selected_indices+=("$i")
     done
-  else
+  elif [[ "$token" =~ ^[0-9]+$ ]]; then
     selected_indices+=("$token")
+  else
+    echo -e "${RD}Ignoring invalid selection '${token}'.${CL}"
   fi
 done
 
@@ -101,8 +112,7 @@ for kernel in "${kernels_to_remove[@]}"; do
     remaining=$(dpkg --list |
       awk '/^ii/ {print $2}' |
       grep -E "^proxmox-kernel-${minor_version}\." |
-      grep -v "^${kernel}$" |
-      wc -l)
+      grep -cv "^${kernel}$")
     if [ "$remaining" -eq 0 ]; then
       pkgs_to_remove+=("$meta")
     fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
some QoL Changes migrated from my private repo

- Trim whitespace, skip empty tokens and reject non-numeric input so a malformed selection no longer feeds garbage into `sed -n "<index>p"`.
- Reject reversed ranges (start greater than end) with a clear message.
- Replace `grep | wc -l` with `grep -c` (ShellCheck SC2126).

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
