### PR TITLE
fix(build.func): expand glob in SSH key "Scan Folder/Glob" so it can find keys

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3600,9 +3600,14 @@ configure_ssh_settings() {
     glob_path=$(whiptail --backtitle "$backtitle" \
       --inputbox "Enter a folder or glob to scan (e.g. /root/.ssh/*.pub)" 10 72 --title "Scan Folder/Glob" 3>&1 1>&2 2>&3)
     if [[ -n "$glob_path" ]]; then
-      shopt -s nullglob
-      read -r -a _scan_files <<<"$glob_path"
-      shopt -u nullglob
+      # A folder means "scan every file inside it"; read(1) performs no
+      # pathname expansion, so expand the glob with compgen -G instead
+      [[ -d "$glob_path" ]] && glob_path="${glob_path%/}/*"
+      local -a _scan_files=()
+      local _scan_file
+      while IFS= read -r _scan_file; do
+        _scan_files+=("$_scan_file")
+      done < <(compgen -G "$glob_path")
       if [[ "${#_scan_files[@]}" -gt 0 ]]; then
         ssh_build_choices_from_files "${_scan_files[@]}"
         if [[ "$COUNT" -gt 0 ]]; then

--- a/misc/build.func
+++ b/misc/build.func
@@ -3600,14 +3600,9 @@ configure_ssh_settings() {
     glob_path=$(whiptail --backtitle "$backtitle" \
       --inputbox "Enter a folder or glob to scan (e.g. /root/.ssh/*.pub)" 10 72 --title "Scan Folder/Glob" 3>&1 1>&2 2>&3)
     if [[ -n "$glob_path" ]]; then
-      # A folder means "scan every file inside it"; read(1) performs no
-      # pathname expansion, so expand the glob with compgen -G instead
       [[ -d "$glob_path" ]] && glob_path="${glob_path%/}/*"
-      local -a _scan_files=()
-      local _scan_file
-      while IFS= read -r _scan_file; do
-        _scan_files+=("$_scan_file")
-      done < <(compgen -G "$glob_path")
+      local -a _scan_files
+      mapfile -t _scan_files < <(compgen -G "$glob_path")
       if [[ "${#_scan_files[@]}" -gt 0 ]]; then
         ssh_build_choices_from_files "${_scan_files[@]}"
         if [[ "$COUNT" -gt 0 ]]; then


### PR DESCRIPTION
## ✍️ Description

The advanced-install SSH key menu offers "folder — Scan another folder (path or glob)", but the input is split with:

    shopt -s nullglob
    read -r -a _scan_files <<<"$glob_path"
    shopt -u nullglob

`read` performs no pathname expansion (`nullglob` has no effect on it), so `_scan_files` holds the literal pattern and `ssh_build_choices_from_files()` runs `[[ -f ... ]]` against it. Both advertised inputs therefore always fail: a glob like `/root/.ssh/*.pub` is tested as a literal filename, and a plain folder fails `-f` because it is a directory. The option unconditionally ends in "No keys found" and has never been able to import a key (behavior introduced in #9540).

This PR expands the pattern with `compgen -G` — the same glob-existence idiom as #15841 — and treats a directory input as `dir/*`, so both input forms shown in the input box work.

Standalone repro (folder containing `one.pub`, `two backup.pub`, `known_hosts`):

    input: /tmp/keys/*.pub   -> old code finds 0 key files, fixed code finds 2
    input: /tmp/keys         -> old code finds 0 key files, fixed code finds 2

shellcheck findings on `misc/build.func`: 34 before, 34 after (no new findings); `bash -n` clean under bash 5.2. Testing scope: verified via the standalone repro (buggy and fixed blocks lifted verbatim) and shellcheck; not run through the full whiptail flow on a live Proxmox host.

*Disclosure: this fix was prepared with AI assistance (Claude); the bug, repro, and diff were verified by running the shown commands.*

## 🔗 Related Issue

Fixes # (none filed — found via shellcheck-guided audit; behavior introduced in #9540)

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected (scope as stated above).
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
