### PR TITLE
Silverbullet: Add optional Runtime API install via Chromium

### DIFF
--- a/install/silverbullet-install.sh
+++ b/install/silverbullet-install.sh
@@ -16,6 +16,17 @@ update_os
 fetch_and_deploy_gh_release "silverbullet" "silverbulletmd/silverbullet" "prebuild" "latest" "/opt/silverbullet/bin" "silverbullet-server-linux-$(arch_resolve "x86_64" "aarch64").zip"
 mkdir -p /opt/silverbullet/space
 
+RUNTIME_API_ENV=""
+read -rp "${TAB3}Enable Silverbullet Runtime API? Requires Chromium (~700MB). Uses ~200MB extra RAM. (y/N): " runtime_api_prompt
+if [[ "${runtime_api_prompt,,}" =~ ^(y|yes)$ ]]; then
+  msg_info "Installing Chromium for Runtime API"
+  $STD apt install -y chromium
+  msg_ok "Installed Chromium for Runtime API"
+  RUNTIME_API_ENV=$'Environment=SB_CHROME_PATH=/usr/bin/chromium\nEnvironment=SB_CHROME_DATA_DIR=/opt/silverbullet/space/.chrome-data\n'
+  touch /opt/silverbullet/.runtime-api-enabled
+  msg_ok "Runtime API will be enabled"
+fi
+
 msg_info "Creating Service"
 cat <<EOF >/etc/systemd/system/silverbullet.service
 [Unit]
@@ -25,6 +36,7 @@ After=syslog.target network.target
 [Service]
 User=root
 Type=simple
+${RUNTIME_API_ENV}
 ExecStart=/opt/silverbullet/bin/silverbullet --hostname 0.0.0.0 --port 3000 /opt/silverbullet/space
 WorkingDirectory=/opt/silverbullet
 Restart=on-failure


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Adds an optional install-time prompt to enable Silverbullet's [Runtime API](https://silverbullet.md/Runtime%20API), which requires headless Chromium.

When the user opts in during fresh install:
- Installs `chromium` via apt (~700MB)
- Configures the systemd service with `SB_CHROME_PATH=/usr/bin/chromium` and `SB_CHROME_DATA_DIR=/opt/silverbullet/space/.chrome-data`
- Writes marker file `/opt/silverbullet/.runtime-api-enabled`

Default install behavior is unchanged (prompt defaults to No). No Docker image required — mirrors the upstream `-runtime-api` Docker variant using native Debian packages.

## 🔗 Related Issue

Fixes #15725

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
