### PR TITLE
fix(adventurelog): allow pnpm build scripts so install/update doesn't abort

### DIFF
--- a/ct/adventurelog.sh
+++ b/ct/adventurelog.sh
@@ -60,6 +60,7 @@ function update_script() {
     $STD .venv/bin/python -m manage migrate
 
     cd /opt/adventurelog/frontend
+    grep -q "^dangerouslyAllowAllBuilds:" ./pnpm-workspace.yaml 2>/dev/null || echo "dangerouslyAllowAllBuilds: true" >>./pnpm-workspace.yaml
     $STD pnpm i
     $STD pnpm build
     msg_ok "Updated AdventureLog"

--- a/install/adventurelog-install.sh
+++ b/install/adventurelog-install.sh
@@ -72,6 +72,7 @@ BODY_SIZE_LIMIT=Infinity
 ORIGIN='http://$LOCAL_IP:3000'
 EOF
 cd /opt/adventurelog/frontend
+grep -q "^dangerouslyAllowAllBuilds:" ./pnpm-workspace.yaml 2>/dev/null || echo "dangerouslyAllowAllBuilds: true" >>./pnpm-workspace.yaml
 $STD pnpm i
 $STD pnpm build
 msg_ok "Installed AdventureLog"


### PR DESCRIPTION
## ✍️ Description

AdventureLog's frontend install runs a bare `pnpm i`. On pnpm v10+, dependency build scripts (esbuild, es5-ext, svelte-preprocess) are ignored by default and pnpm aborts with `ERR_PNPM_IGNORED_BUILDS` (exit 1), so the install never reaches `pnpm build`. The frontend's shipped `pnpm-workspace.yaml` already pins esbuild, so those builds are expected to run.

This appends `dangerouslyAllowAllBuilds: true` to the frontend's `pnpm-workspace.yaml` (guarded against duplication) before `pnpm i`, in both the install and update paths. It is scoped to this app only — AdventureLog ships no `onlyBuiltDependencies`, so it will not hit the global config conflict that motivated #15579, and it restores the build behaviour the script relied on before that change ("scripts that truly need every build script executed enable that themselves").

Verified locally with pnpm 11.10.0 against the app's real shipped `pnpm-workspace.yaml`: reproduces `ERR_PNPM_IGNORED_BUILDS` (exit 1) before, exits 0 after. `bash -n` and `shellcheck` pass. No Proxmox host was available, so this was not run against a live container — a reviewer container test would be appreciated.

Note: if you'd prefer to solve this repo-wide in `misc/tools.func` rather than per-script, happy to close this in favour of that — this per-script fix follows the existing precedent (Homepage/Immich carry the same kind of per-app build-allow) and directly clears the reported failure.

_Disclosure: prepared with AI assistance (Claude); reviewed by me._

## 🔗 Related Issue

Fixes #15670

## ✅ Prerequisites

- [x] Self-review completed
- [ ] Tested thoroughly – verified via local pnpm reproduction; not yet run on a live Proxmox LXC
- [x] No security risks

## 🛠️ Type of Change

- [x] 🐞 Bug fix
