### PR TITLE
[FIX] BookOrbit: add missing `restore_backup` during update

### DIFF
--- a/ct/bookorbit.sh
+++ b/ct/bookorbit.sh
@@ -53,6 +53,7 @@ function update_script() {
     mkdir -p /opt/bookorbit/server/migrations
     cp -r /opt/bookorbit/server/src/db/migrations/. /opt/bookorbit/server/migrations/
     chmod +x /opt/bookorbit/server/bin/kepubify/*
+    restore_backup
     APP_VER=$(cat ~/.bookorbit)
     sed -i "s/^APP_VERSION=.*/APP_VERSION=v$APP_VER/" /opt/bookorbit/.env
     msg_ok "Rebuilt Application"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

- Otherwise the `.env` file is not restored and the sed command fails

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
