### PR TITLE
fix(build.func): parse script status without jq dependency

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3764,19 +3764,18 @@ runtime_script_status_guard() {
     return 0
   fi
 
-  if ! command -v jq >/dev/null 2>&1; then
-    msg_warn "Missing jq for script status check. Continuing without status verification."
+  local is_deleted is_disabled deleted_message disable_message info_url
+  if printf '%s' "$response" | grep -qE '"items":[[:space:]]*\[[[:space:]]*\]'; then
     return 0
   fi
 
-  local has_record is_deleted is_disabled deleted_message disable_message info_url
-  has_record=$(printf '%s' "$response" | jq -r '.items | length')
-  [[ "$has_record" == "0" ]] && return 0
-
-  is_deleted=$(printf '%s' "$response" | jq -r '.items[0].is_deleted // false')
-  is_disabled=$(printf '%s' "$response" | jq -r '.items[0].is_disabled // false')
-  deleted_message=$(printf '%s' "$response" | jq -r '.items[0].deleted_message // ""')
-  disable_message=$(printf '%s' "$response" | jq -r '.items[0].disable_message // ""')
+  # PocketBase returns a flat, fixed-field JSON blob; sed is enough here (no jq needed).
+  is_deleted=$(printf '%s' "$response" | sed -n 's/.*"is_deleted"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p' | head -1)
+  is_disabled=$(printf '%s' "$response" | sed -n 's/.*"is_disabled"[[:space:]]*:[[:space:]]*\(true\|false\).*/\1/p' | head -1)
+  deleted_message=$(printf '%s' "$response" | sed -n 's/.*"deleted_message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  disable_message=$(printf '%s' "$response" | sed -n 's/.*"disable_message"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
+  is_deleted=${is_deleted:-false}
+  is_disabled=${is_disabled:-false}
   info_url="https://community-scripts.org/scripts/${script_slug}"
 
   if [[ "$is_deleted" == "true" ]]; then


### PR DESCRIPTION
## ✍️ Description

`runtime_script_status_guard()` in `misc/build.func` previously required `jq` to parse the PocketBase script-status API response. On Proxmox hosts where `jq` is not installed yet (e.g. during Grafana/Tika updates), users saw:

> Missing jq for script status check. Continuing without status verification.

This change removes the `jq` dependency for that check by parsing the fixed-field PocketBase JSON response with portable `sed`/`grep` instead. Disabled and deleted script guards now work without installing `jq` on the host first.

## 🔗 Related Issue

Fixes #15719

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
