### PR TITLE
fix(pihole): repair Unbound DNS-over-TLS (DoT) forwarding config

### DIFF
--- a/install/pihole-install.sh
+++ b/install/pihole-install.sh
@@ -119,7 +119,8 @@ edns-packet-max=1232
 EOF
 
   if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
-    cat <<EOF >/etc/unbound/unbound.conf.d/pi-hole.conf
+    cat <<EOF >>/etc/unbound/unbound.conf.d/pi-hole.conf
+server:
   tls-cert-bundle: "/etc/ssl/certs/ca-certificates.crt"
 forward-zone:
   name: "."


### PR DESCRIPTION
## ✍️ Description

When the optional Unbound install is chosen **with DoT forwarding**, the script truncated (`>`) `/etc/unbound/unbound.conf.d/pi-hole.conf` and rewrote it starting with an indented `tls-cert-bundle:` option with no `server:` section header. `unbound-checkconf` rejects this ("syntax error, is there no section start"), so `systemctl restart unbound` exits 1 and the install aborts. The overwrite also dropped the `interface: 127.0.0.1` / `port: 5335` settings Pi-hole forwards to.

This appends (`>>`) the DoT additions under a proper `server:` section (unbound merges multiple `server:` clauses) so `tls-cert-bundle` and the `forward-zone` are valid and the resolver keeps listening on `127.0.0.1:5335`. Recursive (non-DoT) mode is unchanged.

Verified with `unbound-checkconf`: the old generated config is rejected with the exact error from the issue, the fixed merged config reports no errors.

## 🔗 Related Issue

Fixes #15622

## ✅ Prerequisites (X in brackets)

- [x] Self-review completed
- [x] Tested thoroughly
- [x] No security risks

## 🛠️ Type of Change (X in brackets)

- [x] 🐞 Bug fix
