### PR TITLE
Zammad : bind Elasticsearch to 127.0.0.1

### DIFF
--- a/install/zammad-install.sh
+++ b/install/zammad-install.sh
@@ -32,6 +32,7 @@ sed -i 's/^#\{0,2\} *-Xms[0-9]*g.*/-Xms2g/' /etc/elasticsearch/jvm.options
 sed -i 's/^#\{0,2\} *-Xmx[0-9]*g.*/-Xmx2g/' /etc/elasticsearch/jvm.options
 cat <<EOF >/etc/elasticsearch/elasticsearch.yml
 discovery.type: single-node
+network.host: 127.0.0.1
 xpack.security.enabled: false
 bootstrap.memory_lock: false
 EOF
@@ -40,7 +41,7 @@ systemctl daemon-reload
 systemctl enable -q elasticsearch
 systemctl restart -q elasticsearch
 for i in $(seq 1 30); do
-  if curl -s http://localhost:9200 >/dev/null 2>&1; then
+  if curl -s http://127.0.0.1:9200 >/dev/null 2>&1; then
     break
   fi
   sleep 2
@@ -55,7 +56,7 @@ setup_deb822_repo \
   "$(get_os_info version_id)" \
   "main"
 $STD apt install -y zammad
-$STD zammad run rails r "Setting.set('es_url', 'http://localhost:9200')"
+$STD zammad run rails r "Setting.set('es_url', 'http://127.0.0.1:9200')"
 $STD zammad run rake zammad:searchindex:rebuild
 msg_ok "Installed Zammad"
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Explicitly bind Elasticsearch to 127.0.0.1 instead of relying on localhost resolution. Updates elasticsearch.yml, health check curl, and Zammad ES URL setting to use 127.0.0.1 for consistency and to avoid potential IPv6 resolution issues

## 🔗 Related Issue

Fixes #15894

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
