### PR TITLE
fix(wanderer): use PocketBase-relative plugin symlink in unprivileged LXC

### DIFF
--- a/ct/wanderer.sh
+++ b/ct/wanderer.sh
@@ -46,8 +46,8 @@ function update_script() {
     cd /opt/wanderer/source/web
     $STD npm ci
     $STD npm run build
-    mkdir -p /opt/wanderer/data/plugins
-    [[ -e /data/plugins ]] || ln -sfn /opt/wanderer/data/plugins /data/plugins
+    mkdir -p /opt/wanderer/data/plugins /opt/wanderer/source/db/data
+    [[ -e /opt/wanderer/source/db/data/plugins ]] || ln -sfn /opt/wanderer/data/plugins /opt/wanderer/source/db/data/plugins
     msg_info "Installing wanderer plugins"
     for plugin in hammerhead komoot strava; do
       fetch_and_deploy_gh_release "wanderer-plugin-${plugin}" "open-wanderer/wanderer" "prebuild" "${CHECK_UPDATE_RELEASE:-latest}" "/opt/wanderer/data/plugins" "wanderer-plugin-${plugin}.tar.gz" || msg_warn "Failed to install wanderer plugin: ${plugin}"

--- a/install/wanderer-install.sh
+++ b/install/wanderer-install.sh
@@ -21,8 +21,9 @@ else
   fetch_and_deploy_gh_release "meilisearch" "meilisearch/meilisearch" "binary" "latest" "/opt/wanderer/source/search"
 fi
 mkdir -p /opt/wanderer/{source,data/pb_data,data/meili_data,data/plugins}
-[[ -e /data/plugins ]] || ln -sfn /opt/wanderer/data/plugins /data/plugins
 fetch_and_deploy_gh_release "wanderer" "open-wanderer/wanderer" "tarball" "latest" "/opt/wanderer/source"
+mkdir -p /opt/wanderer/source/db/data
+[[ -e /opt/wanderer/source/db/data/plugins ]] || ln -sfn /opt/wanderer/data/plugins /opt/wanderer/source/db/data/plugins
 
 msg_info "Installing wanderer (patience)"
 cd /opt/wanderer/source/db


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description

Fixes Wanderer install and update failures in default unprivileged LXC containers introduced by PR #15759.

The script attempted to create a root-level symlink at `/data/plugins`, which fails with `Operation not permitted` in unprivileged containers (`var_unprivileged=1`).

Instead, after deploying the Wanderer source tarball, the script now symlinks `/opt/wanderer/source/db/data/plugins` → `/opt/wanderer/data/plugins`. This matches upstream `PluginDir()` resolution (`data/plugins` relative to PocketBase's cwd at `/opt/wanderer/source/db`) without requiring privileged container settings.

Changes:
- Move plugin symlink creation to after source deploy in `install/wanderer-install.sh`
- Retarget symlink from `/data/plugins` to `/opt/wanderer/source/db/data/plugins`
- Apply the same fix in `ct/wanderer.sh` update path

## 🔗 Related Issue

Fixes #15799

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

## Test plan

- [ ] Fresh install in unprivileged Debian 13 LXC completes past plugin setup
- [ ] `/opt/wanderer/source/db/data/plugins` is a symlink to `/opt/wanderer/data/plugins`
- [ ] `wanderer-web` service starts and plugins (hammerhead, komoot, strava) are present
- [ ] Container update script applies the same symlink and restarts cleanly
