### PR TITLE
QoL: scaling-governor extend selection and guard missing cpufreq

### DIFF
--- a/tools/pve/scaling-governor.sh
+++ b/tools/pve/scaling-governor.sh
@@ -20,16 +20,26 @@ header_info() {
 EOF
 }
 header_info
-whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU Scaling Governors" --yesno "View/Change CPU Scaling Governors. Proceed?" 10 58
-current_governor=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor)
+whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU Scaling Governors" --yesno "View/Change CPU Scaling Governors. Proceed?" 10 58 || exit 0
+
+GOV_BASE="/sys/devices/system/cpu/cpu0/cpufreq"
+if [[ ! -r "$GOV_BASE/scaling_governor" || ! -r "$GOV_BASE/scaling_available_governors" ]]; then
+  whiptail --backtitle "Proxmox VE Helper Scripts" --title "CPU Scaling Not Available" \
+    --msgbox "CPU frequency scaling is not available on this system.\n\nThis is normal when no cpufreq driver is active (e.g. CPU power management handled by the BIOS, or certain virtualized hosts)." 12 70
+  clear
+  exit 0
+fi
+
+current_governor=$(cat "$GOV_BASE/scaling_governor")
 GOVERNORS_MENU=()
 MSG_MAX_LENGTH=0
 while read -r TAG ITEM; do
   OFFSET=2
   ((${#ITEM} + OFFSET > MSG_MAX_LENGTH)) && MSG_MAX_LENGTH=${#ITEM}+OFFSET
   GOVERNORS_MENU+=("$TAG" "$ITEM " "OFF")
-done < <(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors | tr ' ' '\n' | grep -v "$current_governor")
-scaling_governor=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Current CPU Scaling Governor is set to $current_governor" --checklist "\nSelect the Scaling Governor to use:\n" 16 $((MSG_MAX_LENGTH + 58)) 6 "${GOVERNORS_MENU[@]}" 3>&1 1>&2 2>&3 | tr -d '"')
+done < <(tr ' ' '\n' <"$GOV_BASE/scaling_available_governors" | sed '/^$/d' | grep -vxF "$current_governor")
+# A radiolist is used on purpose: only a single governor can be active at a time.
+scaling_governor=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "Current CPU Scaling Governor is set to $current_governor" --radiolist "\nSelect the Scaling Governor to use:\n" 16 $((MSG_MAX_LENGTH + 58)) 6 "${GOVERNORS_MENU[@]}" 3>&1 1>&2 2>&3 | tr -d '"')
 [ -z "$scaling_governor" ] && {
   whiptail --backtitle "Proxmox VE Helper Scripts" --title "No CPU Scaling Governor Selected" --msgbox "It appears that no CPU Scaling Governor was selected" 10 68
   clear
@@ -49,7 +59,7 @@ yes)
   EXISTING_CRONTAB=$(crontab -l 2>/dev/null)
   if [[ -n "$EXISTING_CRONTAB" ]]; then
     TEMP_CRONTAB_FILE=$(mktemp)
-    echo "$EXISTING_CRONTAB" | grep -v "@reboot (sleep 60 && echo*" >"$TEMP_CRONTAB_FILE"
+    echo "$EXISTING_CRONTAB" | grep -vF "@reboot (sleep 60 && echo" >"$TEMP_CRONTAB_FILE"
     crontab "$TEMP_CRONTAB_FILE"
     rm "$TEMP_CRONTAB_FILE"
   fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
- Use a radiolist instead of a checklist: only a single CPU scaling governor can be active, and a multi-select wrote an invalid space-joined value into scaling_governor
- Bail out with a clear message when no cpufreq driver is present (e.g. BIOS-managed power, some virtualized hosts) instead of crashing on `cat` under `set -e`
- Exit cleanly when the confirmation dialog is decline
- Read the available governors without a useless `cat` and match the current governor with a fixed string


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
