### PR TITLE
snapotter: wait for PostgreSQL to accept connections before continuing

### DIFF
--- a/ct/snapotter.sh
+++ b/ct/snapotter.sh
@@ -41,6 +41,22 @@ function update_script() {
     msg_ok "Stopped Service"
 
     PG_VERSION="17" setup_postgresql
+
+    msg_info "Waiting for PostgreSQL"
+    PG_READY=0
+    for _ in {1..30}; do
+      if pg_isready -q -h 127.0.0.1 -p 5432; then
+        PG_READY=1
+        break
+      fi
+      sleep 1
+    done
+    if [[ "$PG_READY" -ne 1 ]]; then
+      msg_error "PostgreSQL is not accepting connections on 127.0.0.1:5432 after 30s"
+      exit 1
+    fi
+    msg_ok "PostgreSQL is ready"
+
     if ! sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname = 'snapotter'" | grep -qx '1'; then
       PG_DB_NAME="snapotter" PG_DB_USER="snapotter" setup_postgresql_db
     else

--- a/install/snapotter-install.sh
+++ b/install/snapotter-install.sh
@@ -40,6 +40,22 @@ msg_ok "Installed Dependencies"
 PYTHON_VERSION="3.11" setup_uv
 NODE_VERSION="22" NODE_MODULE="pnpm" setup_nodejs
 PG_VERSION="17" setup_postgresql
+
+msg_info "Waiting for PostgreSQL"
+PG_READY=0
+for _ in {1..30}; do
+  if pg_isready -q -h 127.0.0.1 -p 5432; then
+    PG_READY=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$PG_READY" -ne 1 ]]; then
+  msg_error "PostgreSQL is not accepting connections on 127.0.0.1:5432 after 30s"
+  exit 1
+fi
+msg_ok "PostgreSQL is ready"
+
 PG_DB_NAME="snapotter" PG_DB_USER="snapotter" setup_postgresql_db
 
 msg_info "Installing Redis"


### PR DESCRIPTION
## Description

`setup_postgresql` can return success even when the cluster failed to actually
start: its `systemctl enable --now postgresql` step is followed by `|| msg_warn`.
The SnapOtter scripts then run `psql` right away (to create the role/database, or
to check whether the database already exists). When the cluster is installed but
not accepting connections, those calls fail with a cryptic mid-run error, and the
update path can report success while the app still can't reach its database.

This adds a short readiness gate right after `setup_postgresql`: poll `pg_isready`
for up to 30s and fail with a clear, actionable message if the cluster never comes
up, before any `psql` work runs or the service starts.

## Motivation

Reported in #15796. SnapOtter 2.x is Postgres-only, so the app crash-loops on
`ECONNREFUSED` when the database isn't reachable, and the failure surfaced only as
a restart counter climbing in the journal. A companion app-side change (retry the
DB/Redis connection at startup) is up at snapotter-hq/SnapOtter#537; this PR makes
the install script itself surface a dead cluster instead of marching on.

## Changes

- `install/snapotter-install.sh`: readiness gate between `setup_postgresql` and `setup_postgresql_db`
- `ct/snapotter.sh`: same gate in the update path, before the database existence check

Scoped to the two SnapOtter scripts; the shared `setup_postgresql` in `misc/tools.func`
is left untouched.

## Validation

- `bash -n` passes on both scripts
- Gate logic exercised with a stubbed `pg_isready`: it recovers when the cluster
  becomes ready mid-loop (exit 0) and exits 1 with the error message when it never
  does (`sleep` stubbed so the 30-iteration path runs instantly)

I don't have a Proxmox host to run the full container lifecycle; a live create/update
check on an LXC would be worth a maintainer's confirmation.

Opened from the upstream SnapOtter project account.
