### PR TITLE
feat(build.func): add var_ignore_disable to bypass disabled-script guard

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3788,6 +3788,17 @@ runtime_script_status_guard() {
   fi
 
   if [[ "$is_disabled" == "true" ]]; then
+    # Allow bypass via var_ignore_disable=true (still warn, but continue)
+    case "${var_ignore_disable:-}" in
+    1 | yes | true | on)
+      msg_warn "This script is currently disabled in community-scripts."
+      [[ -n "$disable_message" ]] && msg_warn "$disable_message"
+      msg_warn "Bypassing disable status via var_ignore_disable — continuing at your own risk."
+      msg_warn "More info: ${info_url}"
+      return 0
+      ;;
+    esac
+
     msg_error "This script is currently disabled in community-scripts."
     [[ -n "$disable_message" ]] && msg_error "$disable_message"
     [[ -z "$disable_message" ]] && msg_error "Updates and installs are temporarily disabled for this script."


### PR DESCRIPTION
## ✍️ Description

Adds a `var_ignore_disable` environment variable that lets users bypass the "script disabled" guard in `runtime_script_status_guard()` (`misc/build.func`).

When `var_ignore_disable` is set to `true`/`yes`/`1`/`on`, the guard downgrades the disabled-script error to a warning and continues execution instead of aborting. Deleted scripts remain a hard stop.

Usage:

```
var_ignore_disable="true" bash -c "$(curl -fsSL ...)"
```

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
