### PR TITLE
VM: fix machine type selection being ignored, VM always created as q35

### DIFF
--- a/vm/haos-vm.sh
+++ b/vm/haos-vm.sh
@@ -280,7 +280,7 @@ function extract_xz_with_pv() {
 function default_settings() {
   BRANCH="$stable"
   VMID=$(get_valid_nextid)
-  MACHINE="q35"
+  MACHINE=" -machine q35"
   FORMAT=""
   DISK_SIZE="32G"
   HN="haos-${BRANCH}"
@@ -598,7 +598,7 @@ msg_ok "${CL}${BL}${URL}${CL}"
 download_and_validate_xz "$URL" "$CACHE_FILE"
 
 msg_info "Creating Home Assistant OS VM shell"
-qm create $VMID -machine q35 -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_TYPE} \
+qm create $VMID${MACHINE} -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_TYPE} \
   -cores "$CORE_COUNT" -memory "$RAM_SIZE" -name "$HN" -tags community-script \
   -net0 "virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU" -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
 msg_ok "Created VM shell"

--- a/vm/umbrel-os-vm.sh
+++ b/vm/umbrel-os-vm.sh
@@ -273,7 +273,7 @@ function extract_xz_with_pv() {
 
 function default_settings() {
   VMID=$(get_valid_nextid)
-  MACHINE="q35"
+  MACHINE=" -machine q35"
   FORMAT=""
   DISK_SIZE="32G"
   HN="umbrelos"
@@ -564,7 +564,7 @@ mkdir -p "$CACHE_DIR" "$(dirname "$FILE_IMG")"
 
 download_and_validate_xz "$URL" "$CACHE_FILE"
 
-qm create $VMID -machine q35 -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_TYPE} \
+qm create $VMID${MACHINE} -bios ovmf -agent 1 -tablet 0 -localtime 1 ${CPU_TYPE} \
   -cores "$CORE_COUNT" -memory "$RAM_SIZE" -name "$HN" -tags community-script \
   -net0 "virtio,bridge=$BRG,macaddr=$MAC$VLAN$MTU" -onboot 1 -ostype l26 -scsihw virtio-scsi-pci >/dev/null
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
fix hardcoded machine type 

## 🔗 Related Issue

Fixes #15991

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
