### PR TITLE
Cockpit: default to Debian 13, 45Drives now ships Trixie packages | little refactor

### DIFF
--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-4}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 

--- a/ct/cockpit.sh
+++ b/ct/cockpit.sh
@@ -33,6 +33,22 @@ function update_script() {
   $STD apt update
   $STD apt -y upgrade
   msg_ok "Updated ${APP} LXC"
+
+  if [[ ! -f /etc/apt/sources.list.d/45drives.sources ]]; then
+    [[ "$(arch_resolve)" == "arm64" ]] || read -r -p "Would you like to install 45Drives' cockpit-file-sharing, cockpit-identities, and cockpit-navigator now? <y/N> " prompt
+    if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
+      msg_info "Installing 45Drives' cockpit extensions"
+      setup_deb822_repo "45drives" \
+        "https://repo.45drives.com/key/gpg.asc" \
+        "https://repo.45drives.com/enterprise/debian" \
+        "$(get_os_info codename)" \
+        "main" \
+        "amd64"
+      $STD apt install -y cockpit-file-sharing cockpit-identities cockpit-navigator
+      msg_ok "Installed 45Drives' cockpit extensions"
+    fi
+  fi
+
   msg_ok "Updated successfully!"
   exit
 }

--- a/install/cockpit-install.sh
+++ b/install/cockpit-install.sh
@@ -15,42 +15,33 @@ network_check
 update_os
 
 msg_info "Installing Cockpit"
-source /etc/os-release
+CODENAME=$(get_os_info codename)
 cat <<EOF >/etc/apt/sources.list.d/debian-backports.sources
 Types: deb deb-src
 URIs: http://deb.debian.org/debian
-Suites: ${VERSION_CODENAME}-backports
+Suites: ${CODENAME}-backports
 Components: main
 Enabled: yes
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOF
 
 $STD apt update
-$STD apt install -t ${VERSION_CODENAME}-backports cockpit cracklib-runtime --no-install-recommends -y
+$STD apt install -t ${CODENAME}-backports cockpit cracklib-runtime --no-install-recommends -y
 sed -i "s/root//g" /etc/cockpit/disallowed-users
 msg_ok "Installed Cockpit"
 
 # 45Drives only publishes amd64 packages
 [[ "$(arch_resolve)" == "arm64" ]] || read -r -p "Would you like to install 45Drives' cockpit-file-sharing, cockpit-identities, and cockpit-navigator  <y/N> " prompt
 if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
-  install_45drives=true
-  if [[ "${VERSION_ID}" -ge 14 ]]; then
-    read -r -p "Debian ${VERSION_ID} is not officially supported by 45Drives yet, would you like to continue anyway? <y/N> " prompt
-    if [[ ! "${prompt,,}" =~ ^(y|yes)$ ]]; then
-      install_45drives=false
-    fi
-  fi
-  if [[ "$install_45drives" == "true" ]]; then
-    msg_info "Installing 45Drives' cockpit extensions"
-    setup_deb822_repo "45drives" \
-      "https://repo.45drives.com/key/gpg.asc" \
-      "https://repo.45drives.com/enterprise/debian" \
-      "${VERSION_CODENAME}" \
-      "main" \
-      "amd64"
-    $STD apt install -y cockpit-file-sharing cockpit-identities cockpit-navigator
-    msg_ok "Installed 45Drives' cockpit extensions"
-  fi
+  msg_info "Installing 45Drives' cockpit extensions"
+  setup_deb822_repo "45drives" \
+    "https://repo.45drives.com/key/gpg.asc" \
+    "https://repo.45drives.com/enterprise/debian" \
+    "${CODENAME}" \
+    "main" \
+    "amd64"
+  $STD apt install -y cockpit-file-sharing cockpit-identities cockpit-navigator
+  msg_ok "Installed 45Drives' cockpit extensions"
 fi
 
 motd_ssh

--- a/install/cockpit-install.sh
+++ b/install/cockpit-install.sh
@@ -34,7 +34,7 @@ msg_ok "Installed Cockpit"
 [[ "$(arch_resolve)" == "arm64" ]] || read -r -p "Would you like to install 45Drives' cockpit-file-sharing, cockpit-identities, and cockpit-navigator  <y/N> " prompt
 if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
   install_45drives=true
-  if [[ "${VERSION_ID}" -ge 13 ]]; then
+  if [[ "${VERSION_ID}" -ge 14 ]]; then
     read -r -p "Debian ${VERSION_ID} is not officially supported by 45Drives yet, would you like to continue anyway? <y/N> " prompt
     if [[ ! "${prompt,,}" =~ ^(y|yes)$ ]]; then
       install_45drives=false
@@ -45,7 +45,7 @@ if [[ "${prompt,,}" =~ ^(y|yes)$ ]]; then
     setup_deb822_repo "45drives" \
       "https://repo.45drives.com/key/gpg.asc" \
       "https://repo.45drives.com/enterprise/debian" \
-      "bookworm" \
+      "${VERSION_CODENAME}" \
       "main" \
       "amd64"
     $STD apt install -y cockpit-file-sharing cockpit-identities cockpit-navigator


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update Packages and minor fixed / refactores
Now it update 45Drive with update too and you can install it afterwards

## 🔗 Related Issue

Fixes #15981

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
