### PR TITLE
tools.func: default Docker setup to official repo

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -4663,20 +4663,20 @@ setup_composer() {
 #   - Cleans up legacy repository files
 #
 # Usage:
-#   setup_docker                              # Uses distro package (recommended)
-#   USE_DOCKER_REPO=true setup_docker         # Uses official Docker repo
+#   setup_docker                              # Uses official Docker repo (recommended)
+#   USE_DOCKER_REPO=false setup_docker        # Uses distro docker.io package
 #   DOCKER_PORTAINER="true" setup_docker
 #   DOCKER_LOG_DRIVER="json-file" setup_docker
 #
 # Variables:
-#   USE_DOCKER_REPO        - Set to "true" to use official Docker repository
-#                            (default: false, uses distro docker.io package)
+#   USE_DOCKER_REPO        - Set to "false" to use distro docker.io package
+#                            (default: true, uses official Docker repository)
 #   DOCKER_PORTAINER       - Install Portainer CE (optional, "true" to enable)
 #   DOCKER_LOG_DRIVER      - Log driver (optional, default: "journald")
 #   DOCKER_SKIP_UPDATES    - Skip container update check (optional, "true" to skip)
 #
 # Features:
-#   - Uses stable distro packages by default
+#   - Uses official Docker repository by default
 #   - Migrates from get.docker.com to repository-based installation
 #   - Updates Docker Engine if newer version available
 #   - Interactive per-container update prompt (Y/N, 60 s auto-no)
@@ -4692,7 +4692,7 @@ _docker_is_noninteractive() {
 setup_docker() {
   local docker_installed=false
   local portainer_installed=false
-  local USE_DOCKER_REPO="${USE_DOCKER_REPO:-false}"
+  local USE_DOCKER_REPO="${USE_DOCKER_REPO:-true}"
 
   # Check if Docker is already installed
   if command -v docker &>/dev/null; then
@@ -4707,7 +4707,7 @@ setup_docker() {
     msg_info "Portainer container detected"
   fi
 
-  # Scenario 1: Use distro repository (default, most stable)
+  # Scenario 1: Use distro repository (opt-out via USE_DOCKER_REPO=false)
   if [[ "$USE_DOCKER_REPO" != "true" && "$USE_DOCKER_REPO" != "TRUE" && "$USE_DOCKER_REPO" != "1" ]]; then
 
     # Install or upgrade Docker from distro repo


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Switch `setup_docker` to use the official Docker repository by default and update the usage/docs to match. The distro `docker.io` package now requires `USE_DOCKER_REPO=false`.


## 🔗 Related Issue

Fixes #15786

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
