### PR TITLE
tools.func: configure pnpm to allow all build scripts for environments

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -7657,6 +7657,12 @@ setup_nodejs() {
     fi
   fi
 
+  # pnpm v10+ blocks dependency build scripts by default (ERR_PNPM_IGNORED_BUILDS).
+  # In a container environment all installed packages are trusted, so we enable builds globally.
+  if command -v pnpm >/dev/null 2>&1; then
+    pnpm config set --global dangerouslyAllowAllBuilds true >/dev/null 2>&1 || true
+  fi
+
   if [[ "$NODE_COREPACK_ENABLE" == "1" ]] && ((wants_corepack)) && command -v corepack >/dev/null 2>&1; then
     msg_info "Enabling corepack"
     if $STD corepack enable 2>/dev/null; then


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
prevent the issue with pnpm, exmpl:
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: es5-ext@0.10.64, esbuild@0.25.12, svelte-preprocess@5.1.4

=> this prevent the issue for now, because the projects need to fix this in upstream and pnpm11 will be available for all. So some Apps break in next time, if we dont add this

## 🔗 Related Issue

Fixes #15525

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
