### PR TITLE
Immich: handle mise monorepo_root rename correctly | bump to 3.0.1

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -212,23 +212,10 @@ EOF
     cd "$SRC_DIR"
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-    $STD mise install
-    export PATH="$(mise bin-paths 2>/dev/null | tr '\n' ':')$PATH"
-    if ! command -v extism-js >/dev/null 2>&1; then
-      # extism-js is published as a bare gzip-compressed single binary (.gz), which
-      # fetch_and_deploy_gh_release cannot deploy (singlefile leaves it compressed,
-      # prebuild only handles zip/tar). Fetch + gunzip it directly.
-      EXTISM_ARCH="$(arch_resolve x86_64 aarch64)"
-      curl_download /tmp/extism-js.gz "https://github.com/extism/js-pdk/releases/download/v1.6.0/extism-js-${EXTISM_ARCH}-linux-v1.6.0.gz"
-      gunzip -f /tmp/extism-js.gz
-      install -m 0755 /tmp/extism-js /usr/local/bin/extism-js
-      rm -f /tmp/extism-js
-    fi
-    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
-    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
+    $STD mise //:plugins
     mkdir -p "$PLUGIN_DIR"
-    cp -r ./dist "$PLUGIN_DIR"/dist
-    cp ./manifest.json "$PLUGIN_DIR"
+    cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
+    cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"
     msg_ok "Updated Immich server, web, cli and plugins"
 
     cd "$SRC_DIR"/machine-learning

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -124,7 +124,7 @@ EOF
     systemctl stop immich-web
     systemctl stop immich-ml
     msg_ok "Stopped Services"
-    VCHORD_RELEASE="0.5.3"
+    VCHORD_RELEASE="1.0.0"
     [[ -f ~/.vchord_version ]] && mv ~/.vchord_version ~/.vectorchord
     if check_for_gh_release "VectorChord" "tensorchord/VectorChord" "${VCHORD_RELEASE}" "updated together with Immich after testing"; then
       fetch_and_deploy_gh_release "VectorChord" "tensorchord/VectorChord" "binary" "${VCHORD_RELEASE}" "/tmp" "postgresql-16-vchord_*_$(arch_resolve).deb"
@@ -140,7 +140,7 @@ EOF
     UPLOAD_DIR="$(sed -n '/^IMMICH_MEDIA_LOCATION/s/[^=]*=//p' /opt/immich/.env)"
     SRC_DIR="${INSTALL_DIR}/source"
     APP_DIR="${INSTALL_DIR}/app"
-    PLUGIN_DIR="${APP_DIR}/corePlugin"
+    PLUGIN_DIR="${APP_DIR}/plugins/immich-plugin-core"
     ML_DIR="${APP_DIR}/machine-learning"
     GEO_DIR="${INSTALL_DIR}/geodata"
 
@@ -176,14 +176,8 @@ EOF
     $STD pnpm config set --global dangerouslyAllowAllBuilds true
 
     msg_info "Updating Immich web and microservices"
-    cd "$SRC_DIR"
-    # Install all workspace deps with locked versions before any build step.
-    # --frozen-lockfile must come AFTER the install subcommand in pnpm v11.
-    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
-    $STD pnpm install --frozen-lockfile
-
-    # server build
     cd "$SRC_DIR"/server
+    # server build
     export SHARP_IGNORE_GLOBAL_LIBVIPS=true
     $STD pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter immich build
     unset SHARP_IGNORE_GLOBAL_LIBVIPS
@@ -200,6 +194,7 @@ EOF
 
     # sdk, cli & web build
     cd "$SRC_DIR"
+    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
     unset SHARP_FORCE_GLOBAL_LIBVIPS
     export SHARP_IGNORE_GLOBAL_LIBVIPS=true
     $STD pnpm --filter @immich/sdk --filter immich-web --filter @immich/cli build
@@ -210,6 +205,11 @@ EOF
 
     # plugins
     cd "$SRC_DIR"
+    # mise 2026.7.0 renamed the monorepo root setting `experimental_monorepo_root`
+    # to `monorepo_root`. Immich still ships the old key, so newer mise cannot resolve
+    # the monorepo tasks (`//:plugins`). Add the new key at the root table (harmless on
+    # older mise, which keeps using the existing `experimental_monorepo_root`).
+    grep -q '^monorepo_root' ./mise.toml || sed -i '1i monorepo_root = true' ./mise.toml
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
     $STD mise //:plugins
@@ -231,13 +231,13 @@ EOF
       ML_PYTHON="python3.13"
       msg_info "Pre-installing Python ${ML_PYTHON} for machine-learning"
       for attempt in $(seq 1 3); do
