### PR TITLE
fix(monitor-all): reduce polling CPU overhead

### DIFF
--- a/tools/pve/monitor-all.sh
+++ b/tools/pve/monitor-all.sh
@@ -54,18 +54,24 @@ while true; do
       continue
     fi
 
-    # Determine type and set config command
-    if pct status $instance >/dev/null 2>&1; then
+    # Determine type and read the current config directly from Proxmox's pmxcfs.
+    # Ignore snapshot sections, matching the current config shown by pct/qm config.
+    if [ -r "/etc/pve/lxc/$instance.conf" ]; then
       type="ct"
-      config_cmd="pct config"
+      config_file="/etc/pve/lxc/$instance.conf"
     else
       type="vm"
-      config_cmd="qm config"
+      config_file="/etc/pve/qemu-server/$instance.conf"
     fi
+    config=$(sed '/^\[/,$d' "$config_file")
 
     # Skip templates and onboot-disabled
-    onboot=$($config_cmd $instance | grep -q "onboot: 0" || ( ! $config_cmd $instance | grep -q "onboot" ) && echo "true" || echo "false")
-    template=$($config_cmd $instance | grep -q "^template:" && echo "true" || echo "false")
+    if grep -q "onboot: 0" <<<"$config" || ! grep -q "onboot" <<<"$config"; then
+      onboot="true"
+    else
+      onboot="false"
+    fi
+    template=$(grep -q "^template:" <<<"$config" && echo "true" || echo "false")
 
     if [ "$onboot" == "true" ]; then
       echo "Skipping $instance because it is set not to boot"
@@ -76,7 +82,7 @@ while true; do
     fi
 
     # Check for mon-restart tag
-    has_tag=$($config_cmd $instance | grep -q "tags:.*mon-restart" && echo "true" || echo "false")
+    has_tag=$(grep -q "tags:.*mon-restart" <<<"$config" && echo "true" || echo "false")
     if [ "$has_tag" != "true" ]; then
       echo "Skipping $instance because it does not have 'mon-restart' tag"
       continue


### PR DESCRIPTION
## ✍️ Description

Monitor-All currently launches `pct status` plus up to three separate `pct config` or `qm config` commands for every guest during each polling cycle. Those repeated Proxmox CLI calls add avoidable CPU overhead.

This change:

- determines the guest type from the authoritative pmxcfs config path;
- reads the current config once per guest;
- ignores snapshot sections, matching the current config exposed by `pct config` and `qm config`;
- reuses that config for the existing onboot, template, and `mon-restart` tag checks.

The monitoring policy, exclusions, health checks, restart commands, messages, and 300-second pause are unchanged.

Validation:

- `bash -n tools/pve/monitor-all.sh`
- generated `ping-instances.sh` payload parses cleanly
- ShellCheck error-level validation passes for the generated payload, excluding the two unchanged existing array findings SC2145 and SC2199
- fixture harness confirms identical logs and recovery actions for healthy, excluded, onboot-disabled, template, VM-failure, and CT-failure cases
- fixture harness confirms zero `pct config` or `qm config` launches after the change

Development disclosure: OpenAI Codex assisted the diagnosis, patch drafting, and fixture harness. The committed result was manually reviewed and validated before submission.

## 🔗 Related Issue

None.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to website-related JSON files or metadata.
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.