### PR TITLE
webtrees: initialize database schema before admin user creation

### DIFF
--- a/install/webtrees-install.sh
+++ b/install/webtrees-install.sh
@@ -47,6 +47,8 @@ msg_ok "Configured Caddy"
 
 msg_info "Automating Webtrees Setup"
 cd /opt/webtrees
+mkdir -p /opt/webtrees/data
+chown -R www-data:www-data /opt/webtrees/data
 WT_ADMIN_PASS=$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | head -c15)
 $STD sudo -u www-data php /opt/webtrees/index.php config-ini \
   --dbhost=127.0.0.1 \
@@ -56,6 +58,15 @@ $STD sudo -u www-data php /opt/webtrees/index.php config-ini \
   --dbname=webtrees \
   --tblpfx=wt_ \
   --base-url="http://${LOCAL_IP}"
+msg_info "Initializing Webtrees database schema"
+for i in {1..15}; do
+  if curl -sf "http://127.0.0.1/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+$STD mariadb -u webtrees -p"${MARIADB_DB_PASS}" -h 127.0.0.1 webtrees -e "SHOW TABLES LIKE 'wt_user';" | grep -q wt_user
+msg_ok "Initialized Webtrees database schema"
 $STD sudo -u www-data php /opt/webtrees/index.php user Admin \
   --create \
   --real-name="Administrator" \


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fresh Webtrees installs fail during automated setup with `Table 'webtrees.wt_user' doesn't exist` when the script tries to create the admin user via CLI.

**Root cause:** PR #14818 replaced the setup wizard `curl POST step=6` flow with upstream-recommended CLI commands (`config-ini`, `user Admin --create`), but omitted the database schema initialization step. The old wizard's step 6 called `updateSchema()` and `seedDatabase()` before creating the admin user; the CLI `config-ini` command only writes `data/config.ini.php` and tests the DB connection — it does not create tables.

**Evidence:**
- Reported in #15828 (install fails at `user Admin --create`)
- Regression introduced in #14818 (replacing curl wizard with CLI)
- Upstream `SetupWizard::step6Install` runs `migration_service->updateSchema()` ([webtrees 2.2.6 source](https://github.com/fisharebest/webtrees/blob/2.2.6/app/Http/RequestHandlers/SetupWizard.php))
- Webtrees has no CLI migrate/setup command ([Console.php commands list](https://github.com/fisharebest/webtrees/blob/2.2.6/app/Cli/Console.php))
- When `config.ini.php` exists, HTTP requests run `UpdateDatabaseSchema` middleware ([Webtrees.php middleware stack](https://github.com/fisharebest/webtrees/blob/2.2.6/app/Webtrees.php))

**Fix:** After `config-ini`, trigger schema creation with an HTTP request to the running Caddy/PHP-FPM stack, verify `wt_user` exists, then proceed with CLI admin user creation. Also ensure `/opt/webtrees/data` exists and is writable by `www-data` before writing config.

## 🔗 Related Issue

Fixes #15828

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

