### PR TITLE
Lychee: Preserve uploads and ownership during update

### DIFF
--- a/ct/lychee.sh
+++ b/ct/lychee.sh
@@ -31,33 +31,38 @@ function update_script() {
   fi
 
   if check_for_gh_release "lychee" "LycheeOrg/Lychee"; then
+    PHP_VER=$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;')
+
     msg_info "Stopping Services"
-    systemctl stop caddy
+    systemctl stop caddy php${PHP_VER}-fpm
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/lychee/.env /opt/lychee.env.bak
-    cp -r /opt/lychee/storage /opt/lychee_storage_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/lychee/.env \
+      /opt/lychee/storage \
+      /opt/lychee/public/uploads \
+      /opt/lychee/public/dist
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "lychee" "LycheeOrg/Lychee" "prebuild" "latest" "/opt/lychee" "Lychee.zip"
 
-    msg_info "Restoring Data"
-    cp /opt/lychee.env.bak /opt/lychee/.env
-    rm -f /opt/lychee.env.bak
-    cp -r /opt/lychee_storage_backup/. /opt/lychee/storage
-    rm -rf /opt/lychee_storage_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Updating Application"
     cd /opt/lychee
     $STD php artisan migrate --force
+    $STD php artisan config:clear
+    $STD php artisan cache:clear
     $STD php artisan optimize:clear
-    chmod -R 775 /opt/lychee/storage /opt/lychee/bootstrap/cache
+    $STD php artisan optimize
+    chown -R www-data:www-data /opt/lychee
+    chmod -R 775 /opt/lychee/storage /opt/lychee/bootstrap/cache \
+      /opt/lychee/public/dist /opt/lychee/public/uploads
+    if [[ "${VERBOSE:-no}" = "yes" ]]; then
+      php artisan lychee:diagnostics || true
+    fi
     msg_ok "Updated Application"
 
     msg_info "Starting Services"
-    systemctl start caddy
+    systemctl start caddy php${PHP_VER}-fpm
     msg_ok "Started Services"
     msg_ok "Updated successfully!"
   fi


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fixes the Lychee update script (`ct/lychee.sh`) which reported success but left installations returning HTTP 500 (#15763).

The update flow now:
- Backs up and restores `.env`, `storage`, `public/uploads`, and `public/dist` via `create_backup` / `restore_backup`
- Stops and starts both Caddy and PHP-FPM during the update
- Runs full Laravel maintenance (`migrate`, `config:clear`, `cache:clear`, `optimize:clear`, `optimize`)
- Re-applies `chown www-data:www-data` and correct permissions (matching the install script)
- Runs `php artisan lychee:diagnostics` in verbose mode for actionable output

## 🔗 Related Issue

Fixes #15763

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
