### PR TITLE
BirdNET-Go: Match new upstream release asset naming

### DIFF
--- a/ct/birdnet-go.sh
+++ b/ct/birdnet-go.sh
@@ -37,7 +37,7 @@ function update_script() {
     systemctl stop birdnet
     msg_ok "Stopped Service"
 
-    fetch_and_deploy_gh_release "birdnet" "tphakala/birdnet-go" "prebuild" "latest" "/opt/birdnet" "birdnet-go-linux-$(arch_resolve).tar.gz"
+    fetch_and_deploy_gh_release "birdnet" "tphakala/birdnet-go" "prebuild" "latest" "/opt/birdnet" "birdnet-go-linux-$(arch_resolve)*.tar.gz"
 
     msg_info "Deploying Binary"
     cp /opt/birdnet/birdnet-go /usr/local/bin/birdnet-go

--- a/install/birdnet-go-install.sh
+++ b/install/birdnet-go-install.sh
@@ -21,7 +21,7 @@ $STD apt install -y \
   ffmpeg
 msg_ok "Installed Dependencies"
 
-fetch_and_deploy_gh_release "birdnet" "tphakala/birdnet-go" "prebuild" "latest" "/opt/birdnet" "birdnet-go-linux-$(arch_resolve).tar.gz"
+fetch_and_deploy_gh_release "birdnet" "tphakala/birdnet-go" "prebuild" "latest" "/opt/birdnet" "birdnet-go-linux-$(arch_resolve)*.tar.gz"
 
 msg_info "Setting up BirdNET-Go"
 cp /opt/birdnet/birdnet-go /usr/local/bin/birdnet-go


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

BirdNET-Go upstream changed prebuilt release asset names to include a date suffix (for example `birdnet-go-linux-amd64-20260713.tar.gz` instead of `birdnet-go-linux-amd64.tar.gz`). The install and update scripts used an exact filename pattern, so `fetch_and_deploy_gh_release` could not match the latest release and fell back to an older nightly.

This PR updates the prebuild asset glob in both scripts to `birdnet-go-linux-$(arch_resolve)*.tar.gz`, which matches both the legacy and new naming formats.

## 🔗 Related Issue

Fixes #15753

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
