### PR TITLE
QoL: Harden microcode download/install in microcode and pbs-microcode

### DIFF
--- a/tools/pve/microcode.sh
+++ b/tools/pve/microcode.sh
@@ -16,10 +16,10 @@ function header_info {
 EOF
 }
 
-RD=$(echo "\033[01;31m")
-YW=$(echo "\033[33m")
-GN=$(echo "\033[1;92m")
-CL=$(echo "\033[m")
+RD="\033[01;31m"
+YW="\033[33m"
+GN="\033[1;92m"
+CL="\033[m"
 BFR="\\r\\033[K"
 HOLD="-"
 CM="${GN}✓${CL}"
@@ -47,7 +47,7 @@ intel() {
     sleep 1
   fi
 
-  intel_microcode=$(curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/i/intel-microcode//" | grep -o 'href="[^"]*amd64.deb"' | sed 's/href="//;s/"//')
+  intel_microcode=$(curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/i/intel-microcode/" | grep -o 'href="[^"]*amd64.deb"' | sed 's/href="//;s/"//')
   [ -z "$intel_microcode" ] && {
     whiptail --backtitle "Proxmox VE Helper Scripts" --title "No Microcode Found" --msgbox "It appears there were no microcode packages found\n Try again later." 10 68
     msg_info "Exiting"
@@ -80,17 +80,17 @@ intel() {
   msg_ok "Downloaded the Intel Processor Microcode Package $microcode"
 
   msg_info "Installing $microcode (Patience)"
-  dpkg -i $microcode &>/dev/null
+  dpkg -i "$microcode" &>/dev/null
   msg_ok "Installed $microcode"
 
   msg_info "Cleaning up"
-  rm $microcode
+  rm -f "$microcode"
   msg_ok "Cleaned"
   echo -e "\nIn order to apply the changes, a system reboot will be necessary.\n"
 }
 
 amd() {
-  amd_microcode=$(curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode///" | grep -o 'href="[^"]*amd64.deb"' | sed 's/href="//;s/"//')
+  amd_microcode=$(curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/" | grep -o 'href="[^"]*amd64.deb"' | sed 's/href="//;s/"//')
 
   [ -z "$amd_microcode" ] && {
     whiptail --backtitle "Proxmox VE Helper Scripts" --title "No Microcode Found" --msgbox "It appears there were no microcode packages found\n Try again later." 10 68
@@ -120,15 +120,15 @@ amd() {
   }
 
   msg_info "Downloading the AMD Processor Microcode Package $microcode"
-  curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode" -o $(basename "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode")
+  curl -fsSL --proto '=https' "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode" -o "$microcode"
   msg_ok "Downloaded the AMD Processor Microcode Package $microcode"
 
   msg_info "Installing $microcode (Patience)"
-  dpkg -i $microcode &>/dev/null
+  dpkg -i "$microcode" &>/dev/null
   msg_ok "Installed $microcode"
 
   msg_info "Cleaning up"
-  rm $microcode
+  rm -f "$microcode"
   msg_ok "Cleaned"
   echo -e "\nIn order to apply the changes, a system reboot will be necessary.\n"
 }

--- a/tools/pve/pbs-microcode.sh
+++ b/tools/pve/pbs-microcode.sh
@@ -18,10 +18,10 @@ EOF
 }
 
 # Color definitions
-RD=$(echo "\033[01;31m")
-YW=$(echo "\033[33m")
-GN=$(echo "\033[1;92m")
-CL=$(echo "\033[m")
+RD="\033[01;31m"
+YW="\033[33m"
+GN="\033[1;92m"
+CL="\033[m"
 BFR="\\r\\033[K"
 HOLD="-"
 CM="${GN}✓${CL}"
@@ -94,11 +94,11 @@ intel() {
   msg_ok "Downloaded Intel processor microcode package $microcode"
 
   msg_info "Installing $microcode (this might take a while)"
-  dpkg -i $microcode &>/dev/null
+  dpkg -i "$microcode" &>/dev/null
   msg_ok "Installed $microcode"
 
   msg_info "Cleaning up"
-  rm $microcode
+  rm -f "$microcode"
   msg_ok "Clean up complete"
   echo -e "\nA system reboot is required to apply the changes.\n"
 }
@@ -137,15 +137,15 @@ amd() {
   }
 
   msg_info "Downloading AMD processor microcode package $microcode"
-  curl -fsSL "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode" -o $(basename "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode")
+  curl -fsSL --proto '=https' "https://ftp.debian.org/debian/pool/non-free-firmware/a/amd64-microcode/$microcode" -o "$microcode"
   msg_ok "Downloaded AMD processor microcode package $microcode"
 
   msg_info "Installing $microcode (this might take a while)"
-  dpkg -i $microcode &>/dev/null
+  dpkg -i "$microcode" &>/dev/null
   msg_ok "Installed $microcode"
 
   msg_info "Cleaning up"
-  rm $microcode
+  rm -f "$microcode"
   msg_ok "Clean up complete"
   echo -e "\nA system reboot is required to apply the changes.\n"
 }


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
some QoL Changes migrated from my private repo

- AMD: download directly to "$microcode" instead of a convoluted, unquoted basename of the full URL (fixes ShellCheck SC2046) and pin to https.
- Quote dpkg install and cleanup paths (SC2086) and use rm -f.
- Normalize the Debian pool URLs (drop the stray double/triple slashes).
- Define color variables directly instead of via $(echo ...) (SC2116/SC2028).

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
