### PR TITLE
Pangolin: Bump to 1.20.0 | BREAKING: Switch to PostgreSQL

### DIFF
--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -50,6 +50,7 @@ function update_script() {
     systemctl stop gerbil
     msg_info "Service stopped"
 
+    DB_URL=$(sed -n 's/.*connection_string: "\(.*\)".*/\1/p' /opt/pangolin/config/config.yml)
     create_backup /opt/pangolin/config
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
@@ -61,10 +62,11 @@ function update_script() {
     $STD npm run set:pg
     $STD npm run set:oss
     rm -rf server/private
-    $STD npm run db:generate
+    DATABASE_URL="$DB_URL" $STD npm run db:generate
     $STD npm run build
     $STD npm run build:cli
     cp -R .next/standalone ./
+    cp -r server/migrations ./dist/init
     chmod +x ./dist/cli.mjs
     cp server/db/names.json ./dist/names.json
     cp server/db/ios_models.json ./dist/ios_models.json
@@ -107,4 +109,4 @@ description
 msg_ok "Completed successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW}Access it using the following URL:${CL}"
-echo -e "${GATEWAY}${BGN}https://<YOUR_PANGOLIN_URL>${CL}"
+echo -e "${GATEWAY}${BGN}https://<YOUR_PANGOLIN_URL> or http://${IP}:3002${CL}"

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -102,6 +102,32 @@ function update_script() {
         sqlite_column_exists "$db_path" "domains" "lastCheckedAt"
     }
 
+    sqlite_value() {
+      local db_path="$1"
+      local query="$2"
+      sqlite3 "$db_path" "$query" 2>/dev/null | tr -d '[:space:]'
+    }
+
+    prepare_sqlite_for_120_replay() {
+      local db_path="$1"
+      local has_120
+      local vm_count
+
+      has_120="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations WHERE version='1.20.0';")"
+      vm_count="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations;")"
+
+      if [[ "${has_120:-0}" -gt 0 ]]; then
+        msg_info "Detected stale migration marker for 1.20.0; forcing replay"
+        sqlite3 "$db_path" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
+        vm_count="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations;")"
+      fi
+
+      if [[ "${vm_count:-0}" -eq 0 ]]; then
+        msg_info "Migration history is empty; seeding baseline 1.19.1 so 1.20.0 migration can run"
+        sqlite3 "$db_path" "INSERT INTO versionMigrations (version, executedAt) VALUES ('1.19.1', CAST(strftime('%s','now') AS INTEGER) * 1000);" 2>/dev/null || true
+      fi
+    }
+
     run_sqlite_migrations() {
       ENVIRONMENT=prod $STD node dist/migrations.mjs
     }
