### PR TITLE
Apache Tika: Switch from Debian Bookworm to Debian Trixie and replace manual install of OpenJDK with setup_java

### DIFF
--- a/ct/apache-tika.sh
+++ b/ct/apache-tika.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-1}"
 var_ram="${var_ram:-2048}"
 var_disk="${var_disk:-10}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 

--- a/install/apache-tika-install.sh
+++ b/install/apache-tika-install.sh
@@ -33,10 +33,7 @@ $STD apt-get install -y \
   cabextract
 msg_ok "Installed Dependencies"
 
-msg_info "Setup OpenJDK"
-$STD apt-get install -y \
-  openjdk-17-jre-headless
-msg_ok "Setup OpenJDK"
+JAVA_VERSION="21" setup_java
 
 msg_info "Installing Apache Tika"
 mkdir -p /opt/apache-tika


### PR DESCRIPTION

## ✍️ Description

Script: Apache Tika:

- Switch from Debian Bookworm to Debian Trixie 
- Replace manual install of OpenJDK with setup_java

OpenJDK 17 does not exist in Debian Trixie repository.
Next version would be OpenJDK 21.

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
