### PR TITLE
Standardize CT update backup handling

### DIFF
--- a/ct/affine.sh
+++ b/ct/affine.sh
@@ -42,8 +42,6 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "affine_app" "toeverything/AFFiNE" "tarball" "${RELEASE}" "/opt/affine"
 
-    # Restore BEFORE the build: CLEAN_INSTALL wiped /opt/affine including .env,
-    # and the build below sources it
     restore_backup
 
     if [[ ! -f /opt/affine/.env ]]; then

--- a/ct/alpine-cinny.sh
+++ b/ct/alpine-cinny.sh
@@ -30,16 +30,11 @@ function update_script() {
   fi
 
   if check_for_gh_release "cinny" "cinnyapp/cinny"; then
-    msg_info "Backing up Configuration"
-    cp /opt/cinny/config.json /opt/cinny_config.json.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/cinny/config.json
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cinny" "cinnyapp/cinny" "prebuild" "latest" "/opt/cinny" "cinny-*.tar.gz"
 
-    msg_info "Restoring Configuration"
-    cp /opt/cinny_config.json.bak /opt/cinny/config.json
-    rm -f /opt/cinny_config.json.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Restarting nginx"
     $STD rc-service nginx restart

--- a/ct/dispatcharr.sh
+++ b/ct/dispatcharr.sh
@@ -116,21 +116,10 @@ EOF
 
     msg_info "Creating Backup"
     BACKUP_FILE="/opt/dispatcharr_backup_$(date +%F_%H-%M-%S).tar.gz"
-    if [[ -f /opt/dispatcharr/.env ]]; then
-      cp /opt/dispatcharr/.env /tmp/dispatcharr.env.backup
-    fi
     if [[ -f /opt/dispatcharr/start-gunicorn.sh ]]; then
       rm -f /opt/dispatcharr/start-gunicorn.sh
     fi
-    if [[ -f /opt/dispatcharr/start-celery.sh ]]; then
-      cp /opt/dispatcharr/start-celery.sh /tmp/start-celery.sh.backup
-    fi
-    if [[ -f /opt/dispatcharr/start-celerybeat.sh ]]; then
-      cp /opt/dispatcharr/start-celerybeat.sh /tmp/start-celerybeat.sh.backup
-    fi
-    if [[ -f /opt/dispatcharr/start-daphne.sh ]]; then
-      cp /opt/dispatcharr/start-daphne.sh /tmp/start-daphne.sh.backup
-    fi
+    create_backup /opt/dispatcharr/.env /opt/dispatcharr/start-celery.sh /opt/dispatcharr/start-celerybeat.sh /opt/dispatcharr/start-daphne.sh
     if [[ -f /opt/dispatcharr/.env ]]; then
       set -o allexport
       source /opt/dispatcharr/.env
@@ -145,20 +134,9 @@ EOF
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "dispatcharr" "Dispatcharr/Dispatcharr" "tarball"
 
-    msg_info "Updating Dispatcharr Backend"
-    if [[ -f /tmp/dispatcharr.env.backup ]]; then
-      mv /tmp/dispatcharr.env.backup /opt/dispatcharr/.env
-    fi
-    if [[ -f /tmp/start-celery.sh.backup ]]; then
-      mv /tmp/start-celery.sh.backup /opt/dispatcharr/start-celery.sh
-    fi
-    if [[ -f /tmp/start-celerybeat.sh.backup ]]; then
-      mv /tmp/start-celerybeat.sh.backup /opt/dispatcharr/start-celerybeat.sh
-    fi
-    if [[ -f /tmp/start-daphne.sh.backup ]]; then
-      mv /tmp/start-daphne.sh.backup /opt/dispatcharr/start-daphne.sh
-    fi
+    restore_backup
 
+    msg_info "Updating Dispatcharr Backend"
     if ! grep -q "DJANGO_SECRET_KEY" /opt/dispatcharr/.env; then
       DJANGO_SECRET=$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | cut -c1-50)
       echo "DJANGO_SECRET_KEY=$DJANGO_SECRET" >>/opt/dispatcharr/.env

--- a/ct/fladder.sh
+++ b/ct/fladder.sh
@@ -35,21 +35,11 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped Service"
 
-    if [[ -f /opt/fladder/assets/config/config.json ]]; then
-      msg_info "Backing up configuration"
-      cp /opt/fladder/assets/config/config.json /tmp/fladder_config.json.bak
-      msg_ok "Configuration backed up"
-    fi
+    create_backup /opt/fladder/assets/config/config.json
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Fladder" "DonutWare/Fladder" "prebuild" "latest" "/opt/fladder" "Fladder-Web-*.zip"
 
-    if [[ -f /tmp/fladder_config.json.bak ]]; then
-      msg_info "Restoring configuration"
-      mkdir -p /opt/fladder/assets/config
-      cp /tmp/fladder_config.json.bak /opt/fladder/assets/config/config.json
-      rm -f /tmp/fladder_config.json.bak
-      msg_ok "Configuration restored"
-    fi
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start nginx

