### PR TITLE
Removed deprecated parameter in Filebrowser Quantum configuration

### DIFF
--- a/tools/addon/filebrowser-quantum.sh
+++ b/tools/addon/filebrowser-quantum.sh
@@ -176,11 +176,10 @@ if [[ "${noauth_prompt,,}" =~ ^(y|yes)$ ]]; then
 server:
   port: $PORT
   sources:
-    - path: "$SRC_DIR"      
+    - path: "$SRC_DIR"
       name: "RootFS"
       config:
         denyByDefault: false
-        disableIndexing: false
         indexingIntervalMinutes: 240
         conditionals:
           rules:
@@ -204,7 +203,6 @@ server:
       name: "RootFS"
       config:
         denyByDefault: false
-        disableIndexing: false
         indexingIntervalMinutes: 240
         conditionals:
           rules:


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Since [v1.4.0](https://github.com/gtsteffaniak/filebrowser/releases/tag/v1.4.0-stable), this parameter was deprecated and made the service to not start. After removing it, the service looks as good as before.

This is my first collaboration. Sorry if something is not right.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
