### PR TITLE
fix(heimdall): migrate PHP to 8.4 on update

### DIFF
--- a/ct/heimdall-dashboard.sh
+++ b/ct/heimdall-dashboard.sh
@@ -35,32 +35,18 @@ function update_script() {
     sleep 1
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -R /opt/Heimdall/database database-backup
-    cp -R /opt/Heimdall/public public-backup
-    sleep 1
-    msg_ok "Backed up Data"
-
+    create_backup /opt/Heimdall/database \
+                  /opt/Heimdall/public
+    PHP_VERSION="8.4" PHP_FPM="YES" setup_php
     setup_composer
     fetch_and_deploy_gh_release "Heimdall" "linuxserver/Heimdall" "tarball"
+    restore_backup
 
     msg_info "Updating Heimdall-Dashboard"
     cd /opt/Heimdall
     export COMPOSER_ALLOW_SUPERUSER=1
     $STD composer dump-autoload
     msg_ok "Updated Heimdall-Dashboard"
-
-    msg_info "Restoring Data"
-    cd ~
-    cp -R database-backup/* /opt/Heimdall/database
-    cp -R public-backup/* /opt/Heimdall/public
-    sleep 1
-    msg_ok "Restored Data"
-
-    msg_info "Cleaning Up"
-    rm -rf {public-backup,database-backup}
-    sleep 1
-    msg_ok "Cleaned Up"
 
     msg_info "Starting Service"
     systemctl start heimdall.service


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Heimdall v2.8.1 requires PHP ^8.4, but the update script did not upgrade PHP on legacy Debian 12 containers that still had PHP 8.2. Updates failed at `composer dump-autoload` with a platform version mismatch.

This PR:
- Calls `setup_php` with PHP 8.4 during update (matching the install script)
- Replaces manual backup/restore `cp`/`rm` with shared `create_backup` / `restore_backup` helpers for `/opt/Heimdall/database` and `/opt/Heimdall/public`

## 🔗 Related Issue

Fixes #15767

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

## Test plan

- [ ] On a legacy Debian 12 LXC with PHP 8.2 and `/opt/Heimdall`, run update and confirm `php -v` reports 8.4.x
- [ ] Confirm `composer dump-autoload` completes without platform errors
- [ ] Confirm `systemctl status heimdall` is active after update
