### PR TITLE
apache-guacamole: detect installed extensions during update

### DIFF
--- a/ct/apache-guacamole.sh
+++ b/ct/apache-guacamole.sh
@@ -146,7 +146,7 @@ function update_script() {
 
   # Check and upgrade optional extensions
   # TOTP Extension
-  if [[ -f /etc/guacamole/extensions/guacamole-auth-totp-*.jar ]]; then
+  if compgen -G "/etc/guacamole/extensions/guacamole-auth-totp-*.jar" >/dev/null; then
     msg_info "Updating TOTP Extension"
     rm -f /etc/guacamole/extensions/guacamole-auth-totp-*.jar
     curl_download "/tmp/guacamole-auth-totp.tar.gz" "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-auth-totp-${LATEST_SERVER}.tar.gz"
@@ -158,7 +158,7 @@ function update_script() {
   fi
 
   # DUO Extension
-  if [[ -f /etc/guacamole/extensions/guacamole-auth-duo-*.jar ]]; then
+  if compgen -G "/etc/guacamole/extensions/guacamole-auth-duo-*.jar" >/dev/null; then
     msg_info "Updating DUO Extension"
     rm -f /etc/guacamole/extensions/guacamole-auth-duo-*.jar
     curl_download "/tmp/guacamole-auth-duo.tar.gz" "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-auth-duo-${LATEST_SERVER}.tar.gz"
@@ -170,7 +170,7 @@ function update_script() {
   fi
 
   # LDAP Extension
-  if [[ -f /etc/guacamole/extensions/guacamole-auth-ldap-*.jar ]]; then
+  if compgen -G "/etc/guacamole/extensions/guacamole-auth-ldap-*.jar" >/dev/null; then
     msg_info "Updating LDAP Extension"
     rm -f /etc/guacamole/extensions/guacamole-auth-ldap-*.jar
     curl_download "/tmp/guacamole-auth-ldap.tar.gz" "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-auth-ldap-${LATEST_SERVER}.tar.gz"
@@ -182,7 +182,7 @@ function update_script() {
   fi
 
   # Quick Connect Extension
-  if [[ -f /etc/guacamole/extensions/guacamole-auth-quickconnect-*.jar ]]; then
+  if compgen -G "/etc/guacamole/extensions/guacamole-auth-quickconnect-*.jar" >/dev/null; then
     msg_info "Updating Quick Connect Extension"
     rm -f /etc/guacamole/extensions/guacamole-auth-quickconnect-*.jar
     curl_download "/tmp/guacamole-auth-quickconnect.tar.gz" "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-auth-quickconnect-${LATEST_SERVER}.tar.gz"
@@ -194,7 +194,7 @@ function update_script() {
   fi
 
   # History Recording Storage Extension
-  if [[ -f /etc/guacamole/extensions/guacamole-history-recording-storage-*.jar ]]; then
+  if compgen -G "/etc/guacamole/extensions/guacamole-history-recording-storage-*.jar" >/dev/null; then
     msg_info "Updating History Recording Storage Extension"
     rm -f /etc/guacamole/extensions/guacamole-history-recording-storage-*.jar
     curl_download "/tmp/guacamole-history-recording-storage.tar.gz" "https://downloads.apache.org/guacamole/${LATEST_SERVER}/binary/guacamole-history-recording-storage-${LATEST_SERVER}.tar.gz"


### PR DESCRIPTION
## ✍️ Description

The `update_script()` extension-upgrade blocks test for installed extension jars with:

    if [[ -f /etc/guacamole/extensions/guacamole-auth-totp-*.jar ]]; then

Bash does not perform pathname expansion inside `[[ ]]`, so `-f` checks for a file literally named with an asterisk and is always false (shellcheck SC2144). As a result, none of the TOTP, DUO, LDAP, Quick Connect, or History Recording Storage extensions are ever updated alongside the server - after each Guacamole upgrade the old extension jars stay behind, version-mismatched with the new server.

This PR switches the five conditionals to `compgen -G "<pattern>" >/dev/null`, the same glob-existence idiom already used in `misc/tools.func` and `ct/plex.sh`.

Standalone repro (with `guacamole-auth-totp-1.5.5.jar` present in the extensions dir):

    $ [[ -f ext/guacamole-auth-totp-*.jar ]] && echo detected || echo missed
    missed
    $ compgen -G "ext/guacamole-auth-totp-*.jar" >/dev/null && echo detected || echo missed
    detected

shellcheck on `ct/apache-guacamole.sh`: SC2144 errors before, 0 after. Testing scope: verified via the standalone repro and shellcheck (the change is a pure conditional-idiom swap); not run on a live Proxmox/Guacamole container.

*Disclosure: this fix was prepared with AI assistance (Claude); the bug, repro, and diff were verified by running the shown commands.*

## 🔗 Related Issue

Fixes # (none filed - found via shellcheck audit; behavior introduced in #10746)

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
