### PR TITLE
Storyteller: bump Node.js version to Node 24

### DIFF
--- a/ct/storyteller.sh
+++ b/ct/storyteller.sh
@@ -30,6 +30,8 @@ function update_script() {
     exit
   fi
 
+  NODE_VERSION="24" NODE_MODULE="corepack,yarn" setup_nodejs
+
   if check_for_gl_release "storyteller" "storyteller-platform/storyteller"; then
     msg_info "Stopping Service"
     systemctl stop storyteller

--- a/install/storyteller-install.sh
+++ b/install/storyteller-install.sh
@@ -24,7 +24,7 @@ $STD apt install -y \
   ffmpeg
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="corepack,yarn" setup_nodejs
+NODE_VERSION="24" NODE_MODULE="corepack,yarn" setup_nodejs
 
 fetch_and_deploy_gh_release "readium" "readium/cli" "prebuild" "latest" "/opt/readium" "readium_linux_$(arch_resolve "x86_64" "arm64").tar.gz"
 ln -sf /opt/readium/readium /usr/local/bin/readium


### PR DESCRIPTION
## ✍️ Description

Update the nodejs version used. Storyteller uses node 24 not 22 see https://gitlab.com/storyteller-platform/storyteller/-/blob/main/Dockerfile.base?ref_type=heads#L135 

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