-        $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv python install "${ML_PYTHON}" && break
+        $STD sudo --preserve-env=VIRTUAL_ENV -Pnu immich uv python install "${ML_PYTHON}" && break
         [[ $attempt -lt 3 ]] && msg_warn "Python download attempt $attempt failed, retrying..." && sleep 5
       done
       msg_ok "Pre-installed Python ${ML_PYTHON}"
       msg_info "Updating Intel OpenVINO machine-learning"
       for attempt in $(seq 1 3); do
-        $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -nu immich uv sync --extra openvino --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
+        $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -Pnu immich uv sync --extra openvino --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
         [[ $attempt -lt 3 ]] && msg_warn "uv sync attempt $attempt failed, retrying..." && sleep 10
       done
       patchelf --clear-execstack "${VIRTUAL_ENV}/lib/python3.13/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.cpython-313-$(arch_resolve "x86_64" "aarch64")-linux-gnu.so"
@@ -246,13 +246,13 @@ EOF
       ML_PYTHON="python3.11"
       msg_info "Pre-installing Python ${ML_PYTHON} for machine-learning"
       for attempt in $(seq 1 3); do
-        $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv python install "${ML_PYTHON}" && break
+        $STD sudo --preserve-env=VIRTUAL_ENV -Pnu immich uv python install "${ML_PYTHON}" && break
         [[ $attempt -lt 3 ]] && msg_warn "Python download attempt $attempt failed, retrying..." && sleep 5
       done
       msg_ok "Pre-installed Python ${ML_PYTHON}"
       msg_info "Updating machine-learning"
       for attempt in $(seq 1 3); do
-        $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -nu immich uv sync --extra cpu --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
+        $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -Pnu immich uv sync --extra cpu --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
         [[ $attempt -lt 3 ]] && msg_warn "uv sync attempt $attempt failed, retrying..." && sleep 10
       done
       msg_ok "Updated machine-learning"
