### PR TITLE
Deluge openssl fix

### DIFF
--- a/ct/deluge.sh
+++ b/ct/deluge.sh
@@ -31,7 +31,7 @@ function update_script() {
   msg_info "Updating Deluge"
   ensure_dependencies python3-setuptools
   $STD apt update
-  $STD pip3 install deluge[all] --upgrade
+  $STD pip3 install deluge[all] "pyopenssl<25" --upgrade
   msg_ok "Updated Deluge"
   msg_ok "Updated successfully!"
   exit

--- a/ct/deluge.sh
+++ b/ct/deluge.sh
@@ -12,7 +12,7 @@ var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
 var_version="${var_version:-13}"
-var_arm64="${var_arm64:-yes}"
+var_arm64="${var_arm64:-no}"
 var_unprivileged="${var_unprivileged:-1}"
 
 header_info "$APP"

--- a/install/deluge-install.sh
+++ b/install/deluge-install.sh
@@ -26,7 +26,7 @@ cat >~/.config/pip/pip.conf <<EOF
 [global]
 break-system-packages = true
 EOF
-$STD pip install deluge[all]
+$STD pip install deluge[all] "pyopenssl<25"
 msg_ok "Installed Deluge"
 
 msg_info "Creating Service"


### PR DESCRIPTION
## ✍️ Description
pyopenssl removed crypto.X509Req that deluge depended on in v25, so it needs to be pinned to <25 to allow deluge to install correctly.

Also a dependency named rencode currently has issues on arm64 preventing it from installing on arm64, fixed in git, but no release since May 2025, so marked it as unsupported.

## 🔗 Related Issue

Fixes #15433 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
