### PR TITLE
cliproxyapi: point setup message at /management.html

### DIFF
--- a/ct/cliproxyapi.sh
+++ b/ct/cliproxyapi.sh
@@ -52,5 +52,5 @@ description
 
 msg_ok "Completed successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW}Access it using the following URL:${CL}"
-echo -e "${GATEWAY}${BGN}http://${IP}:8317${CL}"
+echo -e "${INFO}${YW}Authenticate your AI providers via the management panel at:${CL}"
+echo -e "${GATEWAY}${BGN}http://${IP}:8317/management.html${CL}"


### PR DESCRIPTION
The completion message previously pointed to the bare host:port, which serves the proxy API rather than the admin UI. Provider authentication happens at /management.html.

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Updates the CLIProxyAPI script front-end page warning to include the corrected /management.html for the built-in management console. If you just go the port on the existing warning, you get raw JSON.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
