### PR TITLE
fix(fileflows): install .NET 10 ASP.NET Core Runtime to match current release

### DIFF
--- a/ct/fileflows.sh
+++ b/ct/fileflows.sh
@@ -43,6 +43,28 @@ function update_script() {
     tar -czf "$backup_filename" -C /opt/fileflows Data
     msg_ok "Backup Created"
 
+    # FileFlows tracks the latest release, whose .NET target can move (e.g. 8 -> 10);
+    # ensure the current ASP.NET Core Runtime so an existing install doesn't fail to
+    # start after updating to a newer .NET major version.
+    msg_info "Ensuring ASP.NET Core Runtime"
+    if [[ "$(arch_resolve)" == "arm64" ]]; then
+      if [[ ! -x /usr/lib/dotnet10/dotnet ]]; then
+        curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+        $STD bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/lib/dotnet10
+        ln -sf /usr/lib/dotnet10/dotnet /usr/bin/dotnet
+        rm -f /tmp/dotnet-install.sh
+      fi
+    elif ! is_package_installed "aspnetcore-runtime-10.0"; then
+      $STD apt remove -y aspnetcore-runtime-8.0 aspnetcore-runtime-9.0 2>/dev/null || true
+      setup_deb822_repo \
+        "microsoft" \
+        "https://packages.microsoft.com/keys/microsoft-2025.asc" \
+        "https://packages.microsoft.com/debian/13/prod/" \
+        "trixie"
+      $STD apt install -y aspnetcore-runtime-10.0
+    fi
+    msg_ok "Ensured ASP.NET Core Runtime"
+
     fetch_and_deploy_from_url "https://fileflows.com/downloads/zip" "/opt/fileflows"
 
     msg_info "Starting Service"

--- a/install/fileflows-install.sh
+++ b/install/fileflows-install.sh
@@ -26,8 +26,8 @@ msg_info "Installing ASP.NET Core Runtime"
 if [[ "$(arch_resolve)" == "arm64" ]]; then
   # packages.microsoft.com only ships amd64 debs for Debian; use dotnet-install on arm64
   curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
-  $STD bash /tmp/dotnet-install.sh --channel 8.0 --runtime aspnetcore --install-dir /usr/lib/dotnet8
-  ln -sf /usr/lib/dotnet8/dotnet /usr/bin/dotnet
+  $STD bash /tmp/dotnet-install.sh --channel 10.0 --runtime aspnetcore --install-dir /usr/lib/dotnet10
+  ln -sf /usr/lib/dotnet10/dotnet /usr/bin/dotnet
   rm -f /tmp/dotnet-install.sh
 else
   setup_deb822_repo \
@@ -35,7 +35,7 @@ else
     "https://packages.microsoft.com/keys/microsoft-2025.asc" \
     "https://packages.microsoft.com/debian/13/prod/" \
     "trixie"
-  $STD apt install -y aspnetcore-runtime-8.0
+  $STD apt install -y aspnetcore-runtime-10.0
 fi
 msg_ok "Installed ASP.NET Core Runtime"
 


### PR DESCRIPTION
## ✍️ Description

FileFlows now ships its server/node binaries targeting .NET 10 (`Microsoft.NETCore.App 10.0.0`), but `install/fileflows-install.sh` still installs ASP.NET Core Runtime **8.0**. On a fresh install the app cannot start:

```
Framework: 'Microsoft.NETCore.App', version '10.0.0' (x64)
The following frameworks were found:
  8.0.28 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
✖️  in line 53: exit code 150 (Systemd: Service failed to start): while executing command  dotnet FileFlows.Server.dll --systemd install --root true
```

This bumps the runtime to **10.0** on both branches:
- amd64: `aspnetcore-runtime-10.0` from `packages.microsoft.com` (the same repo/package already used by igotify, rdtclient and technitiumdns)
- arm64: `dotnet-install.sh --channel 10.0`

Confirmed against FileFlows' own Homebrew formula (`depends_on "dotnet@10"`).

## 🔗 Related Issue

Fixes #15686

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Validated statically (bash -n, shellcheck) and against the identical proven pattern in sibling scripts, but not run on a live Proxmox host.
- [x] **No security risks** – No hardcoded secrets, privilege escalation, or permission changes.

## 🛠️ Type of Change

- [x] 🐞 **Bug fix**

---

> **Disclosure:** Prepared with the assistance of Claude (Anthropic). The FileFlows binaries download "latest" from fileflows.com, so this tracks their current .NET 10 requirement. I do not have a Proxmox host, so this was verified statically (bash -n, shellcheck) and by matching the working `aspnetcore-runtime-10.0` setup already used by igotify/rdtclient/technitiumdns, plus FileFlows' Homebrew `dotnet@10` dependency — but not executed end-to-end on hardware. Please confirm on a test container before merge.
