### PR TITLE
immich: vacuum smart_search/face_search before VectorChord bump

### DIFF
--- a/ct/immich.sh
+++ b/ct/immich.sh
@@ -127,6 +127,11 @@ EOF
     VCHORD_RELEASE="1.0.0"
     [[ -f ~/.vchord_version ]] && mv ~/.vchord_version ~/.vectorchord
     if check_for_gh_release "VectorChord" "tensorchord/VectorChord" "${VCHORD_RELEASE}" "updated together with Immich after testing"; then
+      # dead tuples in smart_search/face_search make the REINDEX below fail with
+      # "missing chunk ... for toast value" on VectorChord 1.0.0 (#15588); must vacuum
+      # while still on the old extension version, a post-upgrade vacuum errors instead
+      $STD sudo -u postgres psql -d immich -c "VACUUM (ANALYZE) smart_search;"
+      $STD sudo -u postgres psql -d immich -c "VACUUM (ANALYZE) face_search;"
       fetch_and_deploy_gh_release "VectorChord" "tensorchord/VectorChord" "binary" "${VCHORD_RELEASE}" "/tmp" "postgresql-16-vchord_*_$(arch_resolve).deb"
       systemctl restart postgresql
       $STD sudo -u postgres psql -d immich -c "ALTER EXTENSION vector UPDATE;"


### PR DESCRIPTION
## ✍️ Description

Fixes an update failure where `REINDEX INDEX clip_index`/`face_index` errors with `missing chunk number N for toast value M in pg_toast_*` after the VectorChord 0.5.3 → 1.0.0 bump during the Immich 3.0.1 update. Root cause: dead tuples in `smart_search`/`face_search` trip up VectorChord 1.0.0's reindex (not DB corruption — full details and reproduction in the linked issue and upstream report: supervc-stack/VectorChord#470).

Adds a `VACUUM (ANALYZE)` of both tables before the VectorChord release is fetched (must run while still on the old extension version — a post-upgrade vacuum errors instead, since the index is still in the old on-disk format).

I looked for a way to only vacuum when actually needed (e.g. gating on `pg_stat_user_tables.n_dead_tup`), but that stat isn't reliable here: it resets on Postgres restart, and reads 0 right after a container reboot/snapshot revert even when real dead tuples remain on disk — which is exactly the scenario that triggers this bug in the first place (several reports below are from right after a snapshot revert). `pgstattuple`/`pgstattuple_approx` would give an accurate count, but that means pulling in a new extension just to sometimes skip a vacuum that only takes a few seconds on these tables — not worth the added dependency, so this just vacuums unconditionally.

Tested against a restored pre-upgrade backup: confirmed the unpatched script fails with this exact error, then confirmed this branch's script completes the update successfully from an identical starting snapshot.

## 🔗 Related Issue

Fixes #15588

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
