### PR TITLE
Rackula: install Bun to /opt/bun (ProtectHome breaks /root/.bun) and restore msg pair

### DIFF
--- a/install/rackula-install.sh
+++ b/install/rackula-install.sh
@@ -19,19 +19,16 @@ msg_ok "Installed Dependencies"
 
 msg_info "Installing Bun"
 ensure_dependencies unzip ca-certificates
-BUN_VERSION="${BUN_VERSION:-1.3.14}"
-case "$(uname -m)" in
-x86_64) grep -q avx2 /proc/cpuinfo && BUN_VARIANT="x64" || BUN_VARIANT="x64-baseline" ;;
-aarch64) BUN_VARIANT="aarch64" ;;
-*)
-  msg_error "Unsupported architecture: $(uname -m)"
-  exit 1
-  ;;
-esac
-export BUN_INSTALL="/root/.bun"
+# rackula-api.service ships with ProtectHome=true, so the bun binary must live
+# outside /root; /opt/bun matches yubal and gitea-mirror
+export BUN_INSTALL="/opt/bun"
 curl -fsSL https://bun.sh/install | $STD bash
-ln -sf /root/.bun/bin/bun /usr/local/bin/bun
+ln -sf /opt/bun/bin/bun /usr/local/bin/bun
+msg_ok "Installed Bun"
+
 fetch_and_deploy_gh_release "rackula" "RackulaLives/Rackula" "prebuild" "latest" "/opt/rackula" "rackula-lxc-*.tar.gz"
+
+msg_info "Setting up Rackula"
 mkdir -p /opt/rackula/data /etc/nginx/snippets
 
 SECURITY_HEADERS_SRC="/opt/rackula/config/security-headers.conf"


### PR DESCRIPTION
Follow-up to the review discussion on #15465, as invited by @tremor021.

## What

- `export BUN_INSTALL="/opt/bun"` instead of `/root/.bun`, keeping the standard `curl -fsSL https://bun.sh/install | $STD bash` pipe
- Remove the unused `BUN_VERSION`/`BUN_VARIANT` case block
- Restore the `msg_ok "Installed Bun"` / `msg_info "Setting up Rackula"` pair

## Why

`rackula-api.service` (shipped in the Rackula release tarball and installed by this script) is hardened with `ProtectHome=true`, `ProtectSystem=strict`, and `ExecStart=/usr/local/bin/bun`. A bun binary under `/root/.bun` is unreachable inside the unit's mount namespace, so the service fails with `status=203/EXEC` and crash-loops; the installer output still looks successful because nginx and the frontend come up fine. `/opt/bun` matches the existing yubal and gitea-mirror scripts and stays executable under `ProtectSystem=strict`.

`BUN_VERSION`/`BUN_VARIANT` were left over from the pinned-download approach: `bun.sh/install` reads neither env var (the version is a positional arg and avx2/baseline is self-detected), so the block was dead code that silently installed latest.

## Testing

Ran both variants on PVE 9.1.9, Debian 13 unprivileged CTs (nesting=1, 1 vCPU / 512 MiB / 8 GB, community-scripts defaults), against the real v26.6.6 release tarball:

- Branch head: install completes through "Created Services", but `rackula-api` crash-loops (`status=203/EXEC`, `Unable to locate executable '/usr/local/bin/bun'`); frontend serves 200 while `/api/health` returns 502.
- This branch: `rackula-api` `active (running)` with the hardened sandbox intact; `/api/health` returns `200 {"ok":true,...}` and `/api/layouts` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sGajwSQGg1vd6m2AC6Byq
