### PR TITLE
esphome: install libusb-1.0-0 for ESP-IDF native builds

### DIFF
--- a/ct/esphome.sh
+++ b/ct/esphome.sh
@@ -28,6 +28,7 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+  ensure_dependencies libusb-1.0-0
 
   msg_info "Stopping Service"
   systemctl stop esphome-device-builder 2>/dev/null || true

--- a/install/esphome-install.sh
+++ b/install/esphome-install.sh
@@ -14,7 +14,8 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y git
+$STD apt install -y git \
+  libusb-1.0-0
 msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.12" setup_uv


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

ESPHome 2026.7.0 uses native ESP-IDF as the default ESP32 toolchain. During ESP-IDF setup, `idf_tools.py` validates `openocd-esp32`, which dynamically links `libusb-1.0.so.0`. Fresh ESPHome containers only installed `git`, so ESP32 IDF builds failed with a missing shared library error.

This PR adds the runtime `libusb-1.0-0` package to fresh installs and backfills it on update via `ensure_dependencies`.

## 🔗 Related Issue

Fixes #15835

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Bash syntax validated; change mirrors upstream ESPHome Docker fix and existing repo usage in `bitfocus-companion-install.sh`.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
