### PR TITLE
fix(endurain): update frontend dist path after upstream restructure

### DIFF
--- a/ct/endurain.sh
+++ b/ct/endurain.sh
@@ -36,7 +36,7 @@ function update_script() {
 
     msg_info "Creating Backup"
     cp /opt/endurain/.env /opt/endurain.env
-    cp /opt/endurain/frontend/app/dist/env.js /opt/endurain.env.js
+    cp /opt/endurain/frontend/dist/env.js /opt/endurain.env.js
     msg_ok "Created Backup"
 
     CLEAN_INSTALL=1 fetch_and_deploy_codeberg_release "endurain" "endurain-project/endurain" "tarball" "latest" "/opt/endurain"
@@ -52,10 +52,10 @@ function update_script() {
     msg_ok "Prepared Update"
 
     msg_info "Updating Frontend"
-    cd /opt/endurain/frontend/app
+    cd /opt/endurain/frontend
     $STD npm ci
     $STD npm run build
-    cp /opt/endurain.env.js /opt/endurain/frontend/app/dist/env.js
+    cp /opt/endurain.env.js /opt/endurain/frontend/dist/env.js
     rm /opt/endurain.env.js
     msg_ok "Updated Frontend"
 

--- a/install/endurain-install.sh
+++ b/install/endurain-install.sh
@@ -55,7 +55,7 @@ DB_HOST=localhost
 DATABASE_URL=postgresql+psycopg://${PG_DB_USER}:${PG_DB_PASS}@localhost:5432/${PG_DB_NAME}
 
 BACKEND_DIR="/opt/endurain/backend/app"
-FRONTEND_DIR="/opt/endurain/frontend/app/dist"
+FRONTEND_DIR="/opt/endurain/frontend/dist"
 DATA_DIR="/opt/endurain_data/data"
 LOGS_DIR="/opt/endurain_data/logs"
 
@@ -69,10 +69,10 @@ EOF
 msg_ok "Setup Endurain"
 
 msg_info "Building Frontend"
-cd /opt/endurain/frontend/app
+cd /opt/endurain/frontend
 $STD npm ci --prefer-offline
 $STD npm run build
-cat <<EOF >/opt/endurain/frontend/app/dist/env.js
+cat <<EOF >/opt/endurain/frontend/dist/env.js
 window.env = {
   ENDURAIN_HOST: "${ENDURAIN_HOST}"
 }


### PR DESCRIPTION
## ✍️ Description

Endurain moved its frontend project files from `frontend/app/*` to `frontend/*` upstream (confirmed via `frontend/package.json` and `frontend/vite.config.ts` now living directly under `frontend/`). The Vite build output therefore now lands at `frontend/dist` instead of `frontend/app/dist`.

Updated `FRONTEND_DIR`, the frontend build `cd`, and the `env.js` output/backup paths in both the install script and the update (`ct/`) script so installs and updates continue to work against the new upstream layout. The backend layout (`backend/app`) is unchanged.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
