### PR TITLE
Wizarr: Build JS and CSS static assets

### DIFF
--- a/ct/wizarr.sh
+++ b/ct/wizarr.sh
@@ -50,20 +50,38 @@ function update_script() {
     $STD /usr/local/bin/uv sync --frozen
     $STD /usr/local/bin/uv run --frozen pybabel compile -d app/translations
     $STD npm --prefix app/static install
-    $STD npm --prefix app/static run build:css
+    $STD npm --prefix app/static run build
     mkdir -p ./.cache
     $STD tar -xf "$BACKUP_FILE" --directory=/
-    if grep -q 'workers' /opt/wizarr/start.sh; then
-      sed -i 's/--workers 4//' /opt/wizarr/start.sh
+    if grep -q 'bind' /opt/wizarr/start.sh; then
+      WIZARR_PORT=$(awk -F: '{print $2}' /opt/wizarr/start.sh | awk -F' ' '{print $1}' | tr -d '[:space:]')
     fi
-    if ! grep -qE 'FLASK|WORKERS|VERSION' /opt/wizarr/.env; then
-      cat <<EOF >/opt/wizarr/.env
+    sed -i -E -e 's/[[:space:]]+/ /g' \
+      -e 's/--workers 4//' \
+      -e 's/--bind 0.0.0.0:[0-9]+//' /opt/wizarr/start.sh
+    KEYS=("FLASK" "WORKERS" "HOST" "PORT")
+    for key in "${KEYS[@]}"; do
+      if ! grep -q "$key" /opt/wizarr/.env; then
+        cat <<EOF >/opt/wizarr/.env
+APP_URL=http://${LOCAL_IP}
+DISABLE_BUILTIN_AUTH=false
 FLASK_ENV=production
 GUNICORN_WORKERS=4
-APP_VERSION=$(sed 's/^20/v&/' ~/.wizarr)
+HOST=0.0.0.0
+PORT=${WIZARR_PORT:-5690}
+LOG_LEVEL=info
+APP_VERSION=$(cat ~/.wizarr)
 EOF
-    else
-      sed -i "s/_VERSION=v.*$/_VERSION=v$(cat ~/.wizarr)/" /opt/wizarr/.env
+      fi
+      continue
+    done
+    sed -i "s/_VERSION=.*$/_VERSION=$(cat ~/.wizarr)/" /opt/wizarr/.env
+    if grep -q 'abnormal' /etc/systemd/system/wizarr.service; then
+      sed -i 's/on-abnormal/always \
+RestartSec=10 \
+KillMode=mixed \
+TimeoutStopSec=10/' /etc/systemd/system/wizarr.service
+      systemctl daemon-reload
     fi
     rm -rf "$BACKUP_FILE"
     export FLASK_SKIP_SCHEDULER=true

--- a/install/wizarr-install.sh
+++ b/install/wizarr-install.sh
@@ -27,15 +27,17 @@ cd /opt/wizarr
 $STD /usr/local/bin/uv sync --frozen
 $STD /usr/local/bin/uv run --frozen pybabel compile -d app/translations
 $STD npm --prefix app/static install
-$STD npm --prefix app/static run build:css
+$STD npm --prefix app/static run build
 mkdir -p ./.cache
 cat <<EOF >/opt/wizarr/.env
 FLASK_ENV=production
 GUNICORN_WORKERS=4
 APP_URL=http://${LOCAL_IP}
+HOST=0.0.0.0
+PORT=5690
 DISABLE_BUILTIN_AUTH=false
 LOG_LEVEL=INFO
-APP_VERSION=v$(get_latest_github_release "wizarrrr/wizarr")
+APP_VERSION=$(get_latest_github_release "wizarrrr/wizarr")
 EOF
 
 cat <<EOF >/opt/wizarr/start.sh
@@ -44,7 +46,6 @@ cat <<EOF >/opt/wizarr/start.sh
 uv run --frozen gunicorn \
     --config gunicorn.conf.py \
     --preload \
-    --bind 0.0.0.0:5690 \
     --umask 007 \
     run:app
 EOF
@@ -62,7 +63,10 @@ Type=simple
 WorkingDirectory=/opt/wizarr
 EnvironmentFile=/opt/wizarr/.env
 ExecStart=/opt/wizarr/start.sh
-Restart=on-abnormal
+Restart=always
+RestartSec=10
+KillMode=mixed
+TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Wizarr 2026.7.0+ builds both the CSS and JS static assets, so build had to be updated.
- v was removed from the APP_VERSION as it's superfluous
- `--bind 0.0.0.0:5690` removed from `start.sh` as they have moved to configurable env vars
  - if users have edited start.sh to change the default port the script tries to account for that
- Replaced the simple `grep` check of the Wizarr `.env` during update with a loop; the grep logic ran the risk of either overwriting the existing config with incomplete options, or not running the `cat` even when certain keys were not present.
- Systemd service file updated with `Restart=always` and `KillMode=mixed` as well as timeouts so Wizarr doesn't hang on stops & restarts.

## 🔗 Related Issue

Fixes #15625 

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
