### PR TITLE
fix(infisical): pre-download package before stopping service to avoid downtime on failed apt install

### DIFF
--- a/ct/infisical.sh
+++ b/ct/infisical.sh
@@ -29,6 +29,14 @@ function update_script() {
     exit
   fi
 
+  msg_info "Downloading latest Infisical package"
+  $STD apt-get update
+  if ! $STD apt-get install -y --download-only infisical-core; then
+    msg_error "Failed to download the infisical-core package (the APT artifact may be missing or return HTTP 403). Aborting update - the service was left running untouched."
+    exit 1
+  fi
+  msg_ok "Downloaded latest Infisical package"
+
   msg_info "Stopping service"
   $STD infisical-ctl stop
   msg_ok "Service stopped"
@@ -40,8 +48,7 @@ function update_script() {
   msg_ok "Created backup"
 
   msg_info "Updating Infisical"
-  $STD apt update
-  $STD apt install -y infisical-core
+  $STD apt-get install -y infisical-core
   $STD infisical-ctl reconfigure
   msg_ok "Updated Infisical"
 


### PR DESCRIPTION
## What / Why

`ct/infisical.sh` `update_script()` currently stops the Infisical service **before** the `apt install` that can fail:

```
infisical-ctl stop      # service goes down
pg_dump > backup.sql
apt update
apt install -y infisical-core   # <- if this fails, service stays down
infisical-ctl reconfigure ; infisical-ctl start
```

Right now `apt install infisical-core` is failing for every self-hosted install because the apt candidate `1.0.0-1` returns **HTTP 403** (the `.deb` artifact is missing on S3/CloudFront — see Infisical/infisical#7043). Under the script's `set -Eeuo pipefail` + `ERR` trap, the failed `apt install` aborts the run **after** the service was already stopped, leaving Infisical **down**.

## Fix

Pre-download the package **before** touching the running service. If the download fails, abort with a clear message and leave the service untouched (no `infisical-ctl stop`, no downtime). The service is only stopped once the new `.deb` is confirmed present in the apt cache, so the subsequent `apt-get install` installs from cache.

This uses the idiomatic `if ! $STD ...` pattern that `silent()` (`$STD`) explicitly supports — it returns the command's exit code rather than exiting, so the `ERR` trap is not triggered inside the condition.

Also folds the now-redundant `apt update` into the new pre-download step and aligns the install command on `apt-get` (stable scripting CLI).

## Testing

- `bash -n ct/infisical.sh` — syntax OK
- `shellcheck -x` — no new warnings (only the pre-existing SC1090 on the `source <(curl ...)` line)
- Behaviour: with the current broken 403 candidate, the update now aborts cleanly at the download step with the service still running, instead of stopping the service and then failing.

Fixes the downtime path related to Infisical/infisical#7043.
