### PR TITLE
[tools/pve/*.sh] https://download.proxmox.com -> http://download.proxmox.com (PVE8 Only)

### DIFF
--- a/tools/pve/pbs3-upgrade.sh
+++ b/tools/pve/pbs3-upgrade.sh
@@ -105,7 +105,7 @@ EOF
   yes)
     msg_info "Enabling 'pbs-no-subscription' repository"
     cat <<EOF >/etc/apt/sources.list.d/pbs-install-repo.list
-deb https://download.proxmox.com/debian/pbs bookworm pbs-no-subscription
+deb http://download.proxmox.com/debian/pbs bookworm pbs-no-subscription
 EOF
     msg_ok "Enabled 'pbs-no-subscription' repository"
     ;;

--- a/tools/pve/post-pve-install.sh
+++ b/tools/pve/post-pve-install.sh
@@ -152,7 +152,7 @@ EOF
   yes)
     msg_info "Enabling 'pve-no-subscription' repository"
     cat <<EOF >/etc/apt/sources.list.d/pve-install-repo.list
-deb https://download.proxmox.com/debian/pve bookworm pve-no-subscription
+deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription
 EOF
     msg_ok "Enabled 'pve-no-subscription' repository"
     ;;

--- a/tools/pve/pve8-upgrade.sh
+++ b/tools/pve/pve8-upgrade.sh
@@ -70,7 +70,7 @@ EOF
   whiptail --backtitle "Proxmox VE Helper Scripts" --msgbox --title "PVE8-NO-SUBSCRIPTION" "The 'pve-no-subscription' repository provides access to all of the open-source components of Proxmox VE." 10 58
   msg_info "Enabling 'pve-no-subscription' repository"
   cat <<EOF >/etc/apt/sources.list.d/pve-install-repo.list
-deb https://download.proxmox.com/debian/pve bookworm pve-no-subscription
+deb http://download.proxmox.com/debian/pve bookworm pve-no-subscription
 EOF
   msg_ok "Enabled 'pve-no-subscription' repository"
 


### PR DESCRIPTION
## ✍️ Description

- https://download.proxmox.com responds with https://enterprise.proxmox.com HTTPS certificate for obvious reasons
- yes they have the same IP

## 🔗 Related Issue

- Issues ? Where we're going, we don't need issues!

Fixes #

- `Proxmox Server Solutions GmbH` extreme complexity hyperconverged infrastructure consisting of single puny `nginx` server somewhere in `servinga GmbH, Germany`.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [ ] `tools/pve/pbs3-upgrade.sh` **Tested thoroughly** – Changes work as expected.
- [X] `tools/pve/post-pve-install.sh` **Tested thoroughly** – Changes work as expected.
- [ ] `tools/pve/pve8-upgrade.sh` **Tested thoroughly** – Changes work as expected.
- [✅✅✅✅✅] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
