### PR TITLE
Anytype: preserve default mongod.conf when configuring Anytype replica set

### DIFF
--- a/install/anytype-server-install.sh
+++ b/install/anytype-server-install.sh
@@ -16,7 +16,7 @@ update_os
 setup_mongodb
 
 msg_info "Configuring MongoDB Replica Set"
-cat <<EOF >/etc/mongod.conf
+cat <<EOF >>/etc/mongod.conf
 
 replication:
   replSetName: "rs0"


### PR DESCRIPTION


<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Overwriting /etc/mongod.conf with only the replication block wiped out storage.dbPath from the mongodb-org package default

## 🔗 Related Issue

Fixes #15952

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
