### PR TITLE
fix(shinobi): remove obsolete --unsafe-perm npm flag

### DIFF
--- a/install/shinobi-install.sh
+++ b/install/shinobi-install.sh
@@ -54,7 +54,7 @@ cronKey=$(head -c 1024 </dev/urandom | sha256sum | awk '{print substr($1,1,29)}'
 sed -i -e 's/Shinobi/'"$cronKey"'/g' conf.json
 cp super.sample.json super.json
 $STD npm i npm -g
-$STD npm install --unsafe-perm
+$STD npm install
 $STD npm install pm2@latest -g
 chmod -R 755 .
 touch INSTALL/installed.txt


### PR DESCRIPTION
## ✍️ Description

Remove the obsolete `--unsafe-perm` flag from the Shinobi installer's `npm install` step.

Fresh Shinobi LXC installs on Node.js 22 (npm 10.x) fail with `EUNKNOWNCONFIG` because npm no longer accepts `--unsafe-perm` as a CLI flag. The flag has been obsolete since npm 7; lifecycle scripts already run with the working directory owner's permissions when npm is executed as root.

## 🔗 Related Issue

Fixes #15717

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