@@ -114,11 +140,8 @@ function update_script() {
         sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations;" 2>/dev/null || true
       fi
 
-      if [[ "$PANGOLIN_VERSION" == "1.20.0" ]] &&
-        sqlite3 "$SQLITE_DB" "SELECT 1 FROM versionMigrations WHERE version='1.20.0' LIMIT 1;" 2>/dev/null | grep -q '^1$' &&
-        ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
-        msg_info "Detected stale migration marker for 1.20.0; forcing replay"
-        sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
+      if [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
+        prepare_sqlite_for_120_replay "$SQLITE_DB"
       fi
     fi
 
@@ -126,7 +149,7 @@ function update_script() {
 
     if [[ -f "$SQLITE_DB" ]] && [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
       msg_info "Schema check failed after first pass; retrying 1.20.0 migration"
-      sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
+      prepare_sqlite_for_120_replay "$SQLITE_DB"
       run_sqlite_migrations
     fi
 

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -102,6 +102,25 @@ function update_script() {
         sqlite_column_exists "$db_path" "domains" "lastCheckedAt"
     }
 
+    sqlite_backfill_pre_120_prereqs() {
+      local db_path="$1"
+
+      if sqlite_table_exists "$db_path" "resourceSessions"; then
+        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyPasswordId"; then
+          msg_info "Backfilling missing column resourceSessions.policyPasswordId"
+          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyPasswordId' integer REFERENCES resourcePolicyPassword(passwordId);" 2>/dev/null || true
+        fi
+        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyPincodeId"; then
+          msg_info "Backfilling missing column resourceSessions.policyPincodeId"
+          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyPincodeId' integer REFERENCES resourcePolicyPincode(pincodeId);" 2>/dev/null || true
+        fi
+        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyWhitelistId"; then
+          msg_info "Backfilling missing column resourceSessions.policyWhitelistId"
+          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyWhitelistId' integer REFERENCES resourcePolicyWhitelist(id);" 2>/dev/null || true
+        fi
+      fi
+    }
+
     sqlite_value() {
       local db_path="$1"
       local query="$2"
@@ -126,6 +145,8 @@ function update_script() {
         msg_info "Migration history is empty; seeding baseline 1.19.1 so 1.20.0 migration can run"
         sqlite3 "$db_path" "INSERT INTO versionMigrations (version, executedAt) VALUES ('1.19.1', CAST(strftime('%s','now') AS INTEGER) * 1000);" 2>/dev/null || true
       fi
+
+      sqlite_backfill_pre_120_prereqs "$db_path"
     }
 
     run_sqlite_migrations() {

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -33,14 +33,13 @@ function update_script() {
 
   ensure_dependencies build-essential python3
 
-  CURRENT_VERSION=$(grep -oP '(?<="version": ")[^"]+' /opt/pangolin/package.json 2>/dev/null || echo "0.0.0")
-  if [[ $(echo -e "$CURRENT_VERSION\n1.20.0" | sort -V | head -1) != "1.20.0" ]]; then
-    if [[ "$CURRENT_VERSION" != "1.20.0" ]]; then
-      msg_error "Upgrade from ${CURRENT_VERSION} to ${PANGOLIN_VERSION} is not supported by this script."
-      echo -e "${INFO}${YW}This installation uses SQLite. Please perform a fresh install with PostgreSQL.${CL}"
-      echo -e "${INFO}${YW}See: https://docs.pangolin.net/self-host/advanced/database-options${CL}"
-      exit 1
-    fi
+  if ! command -v psql &>/dev/null; then
+    msg_error "This installation uses SQLite and cannot be upgraded to Pangolin ${PANGOLIN_VERSION}."
+    echo -e "${INFO}${YW}Starting with Pangolin 1.20.0, PostgreSQL is required as the database backend.${CL}"
+    echo -e "${INFO}${YW}An automatic migration of your existing SQLite data is not supported.${CL}"
+    echo -e "${INFO}${YW}Please create a new LXC with the Pangolin install script, which sets up PostgreSQL automatically.${CL}"
+    echo -e "${INFO}${YW}Your current data is preserved in this container and can be manually migrated if needed.${CL}"
+    exit 1
   fi
 
   NODE_VERSION="24" setup_nodejs

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -33,20 +33,17 @@ function update_script() {
 
   ensure_dependencies build-essential python3
 
-  is_sqlite_installation() {
-    [[ -f /opt/pangolin/config/db/db.sqlite ]]
-  }
-
-  has_postgres_config() {
-    local cfg
-    cfg="/opt/pangolin/config/config.yml"
-    [[ ! -f "$cfg" ]] && cfg="/opt/pangolin/config/config.yaml"
-    [[ -f "$cfg" ]] && grep -Eq '^[[:space:]]*postgres:' "$cfg"
-  }
+  CURRENT_VERSION=$(grep -oP '(?<="version": ")[^"]+' /opt/pangolin/package.json 2>/dev/null || echo "0.0.0")
+  if [[ $(echo -e "$CURRENT_VERSION\n1.20.0" | sort -V | head -1) != "1.20.0" ]]; then
+    if [[ "$CURRENT_VERSION" != "1.20.0" ]]; then
+      msg_error "Upgrade from ${CURRENT_VERSION} to ${PANGOLIN_VERSION} is not supported by this script."
+      echo -e "${INFO}${YW}This installation uses SQLite. Please perform a fresh install with PostgreSQL.${CL}"
+      echo -e "${INFO}${YW}See: https://docs.pangolin.net/self-host/advanced/database-options${CL}"
+      exit 1
+    fi
+  fi
 
   NODE_VERSION="24" setup_nodejs
-  PG_VERSION="17" setup_postgresql
-  PG_DB_NAME="pangolin" PG_DB_USER="pangolin" setup_postgresql_db
 
   if check_for_gh_release "pangolin" "fosrl/pangolin" "$PANGOLIN_VERSION" "Pinned to a tested release because Pangolin's schema changes have repeatedly broken unattended updates. To try a newer version at your own risk, run: 'export PANGOLIN_VERSION=<tag>' and re-run update. If it breaks, please open an issue at https://github.com/community-scripts/ProxmoxVE/issues with the error log."; then
     msg_info "Stopping Service"
@@ -56,10 +53,6 @@ function update_script() {
 
     msg_info "Creating backup"
     tar -czf /opt/pangolin_config_backup.tar.gz -C /opt/pangolin config
-    if [[ -f /opt/pangolin/config/db/db.sqlite ]]; then
-      cp -a /opt/pangolin/config/db/db.sqlite \
-        "/opt/pangolin/config/db/db.sqlite.pre-${PANGOLIN_VERSION}-$(date +%Y%m%d-%H%M%S).bak"
-    fi
     msg_ok "Created backup"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
@@ -86,22 +79,6 @@ function update_script() {
     rm -f /opt/pangolin_config_backup.tar.gz
     msg_ok "Restored config"
 
-    if is_sqlite_installation && ! has_postgres_config; then
-      msg_error "SQLite installation detected without PostgreSQL config."
-      echo -e "${INFO}${YW}Automatic data migration from SQLite to PostgreSQL is not supported.${CL}"
-      echo -e "${INFO}${YW}Please migrate your data manually and add the postgres: block to config.yml, then re-run the update.${CL}"
-      exit 1
-    fi
-
-    if ! has_postgres_config; then
-      local cfg="/opt/pangolin/config/config.yml"
-      cat <<EOF >>"$cfg"
-
-postgres:
-  connection_string: "postgresql://pangolin:${PG_DB_PASS}@localhost:5432/pangolin"
-EOF
-    fi
-
     if ! grep -q '^ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service 2>/dev/null; then
       msg_info "Adding migration step to pangolin.service"
       sed -i '/^ExecStart=\/usr\/bin\/node --enable-source-maps dist\/server.mjs/i ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service
@@ -109,17 +86,8 @@ EOF
       msg_ok "Updated pangolin.service"
     fi
 
-    if ! grep -q '^After=.*postgresql.service' /etc/systemd/system/pangolin.service; then
-      sed -i '/^After=/ s/$/ postgresql.service/' /etc/systemd/system/pangolin.service
-    fi
-    if ! grep -q '^Wants=.*postgresql.service' /etc/systemd/system/pangolin.service; then
-      sed -i '/^After=/a Wants=postgresql.service' /etc/systemd/system/pangolin.service
-    fi
-    systemctl daemon-reload
-
     msg_info "Running database migrations"
     cd /opt/pangolin
-    msg_info "Running setup migrations"
     ENVIRONMENT=prod $STD node dist/migrations.mjs
 
     msg_ok "Ran database migrations"

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -33,7 +33,20 @@ function update_script() {
 
   ensure_dependencies build-essential python3
 
+  is_sqlite_installation() {
+    [[ -f /opt/pangolin/config/db/db.sqlite ]]
+  }
+
+  has_postgres_config() {
+    local cfg
+    cfg="/opt/pangolin/config/config.yml"
+    [[ ! -f "$cfg" ]] && cfg="/opt/pangolin/config/config.yaml"
+    [[ -f "$cfg" ]] && grep -Eq '^[[:space:]]*postgres:' "$cfg"
+  }
+
   NODE_VERSION="24" setup_nodejs
+  PG_VERSION="17" setup_postgresql
+  PG_DB_NAME="pangolin" PG_DB_USER="pangolin" setup_postgresql_db
 
   if check_for_gh_release "pangolin" "fosrl/pangolin" "$PANGOLIN_VERSION" "Pinned to a tested release because Pangolin's schema changes have repeatedly broken unattended updates. To try a newer version at your own risk, run: 'export PANGOLIN_VERSION=<tag>' and re-run update. If it breaks, please open an issue at https://github.com/community-scripts/ProxmoxVE/issues with the error log."; then
     msg_info "Stopping Service"
@@ -55,7 +68,7 @@ function update_script() {
     msg_info "Updating Pangolin"
     cd /opt/pangolin
     $STD npm ci
-    $STD npm run set:sqlite
+    $STD npm run set:pg
     $STD npm run set:oss
     rm -rf server/private
     $STD npm run db:generate
@@ -73,6 +86,22 @@ function update_script() {
     rm -f /opt/pangolin_config_backup.tar.gz
     msg_ok "Restored config"
 
+    if is_sqlite_installation && ! has_postgres_config; then
+      msg_error "SQLite installation detected without PostgreSQL config."
+      echo -e "${INFO}${YW}Automatic data migration from SQLite to PostgreSQL is not supported.${CL}"
+      echo -e "${INFO}${YW}Please migrate your data manually and add the postgres: block to config.yml, then re-run the update.${CL}"
+      exit 1
+    fi
+
+    if ! has_postgres_config; then
+      local cfg="/opt/pangolin/config/config.yml"
+      cat <<EOF >>"$cfg"
+
+postgres:
+  connection_string: "postgresql://pangolin:${PG_DB_PASS}@localhost:5432/pangolin"
+EOF
+    fi
+
     if ! grep -q '^ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service 2>/dev/null; then
       msg_info "Adding migration step to pangolin.service"
       sed -i '/^ExecStart=\/usr\/bin\/node --enable-source-maps dist\/server.mjs/i ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service
@@ -80,104 +109,18 @@ function update_script() {
       msg_ok "Updated pangolin.service"
     fi
 
-    sqlite_table_exists() {
-      local db_path="$1"
-      local table_name="$2"
-      sqlite3 "$db_path" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table_name' LIMIT 1;" 2>/dev/null | grep -q '^1$'
-    }
-
-    sqlite_column_exists() {
-      local db_path="$1"
-      local table_name="$2"
-      local column_name="$3"
-      sqlite3 "$db_path" "PRAGMA table_info('$table_name');" 2>/dev/null | awk -F'|' -v col="$column_name" '$2==col{found=1} END{exit !found}'
-    }
-
-    sqlite_schema_ready_for_120() {
-      local db_path="$1"
-      sqlite_table_exists "$db_path" "remoteExitNodePreferenceLabels" &&
-        sqlite_table_exists "$db_path" "remoteExitNodeResources" &&
-        sqlite_table_exists "$db_path" "launcherViews" &&
-        sqlite_column_exists "$db_path" "domains" "customCertResolver" &&
-        sqlite_column_exists "$db_path" "domains" "lastCheckedAt"
-    }
-
-    sqlite_backfill_pre_120_prereqs() {
-      local db_path="$1"
-
-      if sqlite_table_exists "$db_path" "resourceSessions"; then
-        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyPasswordId"; then
-          msg_info "Backfilling missing column resourceSessions.policyPasswordId"
-          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyPasswordId' integer REFERENCES resourcePolicyPassword(passwordId);" 2>/dev/null || true
-        fi
-        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyPincodeId"; then
-          msg_info "Backfilling missing column resourceSessions.policyPincodeId"
-          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyPincodeId' integer REFERENCES resourcePolicyPincode(pincodeId);" 2>/dev/null || true
-        fi
-        if ! sqlite_column_exists "$db_path" "resourceSessions" "policyWhitelistId"; then
-          msg_info "Backfilling missing column resourceSessions.policyWhitelistId"
-          sqlite3 "$db_path" "ALTER TABLE 'resourceSessions' ADD 'policyWhitelistId' integer REFERENCES resourcePolicyWhitelist(id);" 2>/dev/null || true
-        fi
-      fi
-    }
-
-    sqlite_value() {
-      local db_path="$1"
-      local query="$2"
-      sqlite3 "$db_path" "$query" 2>/dev/null | tr -d '[:space:]'
-    }
-
-    prepare_sqlite_for_120_replay() {
-      local db_path="$1"
-      local has_120
-      local vm_count
-
-      has_120="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations WHERE version='1.20.0';")"
-      vm_count="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations;")"
-
-      if [[ "${has_120:-0}" -gt 0 ]]; then
-        msg_info "Detected stale migration marker for 1.20.0; forcing replay"
-        sqlite3 "$db_path" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
-        vm_count="$(sqlite_value "$db_path" "SELECT COUNT(*) FROM versionMigrations;")"
-      fi
-
-      if [[ "${vm_count:-0}" -eq 0 ]]; then
-        msg_info "Migration history is empty; seeding baseline 1.19.1 so 1.20.0 migration can run"
-        sqlite3 "$db_path" "INSERT INTO versionMigrations (version, executedAt) VALUES ('1.19.1', CAST(strftime('%s','now') AS INTEGER) * 1000);" 2>/dev/null || true
-      fi
-
-      sqlite_backfill_pre_120_prereqs "$db_path"
-    }
-
-    run_sqlite_migrations() {
-      ENVIRONMENT=prod $STD node dist/migrations.mjs
-    }
+    if ! grep -q '^After=.*postgresql.service' /etc/systemd/system/pangolin.service; then
+      sed -i '/^After=/ s/$/ postgresql.service/' /etc/systemd/system/pangolin.service
+    fi
+    if ! grep -q '^Wants=.*postgresql.service' /etc/systemd/system/pangolin.service; then
+      sed -i '/^After=/a Wants=postgresql.service' /etc/systemd/system/pangolin.service
+    fi
+    systemctl daemon-reload
 
     msg_info "Running database migrations"
     cd /opt/pangolin
-    SQLITE_DB="/opt/pangolin/config/db/db.sqlite"
-    if [[ -f "$SQLITE_DB" ]]; then
-      if ! sqlite_table_exists "$SQLITE_DB" "statusHistory"; then
-        sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations;" 2>/dev/null || true
-      fi
-
-      if [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
-        prepare_sqlite_for_120_replay "$SQLITE_DB"
-      fi
-    fi
-
-    run_sqlite_migrations
-
-    if [[ -f "$SQLITE_DB" ]] && [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
-      msg_info "Schema check failed after first pass; retrying 1.20.0 migration"
-      prepare_sqlite_for_120_replay "$SQLITE_DB"
-      run_sqlite_migrations
-    fi
-
-    if [[ -f "$SQLITE_DB" ]] && [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
-      msg_error "SQLite schema is still incomplete after migration replay (expected 1.20.0 schema). Aborting update to prevent broken runtime."
-      exit 1
-    fi
+    msg_info "Running setup migrations"
+    ENVIRONMENT=prod $STD node dist/migrations.mjs
 
     msg_ok "Ran database migrations"
 

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -6,7 +6,7 @@ source <(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxV
 # Source: https://pangolin.net/ | Github: https://github.com/fosrl/pangolin
 
 APP="Pangolin"
-PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.4}"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.20.0}"
 var_tags="${var_tags:-proxy}"
 var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-4096}"
@@ -80,15 +80,61 @@ function update_script() {
       msg_ok "Updated pangolin.service"
     fi
 
+    sqlite_table_exists() {
+      local db_path="$1"
+      local table_name="$2"
+      sqlite3 "$db_path" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='$table_name' LIMIT 1;" 2>/dev/null | grep -q '^1$'
+    }
+
+    sqlite_column_exists() {
+      local db_path="$1"
+      local table_name="$2"
+      local column_name="$3"
+      sqlite3 "$db_path" "PRAGMA table_info('$table_name');" 2>/dev/null | awk -F'|' -v col="$column_name" '$2==col{found=1} END{exit !found}'
+    }
+
+    sqlite_schema_ready_for_120() {
+      local db_path="$1"
+      sqlite_table_exists "$db_path" "remoteExitNodePreferenceLabels" &&
+        sqlite_table_exists "$db_path" "remoteExitNodeResources" &&
+        sqlite_table_exists "$db_path" "launcherViews" &&
+        sqlite_column_exists "$db_path" "domains" "customCertResolver" &&
+        sqlite_column_exists "$db_path" "domains" "lastCheckedAt"
+    }
+
+    run_sqlite_migrations() {
+      ENVIRONMENT=prod $STD node dist/migrations.mjs
+    }
+
     msg_info "Running database migrations"
     cd /opt/pangolin
     SQLITE_DB="/opt/pangolin/config/db/db.sqlite"
     if [[ -f "$SQLITE_DB" ]]; then
-      if ! sqlite3 "$SQLITE_DB" ".tables" 2>/dev/null | tr ' ' '\n' | grep -qx "statusHistory"; then
+      if ! sqlite_table_exists "$SQLITE_DB" "statusHistory"; then
         sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations;" 2>/dev/null || true
       fi
+
+      if [[ "$PANGOLIN_VERSION" == "1.20.0" ]] &&
+        sqlite3 "$SQLITE_DB" "SELECT 1 FROM versionMigrations WHERE version='1.20.0' LIMIT 1;" 2>/dev/null | grep -q '^1$' &&
+        ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
+        msg_info "Detected stale migration marker for 1.20.0; forcing replay"
+        sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
+      fi
     fi
-    ENVIRONMENT=prod $STD node dist/migrations.mjs
+
+    run_sqlite_migrations
+
+    if [[ -f "$SQLITE_DB" ]] && [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
+      msg_info "Schema check failed after first pass; retrying 1.20.0 migration"
+      sqlite3 "$SQLITE_DB" "DELETE FROM versionMigrations WHERE version='1.20.0';" 2>/dev/null || true
+      run_sqlite_migrations
+    fi
+
+    if [[ -f "$SQLITE_DB" ]] && [[ "$PANGOLIN_VERSION" == "1.20.0" ]] && ! sqlite_schema_ready_for_120 "$SQLITE_DB"; then
+      msg_error "SQLite schema is still incomplete after migration replay (expected 1.20.0 schema). Aborting update to prevent broken runtime."
+      exit 1
+    fi
+
     msg_ok "Ran database migrations"
 
     msg_info "Updating Badger plugin version"

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -51,9 +51,7 @@ function update_script() {
     systemctl stop gerbil
     msg_info "Service stopped"
 
-    msg_info "Creating backup"
-    tar -czf /opt/pangolin_config_backup.tar.gz -C /opt/pangolin config
-    msg_ok "Created backup"
+    create_backup /opt/pangolin/config
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_$(arch_resolve)"
@@ -74,10 +72,7 @@ function update_script() {
     cp server/db/mac_models.json ./dist/mac_models.json
     msg_ok "Updated Pangolin"
 
-    msg_info "Restoring config"
-    tar -xzf /opt/pangolin_config_backup.tar.gz -C /opt/pangolin --overwrite
-    rm -f /opt/pangolin_config_backup.tar.gz
-    msg_ok "Restored config"
+    restore_backup
 
     if ! grep -q '^ExecStartPre=/usr/bin/node dist/migrations.mjs' /etc/systemd/system/pangolin.service 2>/dev/null; then
       msg_info "Adding migration step to pangolin.service"

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -185,7 +185,8 @@ http:
         servers:
           - url: "http://$LOCAL_IP:3000"
 EOF
-$STD ENVIRONMENT=prod node dist/migrations.mjs
+export ENVIRONMENT=prod
+$STD node dist/migrations.mjs
 
 . /etc/os-release
 if [ "$VERSION_CODENAME" = "trixie" ]; then

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -16,7 +16,6 @@ update_os
 msg_info "Installing Dependencies"
 $STD apt install -y \
   build-essential \
-  python3 \
   iptables
 msg_ok "Installed Dependencies"
 
@@ -29,6 +28,7 @@ fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/
 fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_$(arch_resolve).tar.gz"
 
 read -rp "${TAB3}Enter your Pangolin URL (ex: https://pangolin.example.com): " pango_url
+[[ "$pango_url" != https://* && "$pango_url" != http://* ]] && pango_url="https://${pango_url}"
 read -rp "${TAB3}Enter your email address: " pango_email
 
 msg_info "Setup Pangolin"
@@ -40,10 +40,11 @@ $STD npm ci
 $STD npm run set:pg
 $STD npm run set:oss
 rm -rf server/private
-$STD npm run db:generate
+DATABASE_URL="postgresql://pangolin:${PG_DB_PASS}@localhost:5432/pangolin" $STD npm run db:generate
 $STD npm run build
 $STD npm run build:cli
 cp -R .next/standalone ./
+cp -r server/migrations ./dist/init
 
 cat <<EOF >/usr/local/bin/pangctl
 #!/bin/sh

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -17,11 +17,12 @@ msg_info "Installing Dependencies"
 $STD apt install -y \
   build-essential \
   python3 \
-  sqlite3 \
   iptables
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
+PG_VERSION="17" setup_postgresql
+PG_DB_NAME="pangolin" PG_DB_USER="pangolin" setup_postgresql_db
 PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.20.0}"
 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_$(arch_resolve)"
@@ -36,7 +37,7 @@ BADGER_VERSION=$(get_latest_github_release "fosrl/badger" "false")
 cd /opt/pangolin
 mkdir -p /opt/pangolin/config/{traefik,db,letsencrypt,logs}
 $STD npm ci
-$STD npm run set:sqlite
+$STD npm run set:pg
 $STD npm run set:oss
 rm -rf server/private
 $STD npm run db:generate
@@ -74,6 +75,9 @@ flags:
   require_email_verification: false
   disable_signup_without_invite: false
   disable_user_create_org: false
+
+postgres:
+  connection_string: "postgresql://pangolin:${PG_DB_PASS}@localhost:5432/pangolin"
 EOF
 
 cat <<EOF >/opt/pangolin/config/traefik/traefik_config.yml
@@ -181,7 +185,7 @@ http:
         servers:
           - url: "http://$LOCAL_IP:3000"
 EOF
-$STD npm run db:push
+$STD ENVIRONMENT=prod node dist/migrations.mjs
 
 . /etc/os-release
 if [ "$VERSION_CODENAME" = "trixie" ]; then
@@ -197,7 +201,8 @@ msg_info "Creating Services"
 cat <<EOF >/etc/systemd/system/pangolin.service
 [Unit]
 Description=Pangolin Service
-After=network.target
+After=network.target postgresql.service
+Wants=postgresql.service
 
 [Service]
 Type=simple

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -22,7 +22,7 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.18.4}"
+PANGOLIN_VERSION="${PANGOLIN_VERSION:-1.20.0}"
 fetch_and_deploy_gh_release "pangolin" "fosrl/pangolin" "tarball" "$PANGOLIN_VERSION"
 fetch_and_deploy_gh_release "gerbil" "fosrl/gerbil" "singlefile" "latest" "/usr/bin" "gerbil_linux_$(arch_resolve)"
 fetch_and_deploy_gh_release "traefik" "traefik/traefik" "prebuild" "latest" "/usr/bin" "traefik_v*_linux_$(arch_resolve).tar.gz"


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Starting with Pangolin 1.20.0 we switch to native PostgrSQL, the upstream project ships its own built-in migration runner with dedicated PostgreSQL support. This means we no longer need to maintain individual migration scripts in this repo — Pangolin handles schema migrations itself via dist/migrations.mjs on each startup.

After investing ~20 hours attempting to reliably migrate from 1.18.4 to 1.20.0, it became clear that continuing to support SQLite is not sustainable. The install script has been reworked to use PostgreSQL from the ground up, which aligns with how Pangolin is developed and tested upstream.

The old SQLite-based install required us to track and apply every upstream schema change manually. PostgreSQL is the upstream-supported path and removes that maintenance burden entirely.

We sincerely **apologize that we cannot provide an automated migration** path from SQLite to PostgreSQL. Users on the old SQLite-based install will need to provision a fresh LXC. Your existing container and its data are preserved and can be manually exported/imported if needed.


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [x] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
