### PR TITLE
Open WebUI: add optional OpenTelemetry package install

### DIFF
--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -114,7 +114,14 @@ EOF
 
   msg_info "Updating Open WebUI via uv"
   PYTHON_VERSION="3.12" setup_uv
-  $STD uv tool install --force --python 3.12 --constraint <(echo "numba>=0.60") open-webui[all]
+  OWUI_PYTHON="/root/.local/share/uv/tools/open-webui/bin/python3.12"
+  OTEL_ARGS=()
+  if [[ -x "$OWUI_PYTHON" ]]; then
+    while IFS= read -r pkg; do
+      OTEL_ARGS+=(--with "$pkg")
+    done < <(uv pip list --python "$OWUI_PYTHON" --format freeze 2>/dev/null | grep -i '^opentelemetry-' | cut -d= -f1)
+  fi
+  $STD uv tool install --force --python 3.12 --constraint <(echo "numba>=0.60") "${OTEL_ARGS[@]}" open-webui[all]
   systemctl restart open-webui
   msg_ok "Updated Open WebUI"
   msg_ok "Updated successfully!"

--- a/install/openwebui-install.sh
+++ b/install/openwebui-install.sh
@@ -25,8 +25,28 @@ setup_hwaccel
 
 PYTHON_VERSION="3.12" setup_uv
 
+OTEL_ARGS=()
+read -r -p "${TAB3}Would you like to install OpenTelemetry instrumentation packages (requires manual .env configuration)? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  for pkg in \
+    opentelemetry-api \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp \
+    opentelemetry-exporter-otlp-proto-http \
+    opentelemetry-instrumentation-fastapi \
+    opentelemetry-instrumentation-aiohttp-client \
+    opentelemetry-instrumentation-httpx \
+    opentelemetry-instrumentation-sqlalchemy \
+    opentelemetry-instrumentation-requests \
+    opentelemetry-instrumentation-logging \
+    opentelemetry-instrumentation-redis \
+    opentelemetry-instrumentation-system-metrics; do
+    OTEL_ARGS+=(--with "$pkg")
+  done
+fi
+
 msg_info "Installing Open WebUI"
-$STD uv tool install --python 3.12 --constraint <(echo "numba>=0.60") open-webui[all]
+$STD uv tool install --python 3.12 --constraint <(echo "numba>=0.60") "${OTEL_ARGS[@]}" open-webui[all]
 msg_ok "Installed Open WebUI"
 
 read -r -p "${TAB3}Would you like to add Ollama? <y/N> " prompt


### PR DESCRIPTION
## Summary
- Adds an install-time prompt to optionally install OpenTelemetry instrumentation packages into the Open WebUI `uv tool` environment (`opentelemetry-api`, `-sdk`, exporters, and instrumentation packages for FastAPI/aiohttp/httpx/SQLAlchemy/requests/logging/redis/system-metrics).
- Users still need to configure the relevant `OTEL_*` variables in `/root/.env` themselves — this only installs the packages.
- Fixes the packages being silently dropped on every update: `uv tool install --force` recreates the tool venv from the given package spec, so any manually `pip install`-ed extras previously had to be reinstalled by hand after each update. This uses `uv tool install --with <pkg>` instead.
- `update_script` detects currently-installed `opentelemetry-*` packages directly from the live venv (`uv pip list --python <venv> --format freeze | grep '^opentelemetry-'`) before reinstalling, and re-supplies them as `--with` args. This is not gated by whether the install-time prompt was ever answered "yes" — it also retroactively covers containers that already had OTEL packages added by hand before this change existed, since detection is based on actual installed state rather than a persisted flag.

## Note
This only preserves OpenTelemetry packages specifically. `uv tool install --force` will still silently drop any other manually `uv pip install`-ed package in this venv on update. Scoped to OpenTelemetry only, matching the actual problem being fixed here.

## Test plan
- [x] Fresh install with the OpenTelemetry prompt answered "yes": confirmed all packages import in the tool venv
- [x] Update path against a freshly-installed container with OTEL packages present: confirmed they survive `uv tool install --force`
- [x] Update path against an existing container that had OTEL packages added manually (pre-dating this change, no prior marker/flag): confirmed detection picks them up and preserves them
- [x] Update path against a container with no OTEL packages installed: confirmed no behavior change
- `shellcheck` / `shfmt` clean (no new warnings beyond pre-existing ones in these files)
