### PR TITLE
Open WebUI: add optional OpenTelemetry package install

### DIFF
--- a/ct/openwebui.sh
+++ b/ct/openwebui.sh
@@ -114,7 +114,14 @@ EOF
 
   msg_info "Updating Open WebUI via uv"
   PYTHON_VERSION="3.12" setup_uv
-  $STD uv tool install --force --python 3.12 --constraint <(echo "numba>=0.60") open-webui[all]
+  OWUI_PYTHON="/root/.local/share/uv/tools/open-webui/bin/python3.12"
+  OTEL_ARGS=()
+  if [[ -x "$OWUI_PYTHON" ]]; then
+    while IFS= read -r pkg; do
+      OTEL_ARGS+=(--with "$pkg")
+    done < <(uv pip list --python "$OWUI_PYTHON" --format freeze 2>/dev/null | grep -i '^opentelemetry-' | cut -d= -f1)
+  fi
+  $STD uv tool install --force --python 3.12 --constraint <(echo "numba>=0.60") "${OTEL_ARGS[@]}" open-webui[all]
   systemctl restart open-webui
   msg_ok "Updated Open WebUI"
   msg_ok "Updated successfully!"

--- a/install/openwebui-install.sh
+++ b/install/openwebui-install.sh
@@ -25,8 +25,28 @@ setup_hwaccel
 
 PYTHON_VERSION="3.12" setup_uv
 
+OTEL_ARGS=()
+read -r -p "${TAB3}Would you like to install OpenTelemetry instrumentation packages (requires manual .env configuration)? <y/N> " prompt
+if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
+  for pkg in \
+    opentelemetry-api \
+    opentelemetry-sdk \
+    opentelemetry-exporter-otlp \
+    opentelemetry-exporter-otlp-proto-http \
+    opentelemetry-instrumentation-fastapi \
+    opentelemetry-instrumentation-aiohttp-client \
+    opentelemetry-instrumentation-httpx \
+    opentelemetry-instrumentation-sqlalchemy \
+    opentelemetry-instrumentation-requests \
+    opentelemetry-instrumentation-logging \
+    opentelemetry-instrumentation-redis \
+    opentelemetry-instrumentation-system-metrics; do
+    OTEL_ARGS+=(--with "$pkg")
+  done
+fi
+
 msg_info "Installing Open WebUI"
-$STD uv tool install --python 3.12 --constraint <(echo "numba>=0.60") open-webui[all]
+$STD uv tool install --python 3.12 --constraint <(echo "numba>=0.60") "${OTEL_ARGS[@]}" open-webui[all]
 msg_ok "Installed Open WebUI"
 
 read -r -p "${TAB3}Would you like to add Ollama? <y/N> " prompt


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Open WebUI users who enable OpenTelemetry tracing/metrics currently have to manually reinstall the OTEL Python packages after every update, because `update_script` runs `uv tool install --force`, which fully recreates the tool's virtual environment and silently drops any package that isn't one of Open WebUI's own declared dependencies.

This adds an install-time prompt to optionally install the OpenTelemetry instrumentation packages (API, SDK, OTLP exporters, and instrumentation for FastAPI/aiohttp/httpx/SQLAlchemy/requests/logging/redis/system-metrics) via `uv tool install --with <pkg>`. `update_script` then detects whatever `opentelemetry-*` packages are currently installed in the live venv before reinstalling (`uv pip list --format freeze | grep '^opentelemetry-'`) and re-supplies them as `--with` args, so they survive every future update automatically. This detection is based on live venv state rather than a persisted flag, so it also retroactively fixes containers that already had these packages added by hand before this change existed — no need to have used the prompt in the first place.

Users still need to configure the relevant `OTEL_*` variables in `/root/.env` themselves — this only handles package installation, not enabling/configuring OpenTelemetry itself.

Note: this only preserves OpenTelemetry packages specifically; any other manually `uv pip install`-ed package in this venv would still be dropped on update. Scoped to OpenTelemetry only, matching the actual problem being fixed here.

Tested: fresh install with the prompt answered "yes" (packages import correctly), update on a freshly-installed container with OTEL present (survives `--force` reinstall), update on an existing container that had OTEL packages added manually before this change existed with no prior marker (detected and preserved), and update on a container with no OTEL packages (no behavior change).

## 🔗 Related Issue

Fixes #16050

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