@@ -446,7 +446,7 @@ function compile_imagemagick() {
 
 function compile_libvips() {
   SOURCE=$SOURCE_DIR/libvips
-  LIBVIPS_REVISION="17ad2f62dda7e39985955da189183e594683d45e"
+  LIBVIPS_REVISION="3664cfc5dc2c5661288f5bf5a85ccc51c64c1626"
   if [[ "$LIBVIPS_REVISION" != "$(grep 'libvips' ~/.immich_library_revisions | awk '{print $2}')" ]]; then
     msg_info "Recompiling libvips"
     [[ -d "$SOURCE" ]] && rm -rf "$SOURCE"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -255,6 +255,23 @@ EOF
     cd "$SRC_DIR"
     cp -a machine-learning/{ann,immich_ml} "$ML_DIR"
     [[ -f "$INSTALL_DIR"/ml_start.sh ]] && mv "$INSTALL_DIR"/ml_start.sh "$ML_DIR"
+    # Regenerate ml_start.sh if it is missing (e.g. lost by a previously interrupted update),
+    # otherwise immich-ml.service fails to start with status=203/EXEC
+    if [[ ! -f "$ML_DIR"/ml_start.sh ]]; then
+      cat <<EOF >"$ML_DIR"/ml_start.sh
+#!/usr/bin/env bash
+
+cd ${ML_DIR}
+. ${VIRTUAL_ENV}/bin/activate
+
+set -a
+. ${INSTALL_DIR}/.env
+set +a
+
+python3 -m immich_ml
+EOF
+      chmod +x "$ML_DIR"/ml_start.sh
+    fi
     [[ -f ~/.openvino ]] && sed -i "/intra_op/s/int = 0/int = os.cpu_count() or 0/" "$ML_DIR"/immich_ml/config.py
     ln -sf "$APP_DIR"/resources "$INSTALL_DIR"
     cd "$APP_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -171,11 +171,7 @@ EOF
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
     NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
     $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
-    # corepack activates pnpm but its global bin dir is not in PATH by default;
-    # export it so that `pnpm config set --global` succeeds.
-    export PNPM_HOME="/root/.local/share/pnpm"
-    export PATH="$PNPM_HOME/bin:$PATH"
-    mkdir -p "$PNPM_HOME/bin"
+    export PATH="/root/.local/share/pnpm/bin:$PATH"
     $STD pnpm config set --global dangerouslyAllowAllBuilds true
 
     msg_info "Updating Immich web and microservices"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -110,7 +110,7 @@ EOF
     msg_ok "Image-processing libraries up to date"
   fi
 
-  RELEASE="v3.0.0"
+  RELEASE="v3.0.1"
   if check_for_gh_release "Immich" "immich-app/immich" "${RELEASE}" "each release is tested individually before the version is updated. Please do not open issues for this"; then
     if [[ $(cat ~/.immich) > "2.5.1" ]]; then
       msg_info "Enabling Maintenance Mode"
@@ -202,15 +202,16 @@ EOF
     [[ -f "$INSTALL_DIR"/start.sh ]] && mv "$INSTALL_DIR"/start.sh "$APP_DIR"/bin
 
     # plugins
+    # Build the plugin(s) directly instead of via the `mise //:plugins` monorepo task path,
+    # which repeatedly breaks across mise releases (experimental/monorepo_root setting churn).
+    # mise is used only to provide the build tools (extism-js, wasm-opt, etc.) via `mise install`
+    # and `mise exec`, both of which are stable and do not depend on the monorepo feature.
     cd "$SRC_DIR"
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-    # mise gates monorepo task paths (//:plugins) behind experimental mode and renamed the
-    # 'experimental_monorepo_root' setting to 'monorepo_root' in v2026.7.0. Set the env flag and
-    # ensure both config keys are present so the task works regardless of the installed mise version.
-    export MISE_EXPERIMENTAL=1
-    grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
-    $STD mise //:plugins
+    $STD mise install
+    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
+    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
     mkdir -p "$PLUGIN_DIR"
     cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
     cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -205,6 +205,8 @@ EOF
     cd "$SRC_DIR"
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
+    # mise v2026.7.0 renamed 'experimental_monorepo_root' to 'monorepo_root'; ensure both are set so the //:plugins task works regardless of mise version
+    grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
     $STD mise //:plugins
     mkdir -p "$PLUGIN_DIR"
     cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -169,22 +169,26 @@ EOF
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "${RELEASE}" "$SRC_DIR"
     PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    export CI=1
     NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
     $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
     export PATH="/root/.local/share/pnpm/bin:$PATH"
     $STD pnpm config set --global dangerouslyAllowAllBuilds true
 
     msg_info "Updating Immich web and microservices"
-    cd "$SRC_DIR"/server
-    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-    export CI=1
+    cd "$SRC_DIR"
+    # Install all workspace deps with locked versions before any build step.
+    # --frozen-lockfile must come AFTER the install subcommand in pnpm v11.
+    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
+    $STD pnpm install --frozen-lockfile
 
     # server build
+    cd "$SRC_DIR"/server
     export SHARP_IGNORE_GLOBAL_LIBVIPS=true
-    $STD pnpm --filter immich --frozen-lockfile build
+    $STD pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter immich build
     unset SHARP_IGNORE_GLOBAL_LIBVIPS
     export SHARP_FORCE_GLOBAL_LIBVIPS=true
-    $STD pnpm --filter immich --frozen-lockfile --prod --no-optional deploy "$APP_DIR"
+    $STD pnpm --filter immich --prod --no-optional deploy "$APP_DIR"
 
     # Patch helmet.json: disable upgrade-insecure-requests for HTTP access
     if [[ -f "$APP_DIR/helmet.json" ]]; then
@@ -194,20 +198,14 @@ EOF
     cp "$APP_DIR"/package.json "$APP_DIR"/bin
     sed -i "s|^start|${APP_DIR}/bin/start|" "$APP_DIR"/bin/immich-admin
 
-    # openapi & web build
+    # sdk, cli & web build
     cd "$SRC_DIR"
-    echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
-    $STD pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install
     unset SHARP_FORCE_GLOBAL_LIBVIPS
     export SHARP_IGNORE_GLOBAL_LIBVIPS=true
-    $STD pnpm --filter @immich/sdk --filter immich-web build
+    $STD pnpm --filter @immich/sdk --filter immich-web --filter @immich/cli build
+    $STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
     cp -a web/build "$APP_DIR"/www
     cp LICENSE "$APP_DIR"
-
-    # cli build
-    $STD pnpm --filter @immich/sdk --filter @immich/cli --frozen-lockfile install
-    $STD pnpm --filter @immich/sdk --filter @immich/cli build
-    $STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
     [[ -f "$INSTALL_DIR"/start.sh ]] && mv "$INSTALL_DIR"/start.sh "$APP_DIR"/bin
 
     # plugins

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -205,7 +205,10 @@ EOF
     cd "$SRC_DIR"
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-    # mise v2026.7.0 renamed 'experimental_monorepo_root' to 'monorepo_root'; ensure both are set so the //:plugins task works regardless of mise version
+    # mise gates monorepo task paths (//:plugins) behind experimental mode and renamed the
+    # 'experimental_monorepo_root' setting to 'monorepo_root' in v2026.7.0. Set the env flag and
+    # ensure both config keys are present so the task works regardless of the installed mise version.
+    export MISE_EXPERIMENTAL=1
     grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
     $STD mise //:plugins
     mkdir -p "$PLUGIN_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -168,7 +168,15 @@ EOF
     setup_uv
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "${RELEASE}" "$SRC_DIR"
     PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
-    NODE_VERSION="24" NODE_MODULE="corepack,pnpm@${PNPM_VERSION}" setup_nodejs
+    export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+    NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
+    $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
+    # corepack activates pnpm but its global bin dir is not in PATH by default;
+    # export it so that `pnpm config set --global` succeeds.
+    export PNPM_HOME="/root/.local/share/pnpm"
+    export PATH="$PNPM_HOME/bin:$PATH"
+    mkdir -p "$PNPM_HOME/bin"
+    $STD pnpm config set --global dangerouslyAllowAllBuilds true
 
     msg_info "Updating Immich web and microservices"
     cd "$SRC_DIR"/server
@@ -210,6 +218,22 @@ EOF
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
     $STD mise install
+    # extism-js (the JS PDK compiler used by plugin-core's `build:wasm`) is provided by the
+    # `github:extism/js-pdk` mise tool, but mise's github backend does not reliably expose it on
+    # PATH for nested pnpm build scripts. The `@extism/js-pdk` npm package is only type defs and
+    # ships no binary. Guarantee availability by fetching the pinned release binary directly if it
+    # is not already resolvable.
+    export PATH="$(mise bin-paths 2>/dev/null | tr '\n' ':')$PATH"
+    if ! command -v extism-js >/dev/null 2>&1; then
+      # extism-js is published as a bare gzip-compressed single binary (.gz), which
+      # fetch_and_deploy_gh_release cannot deploy (singlefile leaves it compressed,
+      # prebuild only handles zip/tar). Fetch + gunzip it directly.
+      EXTISM_ARCH="$(arch_resolve x86_64 aarch64)"
+      curl_download /tmp/extism-js.gz "https://github.com/extism/js-pdk/releases/download/v1.6.0/extism-js-${EXTISM_ARCH}-linux-v1.6.0.gz"
+      gunzip -f /tmp/extism-js.gz
+      install -m 0755 /tmp/extism-js /usr/local/bin/extism-js
+      rm -f /tmp/extism-js
+    fi
     $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
     $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
     mkdir -p "$PLUGIN_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -218,6 +218,19 @@ EOF
       install -m 0755 /tmp/extism-js /usr/local/bin/extism-js
       rm -f /tmp/extism-js
     fi
+    if ! command -v wasm-merge >/dev/null 2>&1; then
+      # extism-js needs binaryen's `wasm-merge` to build the plugin wasm. mise
+      # 2026.7.0's github backend no longer exposes `wasm-merge` on PATH (ubi only
+      # extracts a single binary), so install the pinned binaryen release from
+      # mise.toml directly. The extracted bin/ keeps libbinaryen.so alongside it.
+      BINARYEN_VERSION="$(grep -oiP 'binaryen"\s*=\s*"\Kversion_[0-9]+' "$SRC_DIR"/mise.toml | head -n1)"
+      [[ -z "$BINARYEN_VERSION" ]] && BINARYEN_VERSION="version_124"
+      BINARYEN_ARCH="$(arch_resolve x86_64 aarch64)"
+      curl_download /tmp/binaryen.tar.gz "https://github.com/WebAssembly/binaryen/releases/download/${BINARYEN_VERSION}/binaryen-${BINARYEN_VERSION}-${BINARYEN_ARCH}-linux.tar.gz"
+      tar -xzf /tmp/binaryen.tar.gz -C /opt
+      rm -f /tmp/binaryen.tar.gz
+      export PATH="/opt/binaryen-${BINARYEN_VERSION}/bin:$PATH"
+    fi
     $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
     $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
     mkdir -p "$PLUGIN_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -205,14 +205,21 @@ EOF
 
     # plugins
     cd "$SRC_DIR"
-    # mise 2026.7.0 renamed the monorepo root setting `experimental_monorepo_root`
-    # to `monorepo_root`. Immich still ships the old key, so newer mise cannot resolve
-    # the monorepo tasks (`//:plugins`). Add the new key at the root table (harmless on
-    # older mise, which keeps using the existing `experimental_monorepo_root`).
-    grep -q '^monorepo_root' ./mise.toml || sed -i '1i monorepo_root = true' ./mise.toml
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-    $STD mise //:plugins
+    $STD mise install
+    export PATH="$(mise bin-paths 2>/dev/null | tr '\n' ':')$PATH"
+    if ! command -v extism-js >/dev/null 2>&1; then
+      # extism-js ships as a bare gzip-compressed single binary (.gz) that
+      # fetch_and_deploy_gh_release cannot deploy; fetch + gunzip it directly.
+      EXTISM_ARCH="$(arch_resolve x86_64 aarch64)"
+      curl_download /tmp/extism-js.gz "https://github.com/extism/js-pdk/releases/download/v1.6.0/extism-js-${EXTISM_ARCH}-linux-v1.6.0.gz"
+      gunzip -f /tmp/extism-js.gz
+      install -m 0755 /tmp/extism-js /usr/local/bin/extism-js
+      rm -f /tmp/extism-js
+    fi
+    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
+    $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
     mkdir -p "$PLUGIN_DIR"
     cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
     cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"

--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -211,19 +211,10 @@ EOF
     [[ -f "$INSTALL_DIR"/start.sh ]] && mv "$INSTALL_DIR"/start.sh "$APP_DIR"/bin
 
     # plugins
-    # Build the plugin(s) directly instead of via the `mise //:plugins` monorepo task path,
-    # which repeatedly breaks across mise releases (experimental/monorepo_root setting churn).
-    # mise is used only to provide the build tools (extism-js, wasm-opt, etc.) via `mise install`
-    # and `mise exec`, both of which are stable and do not depend on the monorepo feature.
     cd "$SRC_DIR"
     export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
     export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
     $STD mise install
-    # extism-js (the JS PDK compiler used by plugin-core's `build:wasm`) is provided by the
-    # `github:extism/js-pdk` mise tool, but mise's github backend does not reliably expose it on
-    # PATH for nested pnpm build scripts. The `@extism/js-pdk` npm package is only type defs and
-    # ships no binary. Guarantee availability by fetching the pinned release binary directly if it
-    # is not already resolvable.
     export PATH="$(mise bin-paths 2>/dev/null | tr '\n' ':')$PATH"
     if ! command -v extism-js >/dev/null 2>&1; then
       # extism-js is published as a bare gzip-compressed single binary (.gz), which

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -350,7 +350,10 @@ cp LICENSE "$APP_DIR"
 cd "$SRC_DIR"
 export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
 export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-# mise v2026.7.0 renamed 'experimental_monorepo_root' to 'monorepo_root'; ensure both are set so the //:plugins task works regardless of mise version
+# mise gates monorepo task paths (//:plugins) behind experimental mode and renamed the
+# 'experimental_monorepo_root' setting to 'monorepo_root' in v2026.7.0. Set the env flag and
+# ensure both config keys are present so the task works regardless of the installed mise version.
+export MISE_EXPERIMENTAL=1
 grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
 $STD mise //:plugins
 mkdir -p "$PLUGIN_DIR"

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -311,7 +311,7 @@ ML_DIR="${APP_DIR}/machine-learning"
 GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
 
-fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.0" "$SRC_DIR"
+fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.1" "$SRC_DIR"
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
 NODE_VERSION="24" NODE_MODULE="corepack,pnpm@${PNPM_VERSION}" setup_nodejs
 
@@ -347,15 +347,16 @@ cp -a web/build "$APP_DIR"/www
 cp LICENSE "$APP_DIR"
 
 # plugins
+# Build the plugin(s) directly instead of via the `mise //:plugins` monorepo task path,
+# which repeatedly breaks across mise releases (experimental/monorepo_root setting churn).
+# mise is used only to provide the build tools (extism-js, wasm-opt, etc.) via `mise install`
+# and `mise exec`, both of which are stable and do not depend on the monorepo feature.
 cd "$SRC_DIR"
 export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
 export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
-# mise gates monorepo task paths (//:plugins) behind experimental mode and renamed the
-# 'experimental_monorepo_root' setting to 'monorepo_root' in v2026.7.0. Set the env flag and
-# ensure both config keys are present so the task works regardless of the installed mise version.
-export MISE_EXPERIMENTAL=1
-grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
-$STD mise //:plugins
+$STD mise install
+$STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
+$STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
 mkdir -p "$PLUGIN_DIR"
 cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
 cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -312,24 +312,30 @@ GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
 
 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.1" "$SRC_DIR"
-
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
+# Provision the exact pnpm pinned in package.json's packageManager field via corepack instead
+# of `npm i -g pnpm@X`, which collides (EEXIST) with the corepack pnpm shim shipped by the
+# NodeSource nodejs package.
 $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
+# corepack activates pnpm but its global bin dir is not in PATH by default;
+# export it so that `pnpm config set --global` succeeds.
 export PATH="/root/.local/share/pnpm/bin:$PATH"
 $STD pnpm config set --global dangerouslyAllowAllBuilds true
+
 msg_info "Installing Immich (patience)"
 
 cd "$SRC_DIR"/server
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export CI=1
+
 # server build
 export SHARP_IGNORE_GLOBAL_LIBVIPS=true
-$STD pnpm --filter immich --frozen-lockfile build
+$STD pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter immich build
 unset SHARP_IGNORE_GLOBAL_LIBVIPS
 export SHARP_FORCE_GLOBAL_LIBVIPS=true
-$STD pnpm --filter immich --frozen-lockfile --prod --no-optional deploy "$APP_DIR"
+$STD pnpm --filter immich --prod --no-optional deploy "$APP_DIR"
 
 # Patch helmet.json: disable upgrade-insecure-requests for HTTP access
 if [[ -f "$APP_DIR/helmet.json" ]]; then
@@ -369,6 +375,7 @@ mkdir -p "$PLUGIN_DIR"
 cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
 cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"
 msg_ok "Installed Immich Server, Web and Plugin Components"
+
 cd "$SRC_DIR"/machine-learning
 $STD useradd -U -s /usr/sbin/nologin -r -M -d "$INSTALL_DIR" immich
 mkdir -p "$ML_DIR"
@@ -382,13 +389,13 @@ if [[ -f ~/.openvino ]]; then
   ML_PYTHON="python3.13"
   msg_info "Pre-installing Python ${ML_PYTHON} for machine-learning"
   for attempt in $(seq 1 3); do
-    $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv python install "${ML_PYTHON}" && break
+    $STD sudo --preserve-env=VIRTUAL_ENV -Pnu immich uv python install "${ML_PYTHON}" && break
     [[ $attempt -lt 3 ]] && msg_warn "Python download attempt $attempt failed, retrying..." && sleep 5
   done
   msg_ok "Pre-installed Python ${ML_PYTHON}"
   msg_info "Installing Intel OpenVINO machine-learning"
   for attempt in $(seq 1 3); do
-    $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -nu immich uv sync --extra openvino --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
+    $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -Pnu immich uv sync --extra openvino --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
     [[ $attempt -lt 3 ]] && msg_warn "uv sync attempt $attempt failed, retrying..." && sleep 10
   done
   patchelf --clear-execstack "${VIRTUAL_ENV}/lib/python3.13/site-packages/onnxruntime/capi/onnxruntime_pybind11_state.cpython-313-$(arch_resolve "x86_64" "aarch64")-linux-gnu.so"
@@ -397,13 +404,13 @@ else
   ML_PYTHON="python3.11"
   msg_info "Pre-installing Python ${ML_PYTHON} for machine-learning"
   for attempt in $(seq 1 3); do
-    $STD sudo --preserve-env=VIRTUAL_ENV -nu immich uv python install "${ML_PYTHON}" && break
+    $STD sudo --preserve-env=VIRTUAL_ENV -Pnu immich uv python install "${ML_PYTHON}" && break
     [[ $attempt -lt 3 ]] && msg_warn "Python download attempt $attempt failed, retrying..." && sleep 5
   done
   msg_ok "Pre-installed Python ${ML_PYTHON}"
   msg_info "Installing machine-learning"
   for attempt in $(seq 1 3); do
-    $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -nu immich uv sync --extra cpu --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
+    $STD sudo --preserve-env=VIRTUAL_ENV,UV_HTTP_TIMEOUT -Pnu immich uv sync --extra cpu --no-dev --active --link-mode copy -n -p "${ML_PYTHON}" --managed-python && break
     [[ $attempt -lt 3 ]] && msg_warn "uv sync attempt $attempt failed, retrying..." && sleep 10
   done
   msg_ok "Installed machine-learning"

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -350,6 +350,8 @@ cp LICENSE "$APP_DIR"
 cd "$SRC_DIR"
 export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
 export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
+# mise v2026.7.0 renamed 'experimental_monorepo_root' to 'monorepo_root'; ensure both are set so the //:plugins task works regardless of mise version
+grep -q '^monorepo_root = true' "$SRC_DIR"/mise.toml || sed -i 's/^experimental_monorepo_root = true/monorepo_root = true\nexperimental_monorepo_root = true/' "$SRC_DIR"/mise.toml
 $STD mise //:plugins
 mkdir -p "$PLUGIN_DIR"
 cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -310,26 +310,19 @@ PLUGIN_DIR="${APP_DIR}/plugins/immich-plugin-core"
 ML_DIR="${APP_DIR}/machine-learning"
 GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
-
 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.1" "$SRC_DIR"
+
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
-# Provision the exact pnpm pinned in package.json's packageManager field via corepack instead
-# of `npm i -g pnpm@X`, which collides (EEXIST) with the corepack pnpm shim shipped by the
-# NodeSource nodejs package.
 $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
-# corepack activates pnpm but its global bin dir is not in PATH by default;
-# export it so that `pnpm config set --global` succeeds.
 export PATH="/root/.local/share/pnpm/bin:$PATH"
 $STD pnpm config set --global dangerouslyAllowAllBuilds true
-
 msg_info "Installing Immich (patience)"
 
 cd "$SRC_DIR"/server
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 export CI=1
-
 # server build
 export SHARP_IGNORE_GLOBAL_LIBVIPS=true
 $STD pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter immich build

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -162,7 +162,7 @@ PG_VERSION="16" PG_MODULES="pgvector" setup_postgresql
 ACTUAL_PG_VERSION=$(ls /etc/postgresql/ 2>/dev/null | sort -V | tail -1)
 ACTUAL_PG_VERSION=${ACTUAL_PG_VERSION:-16}
 
-VCHORD_RELEASE="0.5.3"
+VCHORD_RELEASE="1.0.0"
 fetch_and_deploy_gh_release "VectorChord" "tensorchord/VectorChord" "binary" "${VCHORD_RELEASE}" "/tmp" "postgresql-${ACTUAL_PG_VERSION}-vchord_*_$(arch_resolve).deb"
 
 sed -i "s/^#shared_preload.*/shared_preload_libraries = 'vchord.so'/" /etc/postgresql/${ACTUAL_PG_VERSION}/main/postgresql.conf
@@ -282,7 +282,7 @@ msg_ok "(4/5) Compiled imagemagick"
 
 msg_info "(5/5) Compiling libvips"
 SOURCE=$SOURCE_DIR/libvips
-LIBVIPS_REVISION="17ad2f62dda7e39985955da189183e594683d45e"
+LIBVIPS_REVISION="3664cfc5dc2c5661288f5bf5a85ccc51c64c1626"
 $STD git clone https://github.com/libvips/libvips.git "$SOURCE"
 cd "$SOURCE"
 $STD git reset --hard "$LIBVIPS_REVISION"
@@ -306,10 +306,11 @@ INSTALL_DIR="/opt/${APPLICATION}"
 UPLOAD_DIR="${INSTALL_DIR}/upload"
 SRC_DIR="${INSTALL_DIR}/source"
 APP_DIR="${INSTALL_DIR}/app"
-PLUGIN_DIR="${APP_DIR}/corePlugin"
+PLUGIN_DIR="${APP_DIR}/plugins/immich-plugin-core"
 ML_DIR="${APP_DIR}/machine-learning"
 GEO_DIR="${INSTALL_DIR}/geodata"
 mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
+
 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.1" "$SRC_DIR"
 
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
@@ -338,13 +339,13 @@ fi
 cp "$APP_DIR"/package.json "$APP_DIR"/bin
 sed -i "s|^start|${APP_DIR}/bin/start|" "$APP_DIR"/bin/immich-admin
 
-# openapi & web build
+# sdk, cli & web build
 cd "$SRC_DIR"
 echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
-$STD pnpm --filter @immich/sdk --filter immich-web --frozen-lockfile --force install
 unset SHARP_FORCE_GLOBAL_LIBVIPS
 export SHARP_IGNORE_GLOBAL_LIBVIPS=true
-$STD pnpm --filter @immich/sdk --filter immich-web build
+$STD pnpm --filter @immich/sdk --filter immich-web --filter @immich/cli build
+$STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
 cp -a web/build "$APP_DIR"/www
 cp LICENSE "$APP_DIR"
 cd "$SRC_DIR"
@@ -365,10 +366,9 @@ fi
 $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
 $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
 mkdir -p "$PLUGIN_DIR"
-cp -r ./dist "$PLUGIN_DIR"/dist
-cp ./manifest.json "$PLUGIN_DIR"
+cp -r ./packages/plugin-core/dist "$PLUGIN_DIR"/dist
+cp ./packages/plugin-core/manifest.json "$PLUGIN_DIR"
 msg_ok "Installed Immich Server, Web and Plugin Components"
-
 cd "$SRC_DIR"/machine-learning
 $STD useradd -U -s /usr/sbin/nologin -r -M -d "$INSTALL_DIR" immich
 mkdir -p "$ML_DIR"

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -317,10 +317,7 @@ export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
 # Provision the exact pnpm pinned in package.json's packageManager field via corepack instead
 # of `npm i -g pnpm@X`, which collides (EEXIST) with the corepack pnpm shim shipped by the
-# NodeSource nodejs package.
 $STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
-# corepack activates pnpm but its global bin dir is not in PATH by default;
-# export it so that `pnpm config set --global` succeeds.
 export PATH="/root/.local/share/pnpm/bin:$PATH"
 $STD pnpm config set --global dangerouslyAllowAllBuilds true
 

--- a/install/immich-install.sh
+++ b/install/immich-install.sh
@@ -313,7 +313,16 @@ mkdir -p {"${APP_DIR}","${UPLOAD_DIR}","${GEO_DIR}","${INSTALL_DIR}"/cache}
 
 fetch_and_deploy_gh_release "Immich" "immich-app/immich" "tarball" "v3.0.1" "$SRC_DIR"
 PNPM_VERSION="$(jq -r '.packageManager | split("@")[1] | split("+")[0]' ${SRC_DIR}/package.json)"
-NODE_VERSION="24" NODE_MODULE="corepack,pnpm@${PNPM_VERSION}" setup_nodejs
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
+# Provision the exact pnpm pinned in package.json's packageManager field via corepack instead
+# of `npm i -g pnpm@X`, which collides (EEXIST) with the corepack pnpm shim shipped by the
+# NodeSource nodejs package.
+$STD corepack prepare "pnpm@${PNPM_VERSION}" --activate
+# corepack activates pnpm but its global bin dir is not in PATH by default;
+# export it so that `pnpm config set --global` succeeds.
+export PATH="/root/.local/share/pnpm/bin:$PATH"
+$STD pnpm config set --global dangerouslyAllowAllBuilds true
 
 msg_info "Installing Immich (patience)"
 
@@ -345,16 +354,21 @@ $STD pnpm --filter @immich/sdk --filter immich-web --filter @immich/cli build
 $STD pnpm --filter @immich/cli --prod --no-optional deploy "$APP_DIR"/cli
 cp -a web/build "$APP_DIR"/www
 cp LICENSE "$APP_DIR"
-
-# plugins
-# Build the plugin(s) directly instead of via the `mise //:plugins` monorepo task path,
-# which repeatedly breaks across mise releases (experimental/monorepo_root setting churn).
-# mise is used only to provide the build tools (extism-js, wasm-opt, etc.) via `mise install`
-# and `mise exec`, both of which are stable and do not depend on the monorepo feature.
 cd "$SRC_DIR"
 export MISE_TRUSTED_CONFIG_PATHS="$SRC_DIR"/mise.toml
 export MISE_DISABLE_TOOLS=github:jellyfin/jellyfin-ffmpeg
 $STD mise install
+export PATH="$(mise bin-paths 2>/dev/null | tr '\n' ':')$PATH"
+if ! command -v extism-js >/dev/null 2>&1; then
+  # extism-js is published as a bare gzip-compressed single binary (.gz), which
+  # fetch_and_deploy_gh_release cannot deploy (singlefile leaves it compressed,
+  # prebuild only handles zip/tar). Fetch + gunzip it directly.
+  EXTISM_ARCH="$(arch_resolve x86_64 aarch64)"
+  curl_download /tmp/extism-js.gz "https://github.com/extism/js-pdk/releases/download/v1.6.0/extism-js-${EXTISM_ARCH}-linux-v1.6.0.gz"
+  gunzip -f /tmp/extism-js.gz
+  install -m 0755 /tmp/extism-js /usr/local/bin/extism-js
+  rm -f /tmp/extism-js
+fi
 $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core install --frozen-lockfile
 $STD mise exec -- pnpm --filter @immich/sdk --filter @immich/plugin-sdk --filter @immich/plugin-core build
 mkdir -p "$PLUGIN_DIR"

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -7627,7 +7627,10 @@ setup_nodejs() {
         MODULE_INSTALLED_VERSION="$(npm list -g --depth=0 "$MODULE_NAME" 2>&1 | grep "$MODULE_NAME@" | awk -F@ '{print $2}' 2>/dev/null | tr -d '[:space:]' || echo '')"
         if [[ "$MODULE_REQ_VERSION" != "latest" && "$MODULE_REQ_VERSION" != "$MODULE_INSTALLED_VERSION" ]]; then
           msg_info "Updating $MODULE_NAME to v$MODULE_REQ_VERSION"
-          if $STD npm install -g "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null; then
+          # Retry with --force to overwrite corepack-provided shims (pnpm/yarn), which now
+          # ship with recent corepack and cause EEXIST on /usr/bin/<tool>
+          if $STD npm install -g "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null ||
+            $STD npm install -g --force "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null; then
             msg_ok "Updated $MODULE_NAME"
           else
             msg_warn "Failed to update $MODULE_NAME to version $MODULE_REQ_VERSION"
@@ -7635,7 +7638,8 @@ setup_nodejs() {
           fi
         elif [[ "$MODULE_REQ_VERSION" == "latest" ]]; then
           msg_info "Updating $MODULE_NAME to latest version"
-          if $STD npm install -g "${MODULE_NAME}@latest" 2>/dev/null; then
+          if $STD npm install -g "${MODULE_NAME}@latest" 2>/dev/null ||
+            $STD npm install -g --force "${MODULE_NAME}@latest" 2>/dev/null; then
             msg_ok "Updated $MODULE_NAME"
           else
             msg_warn "Failed to update $MODULE_NAME to latest version"
@@ -7644,7 +7648,10 @@ setup_nodejs() {
         fi
       else
         msg_info "Installing $MODULE_NAME@$MODULE_REQ_VERSION"
-        if $STD npm install -g "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null; then
+        # Retry with --force to overwrite corepack-provided shims (pnpm/yarn), which now
+        # ship with recent corepack and cause EEXIST on /usr/bin/<tool>
+        if $STD npm install -g "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null ||
+          $STD npm install -g --force "${MODULE_NAME}@${MODULE_REQ_VERSION}" 2>/dev/null; then
           msg_ok "Installed $MODULE_NAME"
         else
           msg_warn "Failed to install $MODULE_NAME@$MODULE_REQ_VERSION"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

The change ensure that monorepo_root = true is present while retaining experimental_monorepo_root = true, so plugin builds work across old and new mise versions after the v2026.7.0 key rename

added tools.func bugfixing due pnpm issues - in setup_nodejs, all variants now fall back to npm install -g --force when the normal install fails. --force is npm's own recommended resolution for this EEXIST

## 🔗 Related Issue

Fixes #15153 
Fixes #15556 
Fixes #15555

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
