### PR TITLE
Stirling-PDF: patch libicudata execstack flag for LXC container compatibility

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -38,6 +38,10 @@ function update_script() {
     PYTHON_VERSION="3.12" setup_uv
     JAVA_VERSION="25" setup_java
 
+    msg_info "Patching Native Libraries for LXC Compatibility"
+    find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \;
+    msg_ok "Patched Native Libraries"
+
     msg_info "Stopping Services"
     systemctl stop stirlingpdf libreoffice-listener unoserver
     msg_ok "Stopped Services"

--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -39,7 +39,8 @@ function update_script() {
     JAVA_VERSION="25" setup_java
 
     msg_info "Patching Native Libraries for LXC Compatibility"
-    find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \;
+    ensure_dependencies patchelf
+    find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \; || true
     msg_ok "Patched Native Libraries"
 
     msg_info "Stopping Services"

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -27,7 +27,8 @@ $STD apt install -y \
   fonts-urw-base35 \
   qpdf \
   poppler-utils \
-  jbig2
+  jbig2 \
+  patchelf
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.12" setup_uv
@@ -114,6 +115,10 @@ SECURITY_INITIALLOGIN_PASSWORD=stirling
 EOF
 fi
 msg_ok "Created Environment Variables"
+
+msg_info "Patching Native Libraries for LXC Compatibility"
+find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \;
+msg_ok "Patched Native Libraries"
 
 msg_info "Refreshing Font Cache"
 $STD fc-cache -fv

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -117,7 +117,7 @@ fi
 msg_ok "Created Environment Variables"
 
 msg_info "Patching Native Libraries for LXC Compatibility"
-find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \;
+find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \; || true
 msg_ok "Patched Native Libraries"
 
 msg_info "Refreshing Font Cache"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description


## 🔗 Related Issue

Fixes #15513

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
