### PR TITLE
fix(plane): don't clobber global app var, breaking /usr/bin/update

### DIFF
--- a/install/plane-install.sh
+++ b/install/plane-install.sh
@@ -85,8 +85,8 @@ VITE_SPACE_BASE_PATH=/spaces
 VITE_LIVE_BASE_URL=http://${LOCAL_IP}
 VITE_LIVE_BASE_PATH=/live"
 # Each Vite app needs its own .env for the build
-for app in web admin space; do
-    echo "$FRONTEND_ENV" >/opt/plane/apps/${app}/.env
+for frontend_app in web admin space; do
+    echo "$FRONTEND_ENV" >/opt/plane/apps/${frontend_app}/.env
 done
 export NODE_OPTIONS="--max-old-space-size=4096"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0


### PR DESCRIPTION
## ✍️ Description
This fixes the issue to do with the update command returning space.sh, it was caused by the install script overriding the app var in a for loop in the install script. Changing the var name fixes the bug.

## 🔗 Related Issue

Fixes #15598

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
