### PR TITLE
core: add OS mismatch guard for container updates

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -3832,6 +3832,55 @@ runtime_script_status_guard() {
 }
 
 # ------------------------------------------------------------------------------
+# check_container_os_guard()
+#
+# - Compares the container OS (/etc/os-release) with the script's recommended
+#   var_os/var_version before running update_script
+# - On mismatch: interactive runs ask whether to continue (default: no);
+#   headless runs (PHS_SILENT=1 / no tty) abort instead of updating on an
+#   unsupported base and leaving the app broken mid-update
+# - Bypass via var_ignore_os_mismatch=1|yes|true|on (still warns, but continues)
+# ------------------------------------------------------------------------------
+check_container_os_guard() {
+  local rec_os="${var_os:-}" rec_ver="${var_version:-}"
+  rec_os="${rec_os,,}"
+  [[ -z "$rec_os" || -z "$rec_ver" ]] && return 0
+  [[ -r /etc/os-release ]] || return 0
+
+  local cur_os cur_ver
+  cur_os="$(. /etc/os-release 2>/dev/null; echo "${ID:-}")"
+  cur_ver="$(. /etc/os-release 2>/dev/null; echo "${VERSION_ID:-}")"
+  cur_os="${cur_os,,}"
+  [[ -z "$cur_os" || -z "$cur_ver" ]] && return 0
+
+  # Exact version or prefix on a dot boundary (e.g. alpine 3.22 matches 3.22.1)
+  if [[ "$cur_os" == "$rec_os" ]] && [[ "$cur_ver" == "$rec_ver" || "$cur_ver" == "$rec_ver".* ]]; then
+    return 0
+  fi
+
+  case "${var_ignore_os_mismatch:-}" in
+  1 | yes | true | on)
+    msg_warn "Container OS is ${cur_os} ${cur_ver} but the script recommends ${rec_os} ${rec_ver} — continuing via var_ignore_os_mismatch."
+    return 0
+    ;;
+  esac
+
+  if [[ "${PHS_SILENT:-0}" != "1" ]] && command -v whiptail &>/dev/null && [ -t 0 ] && [[ "$TERM" != "dumb" ]]; then
+    if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "OS VERSION MISMATCH" --yesno \
+      "This container runs ${cur_os} ${cur_ver}, but this script now targets ${rec_os} ${rec_ver}.\n\nUpdating on the older base OS may fail or leave ${APP:-the application} broken (e.g. required runtime versions are not available).\n\nRecommended: create a new ${rec_os} ${rec_ver} container and migrate your data.\n\nContinue anyway?" 16 70; then
+      msg_warn "Continuing update on ${cur_os} ${cur_ver} despite recommended ${rec_os} ${rec_ver}."
+      return 0
+    fi
+    msg_error "Update cancelled: container OS ${cur_os} ${cur_ver} does not match the recommended ${rec_os} ${rec_ver}."
+    return 1
+  fi
+
+  msg_error "Container OS ${cur_os} ${cur_ver} does not match the recommended ${rec_os} ${rec_ver} — skipping update."
+  msg_error "Recreate the container on ${rec_os} ${rec_ver}, or set var_ignore_os_mismatch=1 to bypass this check."
+  return 1
+}
+
+# ------------------------------------------------------------------------------
 # start()
 #
 # - Entry point of script
@@ -3852,6 +3901,7 @@ start() {
     ensure_profile_loaded
     get_lxc_ip
     runtime_script_status_guard update || return 0
+    check_container_os_guard || return 0
     update_script
     run_addon_updates
     update_motd_ip
@@ -3863,6 +3913,7 @@ start() {
     ensure_profile_loaded
     get_lxc_ip
     runtime_script_status_guard update || return 0
+    check_container_os_guard || return 0
     update_script
     run_addon_updates
     update_motd_ip
@@ -3893,6 +3944,7 @@ start() {
     ensure_profile_loaded
     get_lxc_ip
     runtime_script_status_guard update || return 0
+    check_container_os_guard || return 0
     update_script
     run_addon_updates
     update_motd_ip

--- a/misc/build.func
+++ b/misc/build.func
@@ -3860,23 +3860,45 @@ check_container_os_guard() {
 
   case "${var_ignore_os_mismatch:-}" in
   1 | yes | true | on)
-    msg_warn "Container OS is ${cur_os} ${cur_ver} but the script recommends ${rec_os} ${rec_ver} — continuing via var_ignore_os_mismatch."
+    msg_warn "Container OS is ${cur_os} ${cur_ver} but the script recommends ${rec_os} ${rec_ver} — continuing via var_ignore_os_mismatch (may break, no support)."
     return 0
     ;;
   esac
 
+  # Persistent opt-out: stores the ignored target version, so the question
+  # comes back once the script targets a newer OS again
+  local ignore_file="/root/.helper-scripts-ignoreOSupdate"
+  if [[ -f "$ignore_file" && "$(cat "$ignore_file" 2>/dev/null)" == "${rec_os} ${rec_ver}" ]]; then
+    msg_warn "Container OS is ${cur_os} ${cur_ver} but the script recommends ${rec_os} ${rec_ver} — continuing (previously ignored via ${ignore_file}, may break, no support)."
+    return 0
+  fi
+
   if [[ "${PHS_SILENT:-0}" != "1" ]] && command -v whiptail &>/dev/null && [ -t 0 ] && [[ "$TERM" != "dumb" ]]; then
-    if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "OS VERSION MISMATCH" --yesno \
-      "This container runs ${cur_os} ${cur_ver}, but this script now targets ${rec_os} ${rec_ver}.\n\nUpdating on the older base OS may fail or leave ${APP:-the application} broken (e.g. required runtime versions are not available).\n\nRecommended: upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again.\n\nContinue anyway?" 16 70; then
-      msg_warn "Continuing update on ${cur_os} ${cur_ver} despite recommended ${rec_os} ${rec_ver}."
+    local choice
+    choice=$(whiptail --backtitle "Proxmox VE Helper Scripts" --title "OS VERSION MISMATCH" --menu \
+      "This container runs ${cur_os} ${cur_ver}, but this script now targets ${rec_os} ${rec_ver}.\n\nUpdating on the older base OS may fail or leave ${APP:-the application} broken (e.g. required runtime versions are not available).\n\nRecommended: upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again.\n\nIf you continue anyway, it may break — no support is provided in that case.\n\nContinue anyway?" \
+      20 70 3 \
+      "1" "No  (cancel update)" \
+      "2" "Yes (continue this time)" \
+      "3" "Yes (continue and don't ask again)" \
+      --nocancel --default-item "1" 3>&1 1>&2 2>&3)
+    case "$choice" in
+    2)
+      msg_warn "Continuing update on ${cur_os} ${cur_ver} despite recommended ${rec_os} ${rec_ver} — may break, no support."
       return 0
-    fi
+      ;;
+    3)
+      echo "${rec_os} ${rec_ver}" >"$ignore_file"
+      msg_warn "Continuing update on ${cur_os} ${cur_ver}; OS check for ${rec_os} ${rec_ver} disabled via ${ignore_file} — may break, no support."
+      return 0
+      ;;
+    esac
     msg_error "Update cancelled: container OS ${cur_os} ${cur_ver} does not match the recommended ${rec_os} ${rec_ver}."
     return 1
   fi
 
   msg_error "Container OS ${cur_os} ${cur_ver} does not match the recommended ${rec_os} ${rec_ver} — skipping update."
-  msg_error "Upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again — or set var_ignore_os_mismatch=1 to bypass this check."
+  msg_error "Upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again — or bypass this check (may break, no support) with: echo \"${rec_os} ${rec_ver}\" > ${ignore_file}"
   return 1
 }
 