--- a/ct/flatnotes.sh
+++ b/ct/flatnotes.sh
@@ -34,12 +34,11 @@ function update_script() {
     systemctl stop flatnotes
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration and Data"
-    cp /opt/flatnotes/.env /opt/flatnotes.env
-    cp -r /opt/flatnotes/data /opt/flatnotes_data_backup
-    msg_ok "Backed up Configuration and Data"
+    create_backup /opt/flatnotes/.env /opt/flatnotes/data
 
-    fetch_and_deploy_gh_release "flatnotes" "dullage/flatnotes" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "flatnotes" "dullage/flatnotes" "tarball"
+
+    restore_backup
 
     msg_info "Updating Flatnotes"
     cd /opt/flatnotes/client
@@ -51,13 +50,6 @@ function update_script() {
     $STD /usr/local/bin/uvx migrate-to-uv
     $STD /usr/local/bin/uv sync
     msg_ok "Updated Flatnotes"
-
-    msg_info "Restoring Configuration and Data"
-    cp /opt/flatnotes.env /opt/flatnotes/.env
-    cp -r /opt/flatnotes_data_backup/. /opt/flatnotes/data
-    rm -f /opt/flatnotes.env
-    rm -r /opt/flatnotes_data_backup
-    msg_ok "Restored Configuration and Data"
 
     msg_info "Starting Service"
     systemctl start flatnotes

--- a/ct/fluid-calendar.sh
+++ b/ct/fluid-calendar.sh
@@ -38,9 +38,9 @@ function update_script() {
     systemctl stop fluid-calendar
     msg_info "Stopped Service"
 
-    cp /opt/fluid-calendar/.env /opt/fluid.env
+    create_backup /opt/fluid-calendar/.env
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "fluid-calendar" "dotnetfactory/fluid-calendar" "tarball"
-    mv /opt/fluid.env /opt/fluid-calendar/.env
+    restore_backup
 
     msg_info "Updating Fluid Calendar"
     cd /opt/fluid-calendar

--- a/ct/ghostfolio.sh
+++ b/ct/ghostfolio.sh
@@ -41,13 +41,15 @@ function update_script() {
       --exclude="ghostfolio/node_modules" \
       --exclude="ghostfolio/dist" \
       ghostfolio
-    mv /opt/ghostfolio/.env /opt/env.backup
     msg_ok "Backup Created"
+
+    create_backup /opt/ghostfolio/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "ghostfolio" "ghostfolio/ghostfolio" "tarball" "latest" "/opt/ghostfolio"
 
+    restore_backup
+
     msg_info "Updating Ghostfolio"
-    mv /opt/env.backup /opt/ghostfolio/.env
     sed -i -E '/^DATABASE_URL=/ s/[?&]sslmode=prefer//g' /opt/ghostfolio/.env
     cd /opt/ghostfolio
     $STD npm ci

--- a/ct/gogs.sh
+++ b/ct/gogs.sh
@@ -35,18 +35,11 @@ function update_script() {
     systemctl stop gogs
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -r /opt/gogs/custom /opt/gogs_custom_backup
-    cp -r /opt/gogs/data /opt/gogs_data_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/gogs/custom /opt/gogs/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gogs" "gogs/gogs" "prebuild" "latest" "/opt/gogs" "gogs_*_linux_$(arch_resolve).tar.gz"
 
-    msg_info "Restoring Data"
-    cp -r /opt/gogs_custom_backup/. /opt/gogs/custom
-    cp -r /opt/gogs_data_backup/. /opt/gogs/data
-    rm -rf /opt/gogs_custom_backup /opt/gogs_data_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start gogs

--- a/ct/grist.sh
+++ b/ct/grist.sh
@@ -37,21 +37,14 @@ function update_script() {
     systemctl stop grist
     msg_ok "Stopped Service"
 
-    msg_info "Creating backup"
-    rm -rf /opt/grist_bak
-    mv /opt/grist /opt/grist_bak
-    msg_ok "Backup created"
+    create_backup /opt/grist/.env /opt/grist/docs /opt/grist/grist-sessions.db /opt/grist/landing.db
 
-    fetch_and_deploy_gh_release "grist" "gristlabs/grist-core" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "grist" "gristlabs/grist-core" "tarball"
+
+    restore_backup
 
     msg_info "Updating Grist"
     mkdir -p /opt/grist/docs
-    cp -n /opt/grist_bak/.env /opt/grist/.env
-    if ls /opt/grist_bak/docs/* &>/dev/null; then
-      cp -r /opt/grist_bak/docs/* /opt/grist/docs/
-    fi
-    [[ -f /opt/grist_bak/grist-sessions.db ]] && cp /opt/grist_bak/grist-sessions.db /opt/grist/grist-sessions.db
-    [[ -f /opt/grist_bak/landing.db ]] && cp /opt/grist_bak/landing.db /opt/grist/landing.db
     cd /opt/grist
     $STD yarn install
     $STD yarn run build:prod

--- a/ct/homebox.sh
+++ b/ct/homebox.sh
@@ -39,8 +39,12 @@ function update_script() {
     systemctl stop homebox
     msg_ok "Stopped Service"
 
+    create_backup /opt/homebox/.env /opt/homebox/.data
+
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homebox" "sysadminsmedia/homebox" "prebuild" "latest" "/opt/homebox" "homebox_Linux_$(arch_resolve "x86_64" "arm64").tar.gz"
     chmod +x /opt/homebox/homebox
+
+    restore_backup
     [ -f /opt/.env ] && mv /opt/.env /opt/homebox/.env
     [ -d /opt/.data ] && mv /opt/.data /opt/homebox/.data
 

--- a/ct/homelable.sh
+++ b/ct/homelable.sh
@@ -35,15 +35,11 @@ function update_script() {
     systemctl stop homelable
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration and Data"
-    cp /opt/homelable/backend/.env /opt/homelable.env.bak
-    cp -r /opt/homelable/data /opt/homelable_data_bak
-    if [[ -f /opt/homelable/mcp/.env ]]; then
-      cp -a /opt/homelable/mcp/.env /opt/homelable-mcp.env.bak
-    fi
-    msg_ok "Backed up Configuration and Data"
+    create_backup /opt/homelable/backend/.env /opt/homelable/data /opt/homelable/mcp/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homelable" "Pouzor/homelable" "tarball" "latest" "/opt/homelable"
+
+    restore_backup
 
     msg_info "Updating Python Dependencies"
     cd /opt/homelable/backend
@@ -57,17 +53,8 @@ function update_script() {
     $STD npm run build
     msg_ok "Rebuilt Frontend"
 
-    msg_info "Restoring Configuration and Data"
-    cp /opt/homelable.env.bak /opt/homelable/backend/.env
-    cp -r /opt/homelable_data_bak/. /opt/homelable/data/
-    rm -f /opt/homelable.env.bak
-    rm -rf /opt/homelable_data_bak
-    msg_ok "Restored Configuration and Data"
-
-    if [[ -f /opt/homelable-mcp.env.bak ]]; then
+    if [[ -f /opt/homelable/mcp/.env ]]; then
       msg_info "Restoring MCP Server"
-      cp -a /opt/homelable-mcp.env.bak /opt/homelable/mcp/.env
-      rm -f /opt/homelable-mcp.env.bak
       MCP_OWNER=$(stat -c '%U' /opt/homelable/mcp/.env)
       cd /opt/homelable/mcp
       $STD uv venv --clear /opt/homelable/mcp/.venv

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -38,8 +38,6 @@ function update_script() {
     msg_ok "Stopped service"
 
     create_backup /opt/homepage/.env /opt/homepage/config
-    # Separate store for user assets: they must be restored AFTER the build
-    # (pnpm build regenerates public/), not together with .env/config
     BACKUP_DIR=/opt/homepage-assets.backup create_backup /opt/homepage/public/images /opt/homepage/public/icons
     
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homepage" "gethomepage/homepage" "tarball"

--- a/ct/homepage.sh
+++ b/ct/homepage.sh
@@ -37,20 +37,14 @@ function update_script() {
     systemctl stop homepage
     msg_ok "Stopped service"
 
-    msg_info "Creating Backup"
-    cp /opt/homepage/.env /opt/homepage.env
-    cp -r /opt/homepage/config /opt/homepage_config_backup
-    [[ -d /opt/homepage/public/images ]] && cp -r /opt/homepage/public/images /opt/homepage_images_backup
-    [[ -d /opt/homepage/public/icons ]] && cp -r /opt/homepage/public/icons /opt/homepage_icons_backup
-    msg_ok "Created Backup"
+    create_backup /opt/homepage/.env /opt/homepage/config
+    # Separate store for user assets: they must be restored AFTER the build
+    # (pnpm build regenerates public/), not together with .env/config
+    BACKUP_DIR=/opt/homepage-assets.backup create_backup /opt/homepage/public/images /opt/homepage/public/icons
     
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "homepage" "gethomepage/homepage" "tarball"
     
-    msg_info "Restoring Backup"
-    mv /opt/homepage.env /opt/homepage
-    rm -rf /opt/homepage/config
-    mv /opt/homepage_config_backup /opt/homepage/config
-    msg_ok "Restored Backup"
+    restore_backup
 
     msg_info "Updating Homepage (Patience)"
     RELEASE=$(get_latest_github_release "gethomepage/homepage")
@@ -63,8 +57,7 @@ function update_script() {
     export NEXT_PUBLIC_BUILDTIME=$(curl -fsSL https://api.github.com/repos/gethomepage/homepage/releases/latest | jq -r '.published_at')
     export NEXT_TELEMETRY_DISABLED=1
     $STD pnpm build
-    [[ -d /opt/homepage_images_backup ]] && mv /opt/homepage_images_backup /opt/homepage/public/images
-    [[ -d /opt/homepage_icons_backup ]] && mv /opt/homepage_icons_backup /opt/homepage/public/icons
+    BACKUP_DIR=/opt/homepage-assets.backup restore_backup
     msg_ok "Updated Homepage"
 
     msg_info "Starting service"

--- a/ct/hoodik.sh
+++ b/ct/hoodik.sh
@@ -36,16 +36,11 @@ function update_script() {
     systemctl stop hoodik
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /opt/hoodik/.env /opt/hoodik.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/hoodik/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "hoodik" "hudikhq/hoodik" "prebuild" "latest" "/opt/hoodik" "*$(arch_resolve "x86_64" "arm64").tar.gz"
 
-    msg_info "Restoring Configuration"
-    cp /opt/hoodik.env.bak /opt/hoodik/.env
-    rm -f /opt/hoodik.env.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start hoodik

--- a/ct/igotify.sh
+++ b/ct/igotify.sh
@@ -35,16 +35,11 @@ function update_script() {
     systemctl stop igotify
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /opt/igotify/.env /opt/igotify.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/igotify/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "igotify" "androidseb25/iGotify-Notification-Assistent" "prebuild" "latest" "/opt/igotify" "iGotify-Notification-Service-$(arch_resolve)-v*.zip"
 
-    msg_info "Restoring Configuration"
-    cp /opt/igotify.env.bak /opt/igotify/.env
-    rm -f /opt/igotify.env.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start igotify

--- a/ct/immichframe.sh
+++ b/ct/immichframe.sh
@@ -35,9 +35,7 @@ function update_script() {
     systemctl stop immichframe
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp -r /opt/immichframe/Config /tmp/immichframe_config.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/immichframe/Config
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "immichframe" "immichFrame/ImmichFrame" "tarball" "latest" "/tmp/immichframe"
 
@@ -57,11 +55,9 @@ function update_script() {
     rm -rf /tmp/immichframe
     msg_ok "Setup ImmichFrame"
 
-    msg_info "Restoring Configuration"
-    cp -r /tmp/immichframe_config.bak/* /opt/immichframe/Config/
-    rm -rf /tmp/immichframe_config.bak
+    # Restore AFTER the publish step above (it rewrites /opt/immichframe)
+    restore_backup
     chown -R immichframe:immichframe /opt/immichframe
-    msg_ok "Restored Configuration"
 
 
     msg_info "Starting Service"

--- a/ct/immichframe.sh
+++ b/ct/immichframe.sh
@@ -55,7 +55,6 @@ function update_script() {
     rm -rf /tmp/immichframe
     msg_ok "Setup ImmichFrame"
 
-    # Restore AFTER the publish step above (it rewrites /opt/immichframe)
     restore_backup
     chown -R immichframe:immichframe /opt/immichframe
 

--- a/ct/investbrain.sh
+++ b/ct/investbrain.sh
@@ -41,20 +41,14 @@ function update_script() {
     NODE_VERSION="22" setup_nodejs
     PG_VERSION="17" setup_postgresql
 
-    msg_info "Creating Backup"
-    rm -f /opt/.env.backup
-    rm -rf /opt/investbrain_backup
-    cp /opt/investbrain/.env /opt/.env.backup
-    cp -r /opt/investbrain/storage /opt/investbrain_backup
-    msg_ok "Created Backup"
+    create_backup /opt/investbrain/.env /opt/investbrain/storage
 
-    fetch_and_deploy_gh_release "Investbrain" "investbrainapp/investbrain" "tarball" "latest" "/opt/investbrain"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Investbrain" "investbrainapp/investbrain" "tarball" "latest" "/opt/investbrain"
+
+    restore_backup
 
     msg_info "Updating Investbrain"
     cd /opt/investbrain
-    rm -rf /opt/investbrain/storage
-    cp /opt/.env.backup /opt/investbrain/.env
-    cp -r /opt/investbrain_backup/ /opt/investbrain/storage
     export COMPOSER_ALLOW_SUPERUSER=1
     $STD /usr/local/bin/composer install --no-interaction --no-dev --optimize-autoloader
     $STD npm install
@@ -69,7 +63,6 @@ function update_script() {
     $STD php artisan event:cache
     chown -R www-data:www-data /opt/investbrain
     chmod -R 775 /opt/investbrain/storage /opt/investbrain/bootstrap/cache
-    rm -rf /opt/.env.backup /opt/investbrain_backup
     msg_ok "Updated Investbrain"
 
     msg_info "Starting Services"

--- a/ct/invoiceninja.sh
+++ b/ct/invoiceninja.sh
@@ -35,21 +35,11 @@ function update_script() {
     systemctl stop supervisor nginx php8.4-fpm
     msg_ok "Stopped Services"
 
-    msg_info "Creating Backup"
-    mkdir -p /tmp/invoiceninja_backup
-    cp /opt/invoiceninja/.env /tmp/invoiceninja_backup/
-    cp -r /opt/invoiceninja/storage /tmp/invoiceninja_backup/ 2>/dev/null || true
-    cp -r /opt/invoiceninja/public/storage /tmp/invoiceninja_backup/public_storage 2>/dev/null || true
-    msg_ok "Created Backup"
+    create_backup /opt/invoiceninja/.env /opt/invoiceninja/storage /opt/invoiceninja/public/storage
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "invoiceninja" "invoiceninja/invoiceninja" "prebuild" "latest" "/opt/invoiceninja" "invoiceninja.tar.gz"
 
-    msg_info "Restoring Data"
-    cp /tmp/invoiceninja_backup/.env /opt/invoiceninja/
-    cp -r /tmp/invoiceninja_backup/storage/* /opt/invoiceninja/storage/ 2>/dev/null || true
-    cp -r /tmp/invoiceninja_backup/public_storage/* /opt/invoiceninja/public/storage/ 2>/dev/null || true
-    rm -rf /tmp/invoiceninja_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Running Migrations"
     cd /opt/invoiceninja 

--- a/ct/invoiceshelf.sh
+++ b/ct/invoiceshelf.sh
@@ -35,19 +35,11 @@ function update_script() {
     systemctl stop caddy
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/invoiceshelf/.env /opt/invoiceshelf.env.bak
-    cp -r /opt/invoiceshelf/storage /opt/invoiceshelf_storage_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/invoiceshelf/.env /opt/invoiceshelf/storage
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "invoiceshelf" "InvoiceShelf/InvoiceShelf" "tarball"
 
-    msg_info "Restoring Data"
-    cp /opt/invoiceshelf.env.bak /opt/invoiceshelf/.env
-    rm -f /opt/invoiceshelf.env.bak
-    cp -r /opt/invoiceshelf_storage_backup/. /opt/invoiceshelf/storage
-    rm -rf /opt/invoiceshelf_storage_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Updating Application"
     cd /opt/invoiceshelf

--- a/ct/joplin-server.sh
+++ b/ct/joplin-server.sh
@@ -36,9 +36,9 @@ function update_script() {
     systemctl stop joplin-server
     msg_ok "Stopped Services"
 
-    cp /opt/joplin-server/.env /opt
+    create_backup /opt/joplin-server/.env
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "joplin-server" "laurent22/joplin" "tarball"
-    mv /opt/.env /opt/joplin-server
+    restore_backup
 
     msg_info "Updating Joplin-Server"
     cd /opt/joplin-server

--- a/ct/jotty.sh
+++ b/ct/jotty.sh
@@ -35,20 +35,12 @@ function update_script() {
     systemctl stop jotty
     msg_ok "Stopped Service"
 
-    msg_info "Backing up configuration & data"
-    cp /opt/jotty/.env /opt/app.env
-    [[ -d /opt/jotty/data ]] && mv /opt/jotty/data /opt/data
-    [[ -d /opt/jotty/config ]] && mv /opt/jotty/config /opt/config
-    msg_ok "Backed up configuration & data"
+    create_backup /opt/jotty/.env /opt/jotty/data /opt/jotty/config
 
     NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "jotty" "fccview/jotty" "prebuild" "latest" "/opt/jotty" "jotty_*_prebuild.tar.gz"
 
-    msg_info "Restoring configuration & data"
-    mv /opt/app.env /opt/jotty/.env
-    [[ -d /opt/data ]] && mv /opt/data /opt/jotty/data
-    [[ -d /opt/config ]] && cp -a /opt/config/* /opt/jotty/config && rm -rf /opt/config
-    msg_ok "Restored configuration & data"
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start jotty

--- a/ct/kan.sh
+++ b/ct/kan.sh
@@ -35,16 +35,11 @@ function update_script() {
     systemctl stop kan
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/kan/.env /opt/kan.env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/kan/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "kan" "kanbn/kan" "latest"
 
-    msg_info "Restoring Configuration"
-    cp /opt/kan.env.bak /opt/kan/.env
-    rm -f /opt/kan.env.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Building Application"
     cd /opt/kan

--- a/ct/kima-hub.sh
+++ b/ct/kima-hub.sh
@@ -37,18 +37,11 @@ function update_script() {
     systemctl stop kima-frontend kima-backend kima-analyzer kima-analyzer-clap
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/kima-hub/backend/.env /opt/kima-hub-backend-env.bak
-    cp /opt/kima-hub/frontend/.env /opt/kima-hub-frontend-env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/kima-hub/backend/.env /opt/kima-hub/frontend/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "kima-hub" "Chevron7Locked/kima-hub" "tarball"
 
-    msg_info "Restoring Data"
-    cp /opt/kima-hub-backend-env.bak /opt/kima-hub/backend/.env
-    cp /opt/kima-hub-frontend-env.bak /opt/kima-hub/frontend/.env
-    rm -f /opt/kima-hub-backend-env.bak /opt/kima-hub-frontend-env.bak
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Rebuilding Backend"
     cd /opt/kima-hub/backend

--- a/ct/kitchenowl.sh
+++ b/ct/kitchenowl.sh
@@ -35,22 +35,14 @@ function update_script() {
     systemctl stop kitchenowl
     msg_ok "Stopped Service"
 
-    msg_info "Creating Backup"
-    mkdir -p /opt/kitchenowl_backup
-    cp -r /opt/kitchenowl/data /opt/kitchenowl_backup/
-    cp -f /opt/kitchenowl/kitchenowl.env /opt/kitchenowl_backup/
-    msg_ok "Created Backup"
+    create_backup /opt/kitchenowl/data /opt/kitchenowl/kitchenowl.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "kitchenowl" "TomBursch/kitchenowl" "tarball" "latest" "/opt/kitchenowl"
     rm -rf /opt/kitchenowl/web
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "kitchenowl-web" "TomBursch/kitchenowl" "prebuild" "latest" "/opt/kitchenowl/web" "kitchenowl_Web.tar.gz"
 
-    msg_info "Restoring data"
+    restore_backup
     sed -i 's/default=True/default=False/' /opt/kitchenowl/backend/wsgi.py
-    cp -r /opt/kitchenowl_backup/data /opt/kitchenowl/
-    cp -f /opt/kitchenowl_backup/kitchenowl.env /opt/kitchenowl/
-    rm -rf /opt/kitchenowl_backup
-    msg_ok "Restored data"
 
     msg_info "Updating KitchenOwl"
     cd /opt/kitchenowl/backend

--- a/ct/koel.sh
+++ b/ct/koel.sh
@@ -35,21 +35,11 @@ function update_script() {
     systemctl stop nginx php8.4-fpm
     msg_ok "Stopped Services"
 
-    msg_info "Creating Backup"
-    mkdir -p /tmp/koel_backup
-    cp /opt/koel/.env /tmp/koel_backup/
-    cp -r /opt/koel/storage /tmp/koel_backup/ 2>/dev/null || true
-    cp -r /opt/koel/public/img /tmp/koel_backup/ 2>/dev/null || true
-    msg_ok "Created Backup"
+    create_backup /opt/koel/.env /opt/koel/storage /opt/koel/public/img
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "koel" "koel/koel" "prebuild" "latest" "/opt/koel" "koel-*.tar.gz"
 
-    msg_info "Restoring Data"
-    cp /tmp/koel_backup/.env /opt/koel/
-    cp -r /tmp/koel_backup/storage/* /opt/koel/storage/ 2>/dev/null || true
-    cp -r /tmp/koel_backup/img/* /opt/koel/public/img/ 2>/dev/null || true
-    rm -rf /tmp/koel_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Running Migrations"
     cd /opt/koel 

--- a/ct/leantime.sh
+++ b/ct/leantime.sh
@@ -34,20 +34,18 @@ function update_script() {
     msg_info "Creating Backup"
     mariadb-dump leantime >"/opt/leantime_db_backup_$(date +%F).sql"
     tar -czf "/opt/leantime_backup_$(date +%F).tar.gz" "/opt/leantime"
-    mv /opt/leantime /opt/leantime_bak
     msg_ok "Backup Created"
 
-    fetch_and_deploy_gh_release "leantime" "Leantime/leantime" "prebuild" "latest" "/opt/leantime" Leantime*.tar.gz
+    create_backup /opt/leantime/config/.env
 
-    msg_info "Restoring Config & Permissions"
-    mv /opt/leantime_bak/config/.env /opt/leantime/config/.env
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "leantime" "Leantime/leantime" "prebuild" "latest" "/opt/leantime" Leantime*.tar.gz
+
+    restore_backup
+
+    msg_info "Setting Permissions"
     chown -R www-data:www-data "/opt/leantime"
     chmod -R 750 "/opt/leantime"
-    msg_ok "Restored Config & Permissions"
-
-    msg_info "Removing Backup"
-    rm -rf /opt/leantime_bak
-    msg_ok "Removed Backup"
+    msg_ok "Set Permissions"
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/librechat.sh
+++ b/ct/librechat.sh
@@ -35,11 +35,11 @@ function update_script() {
     systemctl stop librechat rag-api
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Configuration"
-    cp /opt/librechat/.env /opt/librechat.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/librechat/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_tag "librechat" "danny-avila/LibreChat"
+
+    restore_backup
 
     msg_info "Installing Dependencies"
     cd /opt/librechat
@@ -52,11 +52,6 @@ function update_script() {
     $STD npm cache clean --force
     msg_ok "Built Frontend"
 
-    msg_info "Restoring Configuration"
-    cp /opt/librechat.env.bak /opt/librechat/.env
-    rm -f /opt/librechat.env.bak
-    msg_ok "Restored Configuration"
-
     msg_info "Starting Services"
     systemctl start rag-api librechat
     msg_ok "Started Services"
@@ -68,21 +63,16 @@ function update_script() {
     systemctl stop rag-api
     msg_ok "Stopped RAG API"
 
-    msg_info "Backing up RAG API Configuration"
-    cp /opt/rag-api/.env /opt/rag-api.env.bak
-    msg_ok "Backed up RAG API Configuration"
+    create_backup /opt/rag-api/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rag-api" "danny-avila/rag_api" "tarball"
+
+    restore_backup
 
     msg_info "Updating RAG API Dependencies"
     cd /opt/rag-api
     $STD .venv/bin/pip install -r requirements.lite.txt
     msg_ok "Updated RAG API Dependencies"
-
-    msg_info "Restoring RAG API Configuration"
-    cp /opt/rag-api.env.bak /opt/rag-api/.env
-    rm -f /opt/rag-api.env.bak
-    msg_ok "Restored RAG API Configuration"
 
     msg_info "Starting RAG API"
     systemctl start rag-api

--- a/ct/linkding.sh
+++ b/ct/linkding.sh
@@ -35,19 +35,12 @@ function update_script() {
     systemctl stop nginx linkding linkding-tasks
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp -r /opt/linkding/data /opt/linkding_data_backup
-    cp /opt/linkding/.env /opt/linkding_env_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/linkding/data /opt/linkding/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "linkding" "sissbruecker/linkding" "tarball"
 
-    msg_info "Restoring Data"
-    cp -r /opt/linkding_data_backup/. /opt/linkding/data
-    cp /opt/linkding_env_backup /opt/linkding/.env
-    rm -rf /opt/linkding_data_backup /opt/linkding_env_backup
+    restore_backup
     ln -sf /usr/lib/$(arch_resolve "x86_64-linux-gnu" "aarch64-linux-gnu")/mod_icu.so /opt/linkding/libicu.so
-    msg_ok "Restored Data"
 
     msg_info "Updating LinkDing"
     cd /opt/linkding

--- a/ct/linkwarden.sh
+++ b/ct/linkwarden.sh
@@ -35,13 +35,11 @@ function update_script() {
 
     RUST_CRATES="monolith" setup_rust
 
-    msg_info "Backing up data"
-    mv /opt/linkwarden/.env /opt/.env
-    [ -d /opt/linkwarden/data ] && mv /opt/linkwarden/data /opt/data.bak
-    rm -rf /opt/linkwarden
-    msg_ok "Backed up data"
+    create_backup /opt/linkwarden/.env /opt/linkwarden/data
 
-    fetch_and_deploy_gh_release "linkwarden" "linkwarden/linkwarden" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "linkwarden" "linkwarden/linkwarden" "tarball"
+
+    restore_backup
 
     msg_info "Updating Linkwarden"
     cd /opt/linkwarden
@@ -60,11 +58,9 @@ function update_script() {
     $STD yarn
     $STD npx playwright install-deps
     $STD npx playwright install
-    mv /opt/.env /opt/linkwarden/.env
     $STD yarn prisma:generate
     $STD yarn web:build
     $STD yarn prisma:deploy
-    [ -d /opt/data.bak ] && mv /opt/data.bak /opt/linkwarden/data
     rm -rf ~/.cargo/registry ~/.cargo/git ~/.cargo/.package-cache
     rm -rf /root/.cache/yarn
     rm -rf /opt/linkwarden/.next/cache

--- a/ct/lobehub.sh
+++ b/ct/lobehub.sh
@@ -35,16 +35,11 @@ function update_script() {
     systemctl stop lobehub
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/lobehub/.env /opt/lobehub.env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/lobehub/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "lobehub" "lobehub/lobehub" "tarball"
 
-    msg_info "Restoring Configuration"
-    cp /opt/lobehub.env.bak /opt/lobehub/.env
-    rm -f /opt/lobehub.env.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Building Application"
     cd /opt/lobehub

--- a/ct/mail-archiver.sh
+++ b/ct/mail-archiver.sh
@@ -36,10 +36,7 @@ function update_script() {
     systemctl stop mail-archiver
     msg_ok "Stopped Mail-Archiver"
 
-    msg_info "Creating Backup"
-    cp /opt/mail-archiver/appsettings.json /opt/mail-archiver/.env /opt/
-    [[ -d /opt/mail-archiver/DataProtection-Keys ]] && cp -r /opt/mail-archiver/DataProtection-Keys /opt
-    msg_ok "Created Backup"
+    create_backup /opt/mail-archiver/appsettings.json /opt/mail-archiver/.env /opt/mail-archiver/DataProtection-Keys
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "mail-archiver" "s1t5/mail-archiver" "tarball"
 
@@ -51,10 +48,7 @@ function update_script() {
     rm -rf /opt/mail-archiver-build
     msg_ok "Updated Mail-Archiver"
 
-    msg_info "Restoring Backup"
-    cp /opt/appsettings.json /opt/.env /opt/mail-archiver
-    [[ -d /opt/DataProtection-Keys ]] && cp -r /opt/DataProtection-Keys /opt/mail-archiver/
-    msg_ok "Restored Backup"
+    restore_backup
 
     msg_info "Starting Mail-Archiver"
     systemctl start mail-archiver

--- a/ct/manyfold.sh
+++ b/ct/manyfold.sh
@@ -39,12 +39,14 @@ function update_script() {
 
     msg_info "Backing up Data"
     CURRENT_VERSION=$(grep -oP 'APP_VERSION=\K[^ ]+' /opt/manyfold/.env || echo "unknown")
-    cp -r /opt/manyfold/app/storage /opt/manyfold_storage_backup 2>/dev/null || true
-    cp -r /opt/manyfold/app/tmp /opt/manyfold_tmp_backup 2>/dev/null || true
     $STD tar -czf "/opt/manyfold_${CURRENT_VERSION}_backup.tar.gz" -C /opt/manyfold app
     msg_ok "Backed up Data"
 
+    create_backup /opt/manyfold/app/storage /opt/manyfold/app/tmp
+
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "manyfold" "manyfold3d/manyfold" "tarball" "latest" "/opt/manyfold/app"
+
+    restore_backup
 
     msg_info "Configuring Manyfold"
     RUBY_INSTALL_VERSION=$(cat /opt/manyfold/app/.ruby-version)
@@ -55,14 +57,9 @@ function update_script() {
 
     RUBY_VERSION=${RUBY_INSTALL_VERSION} RUBY_INSTALL_RAILS="true" HOME=/home/manyfold setup_ruby
 
-    msg_info "Restoring Data"
-    rm -rf /opt/manyfold/app/{storage,tmp}
-    cp -r /opt/manyfold_storage_backup /opt/manyfold/app/storage 2>/dev/null || true
-    cp -r /opt/manyfold_tmp_backup /opt/manyfold/app/tmp 2>/dev/null || true
+    msg_info "Setting Permissions"
     chown -R manyfold:manyfold {/home/manyfold,/opt/manyfold}
-    chown -R manyfold:manyfold /opt/manyfold/app/storage /opt/manyfold/app/tmp /opt/manyfold/app/config
-    rm -rf /opt/manyfold_storage_backup /opt/manyfold_tmp_backup
-    msg_ok "Restored Data"
+    msg_ok "Set Permissions"
 
     msg_info "Installing Manyfold"
 

--- a/ct/matomo.sh
+++ b/ct/matomo.sh
@@ -49,8 +49,6 @@ function update_script() {
     chmod -R 755 /opt/matomo/tmp
     msg_ok "Set up Matomo"
 
-    # Restore AFTER the matomo/ subdir normalization above, so the restored
-    # config lands in the final directory layout
     restore_backup
     chown -R www-data:www-data /opt/matomo
 

--- a/ct/matomo.sh
+++ b/ct/matomo.sh
@@ -35,11 +35,7 @@ function update_script() {
     systemctl stop caddy
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    [[ -f /opt/matomo/config/config.ini.php ]] && cp /opt/matomo/config/config.ini.php /opt/matomo_config.bak
-    [[ -d /opt/matomo/misc/user ]] && cp -r /opt/matomo/misc/user /opt/matomo_user_backup
-    [[ -f /root/matomo.creds ]] && cp /root/matomo.creds /opt/matomo_db_creds.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/matomo/config/config.ini.php /opt/matomo/misc/user /root/matomo.creds
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "matomo" "matomo-org/matomo" "prebuild" "latest" "/opt/matomo" "matomo-*.zip"
 
@@ -53,20 +49,10 @@ function update_script() {
     chmod -R 755 /opt/matomo/tmp
     msg_ok "Set up Matomo"
 
-    msg_info "Restoring Data"
-    if [[ -f /opt/matomo_config.bak ]]; then
-      mkdir -p /opt/matomo/config
-      cp /opt/matomo_config.bak /opt/matomo/config/config.ini.php
-    fi
-    if [[ -d /opt/matomo_user_backup ]]; then
-      mkdir -p /opt/matomo/misc/user
-      cp -r /opt/matomo_user_backup/. /opt/matomo/misc/user
-    fi
-    [[ -f /opt/matomo_db_creds.bak ]] && cp /opt/matomo_db_creds.bak /root/matomo.creds
-    rm -f /opt/matomo_config.bak /opt/matomo_db_creds.bak
-    rm -rf /opt/matomo_user_backup
+    # Restore AFTER the matomo/ subdir normalization above, so the restored
+    # config lands in the final directory layout
+    restore_backup
     chown -R www-data:www-data /opt/matomo
-    msg_ok "Restored Data"
 
     if [[ -f /opt/matomo/console ]]; then
       msg_info "Running Matomo database upgrade"

--- a/ct/meilisearch.sh
+++ b/ct/meilisearch.sh
@@ -33,14 +33,13 @@ function update_script() {
       systemctl stop meilisearch-ui
       msg_ok "Stopped Meilisearch-UI"
 
-      cp /opt/meilisearch-ui/.env.local /tmp/.env.local.bak
-      rm -rf /opt/meilisearch-ui
-      fetch_and_deploy_gh_release "meilisearch-ui" "riccox/meilisearch-ui" "tarball"
+      create_backup /opt/meilisearch-ui/.env.local
+      CLEAN_INSTALL=1 fetch_and_deploy_gh_release "meilisearch-ui" "riccox/meilisearch-ui" "tarball"
+      restore_backup
 
       msg_info "Configuring Meilisearch-UI"
       cd /opt/meilisearch-ui
       sed -i 's|const hash = execSync("git rev-parse HEAD").toString().trim();|const hash = "unknown";|' /opt/meilisearch-ui/vite.config.ts
-      mv /tmp/.env.local.bak /opt/meilisearch-ui/.env.local
       $STD pnpm install
       msg_ok "Configured Meilisearch-UI"
 

--- a/ct/metube.sh
+++ b/ct/metube.sh
@@ -48,14 +48,11 @@ function update_script() {
     systemctl stop metube
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Old Installation"
-    if [[ -d /opt/metube_bak ]]; then
-      rm -rf /opt/metube_bak
-    fi
-    mv /opt/metube /opt/metube_bak
-    msg_ok "Backup created"
+    create_backup /opt/metube/.env
 
-    fetch_and_deploy_gh_release "metube" "alexta69/metube" "tarball" "latest"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "metube" "alexta69/metube" "tarball" "latest"
+
+    restore_backup
 
     msg_info "Building Frontend"
     cd /opt/metube/ui
@@ -74,13 +71,6 @@ function update_script() {
     cd /opt/metube
     $STD uv sync
     msg_ok "Installed Backend"
-
-    msg_info "Restoring .env"
-    if [[ -f /opt/metube_bak/.env ]]; then
-      cp /opt/metube_bak/.env /opt/metube/.env
-    fi
-    rm -rf /opt/metube_bak
-    msg_ok "Restored .env"
 
     if grep -q 'pipenv' /etc/systemd/system/metube.service; then
       msg_info "Patching systemd Service"

--- a/ct/nametag.sh
+++ b/ct/nametag.sh
@@ -35,15 +35,12 @@ function update_script() {
     systemctl stop nametag
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/nametag/.env /opt/nametag.env.bak
-    cp -r /opt/nametag/data /opt/nametag_data_bak
-    msg_ok "Backed up Data"
+    create_backup /opt/nametag/.env /opt/nametag/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nametag" "mattogodoy/nametag" "tarball" "latest" "/opt/nametag"
 
-    # Restore .env BEFORE the build: CLEAN_INSTALL wiped it and the build sources it
-    cp /opt/nametag.env.bak /opt/nametag/.env
+    # Restore BEFORE the build: CLEAN_INSTALL wiped /opt/nametag and the build sources .env
+    restore_backup
 
     msg_info "Rebuilding Application"
     cd /opt/nametag
@@ -56,13 +53,6 @@ function update_script() {
     cp -r /opt/nametag/.next/static /opt/nametag/.next/standalone/.next/static
     cp -r /opt/nametag/public /opt/nametag/.next/standalone/public
     msg_ok "Rebuilt Application"
-
-    msg_info "Restoring Data"
-    cp /opt/nametag.env.bak /opt/nametag/.env
-    cp -r /opt/nametag_data_bak/. /opt/nametag/data/
-    rm -f /opt/nametag.env.bak
-    rm -rf /opt/nametag_data_bak
-    msg_ok "Restored Data"
 
     msg_info "Running Migrations"
     cd /opt/nametag

--- a/ct/nametag.sh
+++ b/ct/nametag.sh
@@ -39,7 +39,6 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "nametag" "mattogodoy/nametag" "tarball" "latest" "/opt/nametag"
 
-    # Restore BEFORE the build: CLEAN_INSTALL wiped /opt/nametag and the build sources .env
     restore_backup
 
     msg_info "Rebuilding Application"

--- a/ct/overseerr.sh
+++ b/ct/overseerr.sh
@@ -61,18 +61,16 @@ EOF
     systemctl stop overseerr
     msg_ok "Service stopped"
 
-    msg_info "Creating backup"
-    mv /opt/overseerr/config /opt/config_backup
-    msg_ok "Backup created"
+    create_backup /opt/overseerr/config
 
     fetch_and_deploy_gh_release "overseerr" "sct/overseerr" "tarball"
-    rm -rf /opt/overseerr/config
+
+    restore_backup
 
     msg_info "Configuring ${APP} (Patience)"
     cd /opt/overseerr
     $STD yarn install
     $STD yarn build
-    mv /opt/config_backup /opt/overseerr/config
     msg_ok "Configured ${APP}"
 
     msg_info "Starting Service"

--- a/ct/ownfoil.sh
+++ b/ct/ownfoil.sh
@@ -35,22 +35,17 @@ function update_script() {
     systemctl stop ownfoil
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -r /opt/ownfoil/app/config /opt/ownfoil_data_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/ownfoil/app/config
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "ownfoil" "a1ex4/ownfoil" "tarball"
+
+    restore_backup
 
     msg_info "Installing Dependencies"
     cd /opt/ownfoil
     $STD source .venv/bin/activate
     $STD uv pip install -r requirements.txt
     msg_ok "Installed Dependencies"
-
-    msg_info "Restoring Data"
-    cp -r /opt/ownfoil_data_backup /opt/ownfoil/app/config
-    rm -rf /opt/ownfoil_data_backup
-    msg_ok "Restored Data"
 
     msg_info "Starting Service"
     systemctl start ownfoil

--- a/ct/paperclip.sh
+++ b/ct/paperclip.sh
@@ -35,15 +35,11 @@ function update_script() {
     systemctl stop paperclip
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /opt/paperclip-ai/.env /opt/paperclip.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/paperclip-ai/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "paperclip-ai" "paperclipai/paperclip" "tarball"
 
-    msg_info "Restoring Configuration"
-    mv /opt/paperclip.env.bak /opt/paperclip-ai/.env
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Rebuilding Paperclip"
     cd /opt/paperclip-ai

--- a/ct/papra.sh
+++ b/ct/papra.sh
@@ -35,22 +35,18 @@ function update_script() {
     systemctl stop papra
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    if [[ -f /opt/papra/apps/papra-server/.env ]]; then
-      cp /opt/papra/apps/papra-server/.env /opt/papra_env.bak
-    fi
-    msg_ok "Backed up Configuration"
+    create_backup /opt/papra/apps/papra-server/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "papra" "papra-hq/papra" "tarball"
+
+    restore_backup
 
     pnpm_version=$(grep -oP '"packageManager":\s*"pnpm@\K[^"]+' /opt/papra/package.json)
     NODE_VERSION="26" NODE_MODULE="pnpm@$pnpm_version" setup_nodejs
 
     msg_info "Building Application"
     cd /opt/papra
-    if [[ -f /opt/papra_env.bak ]]; then
-      cp /opt/papra_env.bak /opt/papra/apps/papra-server/.env
-    else
+    if [[ ! -f /opt/papra/apps/papra-server/.env ]]; then
       msg_warn ".env missing, regenerating from defaults"
       LOCAL_IP=$(hostname -I | awk '{print $1}')
       cat <<EOF >/opt/papra/apps/papra-server/.env
@@ -74,7 +70,6 @@ EOF
     $STD pnpm --filter "@papra/app-client..." run build
     $STD pnpm --filter "@papra/app-server..." run build
     ln -sf /opt/papra/apps/papra-client/dist /opt/papra/apps/papra-server/public
-    rm -f /opt/papra_env.bak
     msg_ok "Built Application"
 
     msg_info "Starting Service"

--- a/ct/patchmon.sh
+++ b/ct/patchmon.sh
@@ -72,8 +72,12 @@ EOF
       msg_ok "Migration complete!"
     fi
 
+    create_backup /opt/patchmon/.env
+
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "PatchMon" "PatchMon/PatchMon" "singlefile" "latest" "/opt/patchmon" "patchmon-server-linux-$(arch_resolve)"
     mv /opt/patchmon/PatchMon /opt/patchmon/patchmon-server
+
+    restore_backup
 
     msg_info "Fetching PatchMon agent binaries"
     RELEASE=$(get_latest_github_release "PatchMon/PatchMon")

--- a/ct/postiz.sh
+++ b/ct/postiz.sh
@@ -41,8 +41,6 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "postiz" "gitroomhq/postiz-app" "tarball"
 
-    # Restore BEFORE the build: CLEAN_INSTALL wiped /opt/postiz including .env,
-    # and the build below sources it
     restore_backup
 
     msg_info "Building Application"

--- a/ct/powerdns.sh
+++ b/ct/powerdns.sh
@@ -36,18 +36,14 @@ function update_script() {
   msg_ok "Updated PowerDNS"
 
   if check_for_gh_release "poweradmin" "poweradmin/poweradmin"; then
-    msg_info "Backing up Configuration"
-    cp /opt/poweradmin/config/settings.php /opt/poweradmin_settings.php.bak
-    cp /opt/poweradmin/powerdns.db /opt/poweradmin_powerdns.db.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/poweradmin/config/settings.php /opt/poweradmin/powerdns.db
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "poweradmin" "poweradmin/poweradmin" "tarball"
 
+    restore_backup
+
     msg_info "Updating Poweradmin"
-    cp /opt/poweradmin_settings.php.bak /opt/poweradmin/config/settings.php
-    cp /opt/poweradmin_powerdns.db.bak /opt/poweradmin/powerdns.db
     rm -rf /opt/poweradmin/install
-    rm -f /opt/poweradmin_settings.php.bak /opt/poweradmin_powerdns.db.bak
     chown -R www-data:pdns /opt/poweradmin
     chmod 775 /opt/poweradmin
     chown pdns:pdns /opt/poweradmin/powerdns.db

--- a/ct/radicale.sh
+++ b/ct/radicale.sh
@@ -34,17 +34,12 @@ function update_script() {
     systemctl stop radicale
     msg_ok "Stopped service"
 
-    msg_info "Backing up users file"
-    cp /opt/radicale/users /opt/radicale_users_backup
-    msg_ok "Backed up users file"
+    create_backup /opt/radicale/users
 
     PYTHON_VERSION="3.13" setup_uv
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Radicale" "Kozea/Radicale" "tarball" "latest" "/opt/radicale"
 
-    msg_info "Restoring users file"
-    rm -f /opt/radicale/users
-    mv /opt/radicale_users_backup /opt/radicale/users
-    msg_ok "Restored users file"
+    restore_backup
 
     if grep -q 'start.sh' /etc/systemd/system/radicale.service; then
       sed -i -e '/^Description/i[Unit]' \

--- a/ct/reactive-resume.sh
+++ b/ct/reactive-resume.sh
@@ -36,9 +36,11 @@ function update_script() {
 
     ensure_dependencies git
 
-    cp /opt/reactive-resume/.env /opt/reactive-resume.env.bak
+    create_backup /opt/reactive-resume/.env
     NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "reactive-resume" "amruthpillai/reactive-resume" "tarball" "latest" "/opt/reactive-resume"
+
+    restore_backup
 
     msg_info "Updating Reactive Resume (Patience)"
     cd /opt/reactive-resume
@@ -49,7 +51,6 @@ function update_script() {
     export NODE_ENV="production"
     $STD pnpm install --frozen-lockfile
     $STD pnpm run build
-    mv /opt/reactive-resume.env.bak /opt/reactive-resume/.env
     msg_ok "Updated Reactive Resume"
 
     msg_info "Updating Service"

--- a/ct/rustypaste.sh
+++ b/ct/rustypaste.sh
@@ -35,18 +35,11 @@ function update_script() {
     systemctl stop rustypaste
     msg_ok "Stopped Services"
 
-    msg_info "Creating Backup"
-    tar -czf "/opt/rustypaste_backup_$(date +%F).tar.gz" /opt/rustypaste/upload 2>/dev/null || true
-    cp /opt/rustypaste/config.toml /tmp/rustypaste_config.toml.bak
-    msg_ok "Backup Created"
+    create_backup /opt/rustypaste/upload /opt/rustypaste/config.toml
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "rustypaste" "orhun/rustypaste" "prebuild" "latest" "/opt/rustypaste" "*x86_64-unknown-linux-gnu.tar.gz"
 
-    msg_info "Restoring Data"
-    mv /tmp/rustypaste_config.toml.bak /opt/rustypaste/config.toml
-    tar -xzf "/opt/rustypaste_backup_$(date +%F).tar.gz" -C /opt/rustypaste/upload 2>/dev/null || true
-    rm -rf /opt/rustypaste_backup_$(date +%F).tar.gz
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Starting Services"
     systemctl start rustypaste

--- a/ct/scanopy.sh
+++ b/ct/scanopy.sh
@@ -36,19 +36,16 @@ function update_script() {
     [[ -f /etc/systemd/system/scanopy-daemon.service ]] && systemctl stop scanopy-daemon
     msg_ok "Stopped services"
 
-    msg_info "Backing up configurations"
-    cp /opt/scanopy/.env /opt/scanopy.env
-    [[ -f /opt/scanopy/oidc.toml ]] && cp /opt/scanopy/oidc.toml /opt/scanopy.oidc.toml
-    msg_ok "Backed up configurations"
+    create_backup /opt/scanopy/.env /opt/scanopy/oidc.toml
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Scanopy" "scanopy/scanopy" "tarball" "latest" "/opt/scanopy"
+
+    restore_backup
 
     ensure_dependencies pkg-config libssl-dev
     TOOLCHAIN="$(grep "channel" /opt/scanopy/backend/rust-toolchain.toml | awk -F\" '{print $2}')"
     RUST_TOOLCHAIN=$TOOLCHAIN setup_rust
 
-    [[ -f /opt/scanopy.env ]] && mv /opt/scanopy.env /opt/scanopy/.env
-    [[ -f /opt/scanopy.oidc.toml ]] && mv /opt/scanopy.oidc.toml /opt/scanopy/oidc.toml
     if ! grep -q "PUBLIC_URL" /opt/scanopy/.env; then
       sed -i "\|_PATH=|a\\scanopy_PUBLIC_URL=http://${LOCAL_IP}:60072" /opt/scanopy/.env
     fi

--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -52,11 +52,12 @@ function update_script() {
       msg_ok "Updated FlareSolverr"
     fi
 
-    cp /opt/shelfmark/start.sh /opt/start.sh.bak
+    create_backup /opt/shelfmark/start.sh
     if command -v chromedriver &>/dev/null; then
       $STD apt remove -y chromium-driver
     fi
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shelfmark" "calibrain/shelfmark" "tarball" "latest" "/opt/shelfmark"
+    restore_backup
     RELEASE_VERSION=$(cat "$HOME/.shelfmark")
 
     msg_info "Updating Shelfmark"
@@ -74,7 +75,6 @@ function update_script() {
     else
       $STD uv sync --active --locked --no-default-groups
     fi
-    mv /opt/start.sh.bak /opt/shelfmark/start.sh
     msg_ok "Updated Shelfmark"
 
     msg_info "Starting Service(s)"

--- a/ct/shlink.sh
+++ b/ct/shlink.sh
@@ -35,19 +35,11 @@ function update_script() {
     systemctl stop shlink
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/shlink/.env /opt/shlink.env.bak
-    cp -r /opt/shlink/data /opt/shlink_data_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/shlink/.env /opt/shlink/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shlink" "shlinkio/shlink" "prebuild" "latest" "/opt/shlink" "shlink*_php8.5_dist.zip"
 
-    msg_info "Restoring Data"
-    cp /opt/shlink.env.bak /opt/shlink/.env
-    rm -f /opt/shlink.env.bak
-    cp -r /opt/shlink_data_backup/. /opt/shlink/data
-    rm -rf /opt/shlink_data_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Updating Application"
     cd /opt/shlink

--- a/ct/slskd.sh
+++ b/ct/slskd.sh
@@ -36,19 +36,17 @@ function update_script() {
     [[ -f /etc/systemd/system/soularr.service ]] && systemctl stop soularr.timer soularr.service
     msg_ok "Stopped Service(s)"
 
-    msg_info "Backing up config"
-    cp /opt/slskd/config/slskd.yml /opt/slskd.yml.bak
-    msg_ok "Backed up config"
+    create_backup /opt/slskd/config/slskd.yml
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Slskd" "slskd/slskd" "prebuild" "latest" "/opt/slskd" "slskd-*-linux-$(arch_resolve "x64" "arm64").zip"
 
-    msg_info "Restoring config"
-    mv /opt/slskd.yml.bak /opt/slskd/config/slskd.yml
+    restore_backup
 
+    msg_info "Migrating config"
     # Migrate 0.25.0 breaking config key renames
     sed -i 's/^global:/transfers:/' /opt/slskd/config/slskd.yml
     sed -i 's/^integration:/integrations:/' /opt/slskd/config/slskd.yml
-    msg_ok "Restored config"
+    msg_ok "Migrated config"
 
     msg_info "Starting Service(s)"
     systemctl start slskd
@@ -63,13 +61,11 @@ function update_script() {
       msg_ok "Stopped Timer and Service"
     fi
 
-    msg_info "Backing up Soularr config"
-    cp /opt/soularr/config.ini /opt/soularr_config.ini.bak
-    cp /opt/soularr/run.sh /opt/soularr_run.sh.bak
-    msg_ok "Backed up Soularr config"
+    create_backup /opt/soularr/config.ini /opt/soularr/run.sh
 
     PYTHON_VERSION="3.11" setup_uv
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Soularr" "mrusse/soularr" "tarball" "latest" "/opt/soularr"
+    restore_backup
     msg_info "Updating Soularr"
     cd /opt/soularr
     $STD uv venv -c venv
@@ -77,11 +73,6 @@ function update_script() {
     $STD uv pip install -r requirements.txt
     deactivate
     msg_ok "Updated Soularr"
-
-    msg_info "Restoring Soularr config"
-    mv /opt/soularr_config.ini.bak /opt/soularr/config.ini
-    mv /opt/soularr_run.sh.bak /opt/soularr/run.sh
-    msg_ok "Restored Soularr config"
 
     msg_info "Starting Soularr Timer"
     systemctl restart soularr.timer

--- a/ct/solidtime.sh
+++ b/ct/solidtime.sh
@@ -35,19 +35,11 @@ function update_script() {
     systemctl stop caddy
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/solidtime/.env /opt/solidtime.env.bak
-    cp -r /opt/solidtime/storage /opt/solidtime_storage_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/solidtime/.env /opt/solidtime/storage
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "solidtime" "solidtime-io/solidtime" "tarball"
 
-    msg_info "Restoring Data"
-    cp /opt/solidtime.env.bak /opt/solidtime/.env
-    rm -f /opt/solidtime.env.bak
-    cp -r /opt/solidtime_storage_backup/. /opt/solidtime/storage
-    rm -rf /opt/solidtime_storage_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Updating Application"
     cd /opt/solidtime

--- a/ct/soulsync.sh
+++ b/ct/soulsync.sh
@@ -37,12 +37,11 @@ function update_script() {
     systemctl stop soulsync
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    mv /opt/soulsync/config /opt/soulsync-config.bak
-    mv /opt/soulsync/data /opt/soulsync-data.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/soulsync/config /opt/soulsync/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "soulsync" "Nezreka/SoulSync" "tarball"
+
+    restore_backup
 
     msg_info "Updating Python Dependencies"
     cd /opt/soulsync
@@ -55,9 +54,6 @@ function update_script() {
     $STD npm ci
     $STD npm run build
     msg_ok "Built WebUI"
-
-    mv /opt/soulsync-config.bak /opt/soulsync/config
-    mv /opt/soulsync-data.bak /opt/soulsync/data
 
     msg_info "Starting Service"
     systemctl start soulsync

--- a/ct/sparkyfitness.sh
+++ b/ct/sparkyfitness.sh
@@ -35,17 +35,11 @@ function update_script() {
     systemctl stop sparkyfitness-server nginx
     msg_ok "Stopped Services"
 
-    msg_info "Backing up data"
-    mkdir -p /opt/sparkyfitness_backup
-    if [[ -d /opt/sparkyfitness/SparkyFitnessServer/uploads ]]; then
-      cp -r /opt/sparkyfitness/SparkyFitnessServer/uploads /opt/sparkyfitness_backup/
-    fi
-    if [[ -d /opt/sparkyfitness/SparkyFitnessServer/backup ]]; then
-      cp -r /opt/sparkyfitness/SparkyFitnessServer/backup /opt/sparkyfitness_backup/
-    fi
-    msg_ok "Backed up data"
+    create_backup /opt/sparkyfitness/SparkyFitnessServer/uploads /opt/sparkyfitness/SparkyFitnessServer/backup
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "sparkyfitness" "CodeWithCJ/SparkyFitness" "tarball"
+
+    restore_backup
 
     PNPM_VERSION="$(jq -r '.packageManager | split("@")[1]' /opt/sparkyfitness/package.json)"
     NODE_VERSION="25" NODE_MODULE="pnpm@${PNPM_VERSION}" setup_nodejs
@@ -95,11 +89,6 @@ function update_script() {
 EOF
     systemctl daemon-reload
     msg_ok "Refreshed SparkyFitness Service"
-
-    msg_info "Restoring data"
-    cp -r /opt/sparkyfitness_backup/. /opt/sparkyfitness/SparkyFitnessServer/
-    rm -rf /opt/sparkyfitness_backup
-    msg_ok "Restored data"
 
     msg_info "Starting Services"
     $STD systemctl start sparkyfitness-server nginx

--- a/ct/spliit.sh
+++ b/ct/spliit.sh
@@ -35,16 +35,11 @@ function update_script() {
     systemctl stop spliit
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    rm -f /opt/spliit.env.bak
-    cp /opt/spliit/.env /opt/spliit.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/spliit/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "spliit" "spliit-app/spliit" "tarball"
 
-    msg_info "Restoring Configuration"
-    cp /opt/spliit.env.bak /opt/spliit/.env
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Building Application"
     cd /opt/spliit

--- a/ct/spoolman.sh
+++ b/ct/spoolman.sh
@@ -36,18 +36,16 @@ function update_script() {
     systemctl stop spoolman
     msg_ok "Stopped Service"
 
-    msg_info "Creating Backup"
-    [ -d /opt/spoolman_bak ] && rm -rf /opt/spoolman_bak
-    mv /opt/spoolman /opt/spoolman_bak
-    msg_ok "Created Backup"
+    create_backup /opt/spoolman/.env
 
-    fetch_and_deploy_gh_release "spoolman" "Donkie/Spoolman" "prebuild" "latest" "/opt/spoolman" "spoolman.zip"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "spoolman" "Donkie/Spoolman" "prebuild" "latest" "/opt/spoolman" "spoolman.zip"
+
+    restore_backup
 
     msg_info "Updating Spoolman"
     cd /opt/spoolman
     $STD uv sync --locked --no-install-project
     $STD uv sync --locked
-    cp /opt/spoolman_bak/.env /opt/spoolman
     sed -i 's|^ExecStart=.*|ExecStart=/usr/bin/bash /opt/spoolman/scripts/start.sh|' /etc/systemd/system/spoolman.service
     msg_ok "Updated Spoolman"
 

--- a/ct/storyteller.sh
+++ b/ct/storyteller.sh
@@ -37,15 +37,11 @@ function update_script() {
     systemctl stop storyteller
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/storyteller/.env /opt/storyteller_env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/storyteller/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gl_release "storyteller" "storyteller-platform/storyteller" "tarball" "latest" "/opt/storyteller" "" "web-v2"
 
-    msg_info "Restoring Configuration"
-    mv /opt/storyteller_env.bak /opt/storyteller/.env
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Rebuilding Storyteller"
     cd /opt/storyteller

--- a/ct/tandoor.sh
+++ b/ct/tandoor.sh
@@ -43,17 +43,15 @@ function update_script() {
     systemctl stop tandoor
     msg_ok "Stopped Service"
 
-    msg_info "Creating Backup"
-    mv /opt/tandoor /opt/tandoor.bak
-    msg_ok "Backup Created"
+    create_backup /opt/tandoor/config /opt/tandoor/api /opt/tandoor/mediafiles /opt/tandoor/staticfiles /opt/tandoor/.env
 
     NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
     PYTHON_VERSION="3.13" setup_uv
-    fetch_and_deploy_gh_release "tandoor" "TandoorRecipes/recipes" "tarball" "latest" "/opt/tandoor"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "tandoor" "TandoorRecipes/recipes" "tarball" "latest" "/opt/tandoor"
+
+    restore_backup
 
     msg_info "Updating Tandoor"
-    cp -r /opt/tandoor.bak/{config,api,mediafiles,staticfiles} /opt/tandoor/
-    mv /opt/tandoor.bak/.env /opt/tandoor/.env
     cd /opt/tandoor
     $STD uv venv --clear .venv --python=python3
     $STD uv pip install -r requirements.txt --python .venv/bin/python
@@ -69,7 +67,6 @@ EOF
     cd /opt/tandoor
     $STD /opt/tandoor/.venv/bin/python manage.py migrate
     $STD /opt/tandoor/.venv/bin/python manage.py collectstatic --no-input
-    rm -rf /opt/tandoor.bak
     msg_ok "Updated Tandoor"
 
     msg_info "Starting Service"

--- a/ct/tautulli.sh
+++ b/ct/tautulli.sh
@@ -36,12 +36,11 @@ function update_script() {
     systemctl stop tautulli
     msg_ok "Stopped Service"
 
-    msg_info "Backing up config and database"
-    cp /opt/Tautulli/config.ini /opt/tautulli_config.ini.backup
-    cp /opt/Tautulli/tautulli.db /opt/tautulli.db.backup
-    msg_ok "Backed up config and database"
+    create_backup /opt/Tautulli/config.ini /opt/Tautulli/tautulli.db
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Tautulli" "Tautulli/Tautulli" "tarball"
+
+    restore_backup
 
     msg_info "Updating Tautulli"
     cd /opt/Tautulli
@@ -54,12 +53,6 @@ function update_script() {
     $STD uv pip install pyopenssl
     $STD uv pip install "setuptools<81"
     msg_ok "Updated Tautulli"
-
-    msg_info "Restoring config and database"
-    cp /opt/tautulli_config.ini.backup /opt/Tautulli/config.ini
-    cp /opt/tautulli.db.backup /opt/Tautulli/tautulli.db
-    rm -f /opt/{tautulli_config.ini.backup,tautulli.db.backup}
-    msg_ok "Restored config and database"
 
     msg_info "Starting Service"
     systemctl start tautulli

--- a/ct/teable.sh
+++ b/ct/teable.sh
@@ -36,15 +36,11 @@ function update_script() {
     systemctl stop teable
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /opt/teable/.env /opt/teable.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/teable/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "teable" "teableio/teable" "tarball"
 
-    msg_info "Restoring Configuration"
-    mv /opt/teable.env.bak /opt/teable/.env
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Rebuilding Teable"
     cd /opt/teable

--- a/ct/teddycloud.sh
+++ b/ct/teddycloud.sh
@@ -34,16 +34,11 @@ function update_script() {
     systemctl stop teddycloud
     msg_ok "Stopped Service"
 
-    msg_info "Creating backup"
-    mv /opt/teddycloud /opt/teddycloud_bak
-    msg_ok "Backup created"
+    create_backup /opt/teddycloud/certs /opt/teddycloud/config /opt/teddycloud/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "teddycloud" "toniebox-reverse-engineering/teddycloud" "prebuild" "latest" "/opt/teddycloud" "teddycloud.amd64.release*.zip"
 
-    msg_info "Restoring data"
-    cp -R /opt/teddycloud_bak/certs /opt/teddycloud_bak/config /opt/teddycloud_bak/data /opt/teddycloud
-    rm -rf /opt/teddycloud_bak
-    msg_ok "Data restored"
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start teddycloud

--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -143,12 +143,11 @@ EOF
     fi
     msg_ok "Migrated Configuration"
 
-    msg_info "Backing up Data"
-    cp -r /opt/termix/data /opt/termix_data_backup
-    cp -r /opt/termix/uploads /opt/termix_uploads_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/termix/data /opt/termix/uploads
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "termix" "Termix-SSH/Termix" "tarball"
+
+    restore_backup
 
     msg_info "Recreating Directories"
     mkdir -p /opt/termix/html \
@@ -176,12 +175,6 @@ EOF
     $STD npm rebuild better-sqlite3 bcryptjs --force
     $STD npm cache clean --force
     msg_ok "Set up Production Dependencies"
-
-    msg_info "Restoring Data"
-    cp -r /opt/termix_data_backup /opt/termix/data
-    cp -r /opt/termix_uploads_backup /opt/termix/uploads
-    rm -rf /opt/termix_data_backup /opt/termix_uploads_backup
-    msg_ok "Restored Data"
 
     msg_info "Updating Frontend Files"
     rm -rf /opt/termix/html/*

--- a/ct/tianji.sh
+++ b/ct/tianji.sh
@@ -36,12 +36,11 @@ function update_script() {
     systemctl stop tianji
     msg_ok "Stopped Service"
 
-    msg_info "Backing up data"
-    cp /opt/tianji/src/server/.env /opt/.env
-    mv /opt/tianji /opt/tianji_bak
-    msg_ok "Backed up data"
+    create_backup /opt/tianji/src/server/.env
 
-    fetch_and_deploy_gh_release "tianji" "msgbyte/tianji" "tarball"
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "tianji" "msgbyte/tianji" "tarball"
+
+    restore_backup
 
     msg_info "Updating Tianji"
     cd /opt/tianji
@@ -52,10 +51,8 @@ function update_script() {
     mkdir -p ./src/server/public
     cp -r ./geo ./src/server/public
     $STD pnpm build:server
-    mv /opt/.env /opt/tianji/src/server/.env
     cd src/server
     $STD pnpm db:migrate:apply
-    rm -rf /opt/tianji_bak
     rm -rf /opt/tianji/src/client
     rm -rf /opt/tianji/website
     rm -rf /opt/tianji/reporter

--- a/ct/transmute.sh
+++ b/ct/transmute.sh
@@ -40,12 +40,11 @@ function update_script() {
     systemctl stop transmute
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp /opt/transmute/backend/.env /opt/transmute.env.bak
-    cp -r /opt/transmute/data /opt/transmute_data_bak
-    msg_ok "Backed up Data"
+    create_backup /opt/transmute/backend/.env /opt/transmute/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "transmute" "transmute-app/transmute" "tarball"
+
+    restore_backup
 
     msg_info "Updating Python Dependencies"
     cd /opt/transmute
@@ -59,12 +58,6 @@ function update_script() {
     $STD npm run build
     msg_ok "Rebuilt Frontend"
 
-    msg_info "Restoring Data"
-    cp /opt/transmute.env.bak /opt/transmute/backend/.env
-    cp -r /opt/transmute_data_bak/. /opt/transmute/data/
-    rm -f /opt/transmute.env.bak
-    rm -rf /opt/transmute_data_bak
-    msg_ok "Restored Data"
 
     msg_info "Starting Service"
     systemctl start transmute

--- a/ct/tubearchivist.sh
+++ b/ct/tubearchivist.sh
@@ -35,11 +35,11 @@ function update_script() {
     systemctl stop tubearchivist tubearchivist-celery tubearchivist-beat
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/tubearchivist/.env /opt/tubearchivist_env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/tubearchivist/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "tubearchivist" "tubearchivist/tubearchivist" "tarball"
+
+    restore_backup
 
     msg_info "Rebuilding Tube Archivist"
     cd /opt/tubearchivist/frontend
@@ -56,7 +56,6 @@ function update_script() {
     msg_ok "Rebuilt Tube Archivist"
 
     msg_info "Restoring Configuration"
-    mv /opt/tubearchivist_env.bak /opt/tubearchivist/.env
     sed -i 's|^TA_APP_DIR=/opt/tubearchivist$|TA_APP_DIR=/opt/tubearchivist/backend|' /opt/tubearchivist/.env
     sed -i 's|^TA_CACHE_DIR=/opt/tubearchivist/cache$|TA_CACHE_DIR=/cache|' /opt/tubearchivist/.env
     sed -i 's|^TA_MEDIA_DIR=/opt/tubearchivist/media$|TA_MEDIA_DIR=/youtube|' /opt/tubearchivist/.env

--- a/ct/umami.sh
+++ b/ct/umami.sh
@@ -34,9 +34,9 @@ function update_script() {
     systemctl stop umami
     msg_ok "Stopped Service"
 
-    mv /opt/umami/.env /opt/.env.bak
+    create_backup /opt/umami/.env
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "umami" "umami-software/umami" "tarball"
-    mv /opt/.env.bak /opt/umami/.env
+    restore_backup
 
     msg_info "Updating Umami"
     cd /opt/umami

--- a/ct/umlautadaptarr.sh
+++ b/ct/umlautadaptarr.sh
@@ -34,9 +34,9 @@ function update_script() {
     systemctl stop umlautadaptarr
     msg_ok "Stopped Service"
 
-    cp /opt/UmlautAdaptarr/appsettings.json /opt/UmlautAdaptarr/appsettings.json.bak
+    create_backup /opt/UmlautAdaptarr/appsettings.json
     fetch_and_deploy_gh_release "UmlautAdaptarr" "PCJones/Umlautadaptarr" "prebuild" "latest" "/opt/UmlautAdaptarr" "linux-x64.zip"
-    cp /opt/UmlautAdaptarr/appsettings.json.bak /opt/UmlautAdaptarr/appsettings.json
+    restore_backup
 
     msg_info "Starting Service"
     systemctl start umlautadaptarr

--- a/ct/wallabag.sh
+++ b/ct/wallabag.sh
@@ -38,16 +38,11 @@ function update_script() {
     systemctl stop nginx php8.3-fpm
     msg_ok "Stopped Services"
 
-    msg_info "Creating Backup"
-    cp /opt/wallabag/app/config/parameters.yml /tmp/wallabag_parameters.yml.bak
-    msg_ok "Created Backup"
+    create_backup /opt/wallabag/app/config/parameters.yml
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wallabag" "wallabag/wallabag" "prebuild" "latest" "/opt/wallabag" "wallabag-*.tar.gz"
 
-    msg_info "Restoring Configuration"
-    cp /tmp/wallabag_parameters.yml.bak /opt/wallabag/app/config/parameters.yml
-    rm -f /tmp/wallabag_parameters.yml.bak
-    msg_ok "Restored Configuration"
+    restore_backup
 
     msg_info "Running Migrations"
     cd /opt/wallabag

--- a/ct/wealthfolio.sh
+++ b/ct/wealthfolio.sh
@@ -39,19 +39,12 @@ function update_script() {
     systemctl stop wealthfolio
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -r /opt/wealthfolio_data /opt/wealthfolio_data_backup
-    cp /opt/wealthfolio/.env /opt/wealthfolio_env_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/wealthfolio_data /opt/wealthfolio/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wealthfolio" "wealthfolio/wealthfolio" "prebuild" "latest" "/opt/wealthfolio" "wealthfolio-server-*-linux-amd64.tar.gz"
-    install -m 755 /opt/wealthfolio/wealthfolio-server /usr/local/bin/wealthfolio-server
 
-    msg_info "Restoring Data"
-    cp -r /opt/wealthfolio_data_backup/. /opt/wealthfolio_data
-    cp /opt/wealthfolio_env_backup /opt/wealthfolio/.env
-    rm -rf /opt/wealthfolio_data_backup /opt/wealthfolio_env_backup
-    msg_ok "Restored Data"
+    restore_backup
+    install -m 755 /opt/wealthfolio/wealthfolio-server /usr/local/bin/wealthfolio-server
 
     msg_info "Starting Service"
     systemctl start wealthfolio

--- a/ct/web-check.sh
+++ b/ct/web-check.sh
@@ -34,16 +34,12 @@ function update_script() {
     systemctl stop web-check
     msg_ok "Stopped Service"
 
-    msg_info "Creating backup"
-    mv /opt/web-check/.env /opt
-    msg_ok "Created backup"
+    create_backup /opt/web-check/.env
 
     NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "web-check" "Lissy93/web-check" "tarball"
 
-    msg_info "Restoring backup"
-    mv /opt/.env /opt/web-check
-    msg_ok "Restored backup"
+    restore_backup
 
     msg_info "Building Web-Check"
     cd /opt/web-check 

--- a/ct/webtrees.sh
+++ b/ct/webtrees.sh
@@ -36,17 +36,12 @@ function update_script() {
     systemctl stop caddy php${PHP_VER}-fpm
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -r /opt/webtrees/data /opt/webtrees_data_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/webtrees/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "webtrees" "fisharebest/webtrees" "prebuild" "latest" "/opt/webtrees" "webtrees-*.zip"
 
-    msg_info "Restoring Data"
-    cp -r /opt/webtrees_data_backup/. /opt/webtrees/data
-    rm -rf /opt/webtrees_data_backup
+    restore_backup
     chown -R www-data:www-data /opt/webtrees
-    msg_ok "Restored Data"
 
     msg_info "Starting Service"
     systemctl start caddy php${PHP_VER}-fpm

--- a/ct/wishlist.sh
+++ b/ct/wishlist.sh
@@ -35,15 +35,12 @@ function update_script() {
     systemctl stop wishlist
     msg_ok "Stopped Service"
 
-    msg_info "Creating Backup"
-    mkdir -p /opt/wishlist-backup
-    cp /opt/wishlist/.env /opt/wishlist-backup/.env
-    cp -a /opt/wishlist/uploads /opt/wishlist-backup
-    cp -a /opt/wishlist/data /opt/wishlist-backup
-    msg_ok "Created Backup"
+    create_backup /opt/wishlist/.env /opt/wishlist/uploads /opt/wishlist/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "wishlist" "cmintey/wishlist" "tarball"
     LATEST_APP_VERSION=$(get_latest_github_release "cmintey/wishlist")
+
+    restore_backup
 
     msg_info "Updating Wishlist"
     cd /opt/wishlist
@@ -56,13 +53,6 @@ function update_script() {
     $STD pnpm run build
     $STD pnpm prune --prod
     chmod +x /opt/wishlist/entrypoint.sh
-
-    msg_info "Restoring Backup"
-    cp /opt/wishlist-backup/.env /opt/wishlist/.env
-    cp -a /opt/wishlist-backup/uploads /opt/wishlist
-    cp -a /opt/wishlist-backup/data /opt/wishlist
-    rm -rf /opt/wishlist-backup
-    msg_ok "Restored Backup"
     
     msg_ok "Updated Wishlist"
     msg_info "Starting Service"

--- a/ct/writefreely.sh
+++ b/ct/writefreely.sh
@@ -35,19 +35,11 @@ function update_script() {
     systemctl stop writefreely
     msg_ok "Stopped Services"
 
-    msg_info "Creating Backup"
-    mkdir -p /tmp/writefreely_backup
-    cp /opt/writefreely/keys /tmp/writefreely_backup/ 2>/dev/null
-    cp /opt/writefreely/config.ini /tmp/writefreely_backup/ 2>/dev/null
-    msg_ok "Created Backup"
+    create_backup /opt/writefreely/keys /opt/writefreely/config.ini
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "writefreely" "writefreely/writefreely" "prebuild" "latest" "/opt/writefreely" "writefreely_*_linux_$(arch_resolve).tar.gz"
 
-    msg_info "Restoring Data"
-    cp /tmp/writefreely_backup/config.ini /opt/writefreely/ 2>/dev/null
-    cp /tmp/writefreely_backup/keys/* /opt/writefreely/keys/ 2>/dev/null
-    rm -rf /tmp/writefreely_backup
-    msg_ok "Restored Data"
+    restore_backup
 
     msg_info "Running Post-Update Tasks"
     cd /opt/writefreely

--- a/ct/xyops.sh
+++ b/ct/xyops.sh
@@ -35,12 +35,11 @@ function update_script() {
     systemctl stop xyops
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Data"
-    cp -r /opt/xyops/data /opt/xyops_data_backup
-    cp -r /opt/xyops/conf /opt/xyops_conf_backup
-    msg_ok "Backed up Data"
+    create_backup /opt/xyops/data /opt/xyops/conf
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "xyops" "pixlcore/xyops" "tarball"
+
+    restore_backup
 
     msg_info "Rebuilding Application"
     cd /opt/xyops
@@ -48,12 +47,6 @@ function update_script() {
     $STD node bin/build.js dist
     chmod 644 /opt/xyops/node_modules/useragent-ng/lib/regexps.js
     msg_ok "Rebuilt Application"
-
-    msg_info "Restoring Data"
-    cp -r /opt/xyops_data_backup/. /opt/xyops/data
-    cp -r /opt/xyops_conf_backup/. /opt/xyops/conf
-    rm -rf /opt/xyops_data_backup /opt/xyops_conf_backup
-    msg_ok "Restored Data"
 
     msg_info "Starting Service"
     systemctl start xyops

--- a/ct/yamtrack.sh
+++ b/ct/yamtrack.sh
@@ -36,21 +36,16 @@ function update_script() {
     systemctl stop yamtrack yamtrack-celery
     msg_ok "Stopped Services"
 
-    msg_info "Backing up Data"
-    cp /opt/yamtrack/src/.env /opt/yamtrack_env.bak
-    msg_ok "Backed up Data"
+    create_backup /opt/yamtrack/src/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "yamtrack" "FuzzyGrim/Yamtrack" "tarball"
+
+    restore_backup
 
     msg_info "Installing Python Dependencies"
     cd /opt/yamtrack
     $STD uv sync --locked
     msg_ok "Installed Python Dependencies"
-
-    msg_info "Restoring Data"
-    cp /opt/yamtrack_env.bak /opt/yamtrack/src/.env
-    rm -f /opt/yamtrack_env.bak
-    msg_ok "Restored Data"
 
     msg_info "Updating Yamtrack"
     cd /opt/yamtrack/src

--- a/ct/yourls.sh
+++ b/ct/yourls.sh
@@ -35,17 +35,12 @@ function update_script() {
     systemctl stop nginx
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp -r /opt/yourls/user /opt/yourls_user.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/yourls/user
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "yourls" "YOURLS/YOURLS" "tarball"
-    chown -R www-data:www-data /opt/yourls
 
-    msg_info "Restoring Configuration"
-    cp -r /opt/yourls_user.bak/. /opt/yourls/user/
-    rm -rf /opt/yourls_user.bak
-    msg_ok "Restored Configuration"
+    restore_backup
+    chown -R www-data:www-data /opt/yourls
 
     msg_info "Starting Service"
     systemctl start nginx

--- a/ct/zerobyte.sh
+++ b/ct/zerobyte.sh
@@ -35,13 +35,13 @@ function update_script() {
     systemctl stop zerobyte
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /opt/zerobyte/.env /opt/zerobyte.env.bak
-    msg_ok "Backed up Configuration"
+    create_backup /opt/zerobyte/.env
     
     ensure_dependencies git
     NODE_VERSION="24" setup_nodejs
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "zerobyte" "nicotsx/zerobyte" "tarball"
+
+    restore_backup
 
     msg_info "Building Zerobyte"
     export NODE_OPTIONS="--max-old-space-size=3072"
@@ -49,11 +49,6 @@ function update_script() {
     $STD bun install
     $STD node ./node_modules/vite/bin/vite.js build
     msg_ok "Built Zerobyte"
-
-    msg_info "Restoring Configuration"
-    cp /opt/zerobyte.env.bak /opt/zerobyte/.env
-    rm -f /opt/zerobyte.env.bak
-    msg_ok "Restored Configuration"
 
     msg_info "Starting Service"
     systemctl start zerobyte

--- a/ct/zigbee2mqtt.sh
+++ b/ct/zigbee2mqtt.sh
@@ -37,24 +37,24 @@ function update_script() {
 
     msg_info "Creating Backup"
     ensure_dependencies zstd
-    mkdir -p /opt/{backups,z2m_backup}
+    mkdir -p /opt/backups
     BACKUP_VERSION="$(<"$HOME/.zigbee2mqtt")"
     BACKUP_FILE="/opt/backups/${APP}_backup_${BACKUP_VERSION}.tar.zst"
     $STD tar -cf - -C /opt zigbee2mqtt | zstd -q -o "$BACKUP_FILE"
     ls -t /opt/backups/${APP}_backup_*.tar.zst 2>/dev/null | tail -n +6 | xargs -r rm -f
-    mv /opt/zigbee2mqtt/data /opt/z2m_backup/data
     msg_ok "Backup Created (${BACKUP_VERSION})"
+
+    create_backup /opt/zigbee2mqtt/data
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "Zigbee2MQTT" "Koenkk/zigbee2mqtt" "tarball" "latest" "/opt/zigbee2mqtt"
 
+    restore_backup
+
     msg_info "Updating Zigbee2MQTT"
-    rm -rf /opt/zigbee2mqtt/data
-    mv /opt/z2m_backup/data /opt/zigbee2mqtt
     cd /opt/zigbee2mqtt
     grep -q "^packageImportMethod" ./pnpm-workspace.yaml 2>/dev/null || echo "packageImportMethod: hardlink" >>./pnpm-workspace.yaml
     $STD pnpm install --frozen-lockfile
     $STD pnpm build
-    rm -rf /opt/z2m_backup
     msg_ok "Updated Zigbee2MQTT"
 
     msg_info "Starting Service"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Refactors a large set of CT update scripts to use the shared `create_backup`/`restore_backup` helpers instead of per-script manual copy/move logic. This removes duplicated backup code, temp-file cleanup paths, and inconsistent restore behavior while keeping data/config restoration in the correct order for build/deploy steps. Several update paths were also aligned to use `CLEAN_INSTALL=1` during release deploys, with minor message/comment tweaks where restore timing is important.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