--- a/misc/build.func
+++ b/misc/build.func
@@ -3867,7 +3867,7 @@ check_container_os_guard() {
 
   # Persistent opt-out: stores the ignored target version, so the question
   # comes back once the script targets a newer OS again
-  local ignore_file="/root/.helper-scripts-ignoreOSupdate"
+  local ignore_file="/usr/local/community-scripts/ignore-os-mismatch"
   if [[ -f "$ignore_file" && "$(cat "$ignore_file" 2>/dev/null)" == "${rec_os} ${rec_ver}" ]]; then
     msg_warn "Container OS is ${cur_os} ${cur_ver} but the script recommends ${rec_os} ${rec_ver} — continuing (previously ignored via ${ignore_file}, may break, no support)."
     return 0
@@ -3888,6 +3888,7 @@ check_container_os_guard() {
       return 0
       ;;
     3)
+      mkdir -p "${ignore_file%/*}"
       echo "${rec_os} ${rec_ver}" >"$ignore_file"
       msg_warn "Continuing update on ${cur_os} ${cur_ver}; OS check for ${rec_os} ${rec_ver} disabled via ${ignore_file} — may break, no support."
       return 0

--- a/misc/build.func
+++ b/misc/build.func
@@ -3867,7 +3867,7 @@ check_container_os_guard() {
 
   if [[ "${PHS_SILENT:-0}" != "1" ]] && command -v whiptail &>/dev/null && [ -t 0 ] && [[ "$TERM" != "dumb" ]]; then
     if whiptail --backtitle "Proxmox VE Helper Scripts" --defaultno --title "OS VERSION MISMATCH" --yesno \
-      "This container runs ${cur_os} ${cur_ver}, but this script now targets ${rec_os} ${rec_ver}.\n\nUpdating on the older base OS may fail or leave ${APP:-the application} broken (e.g. required runtime versions are not available).\n\nRecommended: create a new ${rec_os} ${rec_ver} container and migrate your data.\n\nContinue anyway?" 16 70; then
+      "This container runs ${cur_os} ${cur_ver}, but this script now targets ${rec_os} ${rec_ver}.\n\nUpdating on the older base OS may fail or leave ${APP:-the application} broken (e.g. required runtime versions are not available).\n\nRecommended: upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again.\n\nContinue anyway?" 16 70; then
       msg_warn "Continuing update on ${cur_os} ${cur_ver} despite recommended ${rec_os} ${rec_ver}."
       return 0
     fi
@@ -3876,7 +3876,7 @@ check_container_os_guard() {
   fi
 
   msg_error "Container OS ${cur_os} ${cur_ver} does not match the recommended ${rec_os} ${rec_ver} — skipping update."
-  msg_error "Recreate the container on ${rec_os} ${rec_ver}, or set var_ignore_os_mismatch=1 to bypass this check."
+  msg_error "Upgrade the container OS to ${rec_os} ${rec_ver} first, then run this update again — or set var_ignore_os_mismatch=1 to bypass this check."
   return 1
 }
 


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
introduce check_container_os_guard to compare the containers /etc/os-release against the script's recommended var_os / var_version before running updates. On mismatch, interactive runs now prompt to continue (default no), while silent/headless runs abort to avoid partial breakage on unsupported bases. A bypass flag (`var_ignore_os_mismatch=1|yes|true|on`) was added, and the guard is wired into all update entry paths in _start_.

## 🔗 Related Issue

Related #15947

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
