### PR TITLE
OpenThread-BR: Add runtime configuration options

### DIFF
--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -103,27 +103,29 @@ EOF
   mv /etc/default/otbr-agent.bak /etc/default/otbr-agent
   msg_ok "Restored Configuration"
 
-  if [[ ! -f /etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf ]]; then
-    msg_info "Configuring OpenThread Border Router initialization service"
-    cat <<'EOF' >/usr/local/bin/otbr-init.sh
+  if [[ ! -f /etc/systemd/system/otbr-agent.service.d/10-otbr-post-start.conf ]]; then
+    msg_info "Configuring OpenThread Border Router post-start service"
+    cat <<'EOF' >/usr/local/bin/otbr-post-start.sh
 #!/bin/sh
 
-# This script is executed after the otbr-agent service has started. It can be used to perform additional configuration or initialization tasks for the OpenThread Border Router.
-# Give otbr-agent a few seconds to establish the interface and network attach
+# OpenThread Border Router post-start script
+# Run custom commands for runtime configuration options
+
+# Wait for the otbr-agent service to be initialized
 #sleep 3
 
 # Configure routing and translation features
 #ot-ctl nat64 enable
 #ot-ctl dns server upstream enable
 EOF
-    chmod +x /usr/local/bin/otbr-init.sh
+    chmod +x /usr/local/bin/otbr-post-start.sh
     mkdir -p /etc/systemd/system/otbr-agent.service.d
-    cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf
+    cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-post-start.conf
 [Service]
-ExecStartPost=/usr/local/bin/otbr-init.sh
+ExecStartPost=/usr/local/bin/otbr-post-start.sh
 EOF
     systemctl daemon-reload
-    msg_ok "Configured OpenThread Border Router initialization service"
+    msg_ok "Configured OpenThread Border Router post-start service"
   fi
 
   msg_info "Starting Services"

--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -70,7 +70,9 @@ function update_script() {
     -DOTBR_BACKBONE_ROUTER=ON \
     -DOTBR_SYSTEMD_UNIT_DIR=/etc/systemd/system \
     -DOT_FIREWALL=ON \
+    -DOTBR_NAT64=ON \
     -DOT_POSIX_NAT64_CIDR="192.168.255.0/24" \
+    -DOTBR_DNS_UPSTREAM_QUERY=ON \
     ..
   $STD ninja
   $STD ninja install

--- a/ct/openthread-br.sh
+++ b/ct/openthread-br.sh
@@ -103,6 +103,29 @@ EOF
   mv /etc/default/otbr-agent.bak /etc/default/otbr-agent
   msg_ok "Restored Configuration"
 
+  if [[ ! -f /etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf ]]; then
+    msg_info "Configuring OpenThread Border Router initialization service"
+    cat <<'EOF' >/usr/local/bin/otbr-init.sh
+#!/bin/sh
+
+# This script is executed after the otbr-agent service has started. It can be used to perform additional configuration or initialization tasks for the OpenThread Border Router.
+# Give otbr-agent a few seconds to establish the interface and network attach
+#sleep 3
+
+# Configure routing and translation features
+#ot-ctl nat64 enable
+#ot-ctl dns server upstream enable
+EOF
+    chmod +x /usr/local/bin/otbr-init.sh
+    mkdir -p /etc/systemd/system/otbr-agent.service.d
+    cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf
+[Service]
+ExecStartPost=/usr/local/bin/otbr-init.sh
+EOF
+    systemctl daemon-reload
+    msg_ok "Configured OpenThread Border Router initialization service"
+  fi
+
   msg_info "Starting Services"
   systemctl start otbr-agent
   systemctl start otbr-web

--- a/install/openthread-br-install.sh
+++ b/install/openthread-br-install.sh
@@ -105,6 +105,23 @@ EOF
 cat <<'EOF' >/etc/default/otbr-web
 OTBR_WEB_OPTS="-I wpan0 -a 0.0.0.0 -p 80"
 EOF
+cat <<'EOF' >/usr/local/bin/otbr-init.sh
+#!/bin/sh
+
+# This script is executed after the otbr-agent service has started. It can be used to perform additional configuration or initialization tasks for the OpenThread Border Router.
+# Give otbr-agent a few seconds to establish the interface and network attach
+#sleep 3
+
+# Configure routing and translation features
+#ot-ctl nat64 enable
+#ot-ctl dns server upstream enable
+EOF
+chmod +x /usr/local/bin/otbr-init.sh
+mkdir -p /etc/systemd/system/otbr-agent.service.d
+cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf
+[Service]
+ExecStartPost=/usr/local/bin/otbr-init.sh
+EOF
 systemctl enable -q dbus rsyslog otbr-agent otbr-web
 systemctl enable -q bind9 2>/dev/null || systemctl enable -q named 2>/dev/null || true
 systemctl start -q dbus rsyslog bind9

--- a/install/openthread-br-install.sh
+++ b/install/openthread-br-install.sh
@@ -105,22 +105,24 @@ EOF
 cat <<'EOF' >/etc/default/otbr-web
 OTBR_WEB_OPTS="-I wpan0 -a 0.0.0.0 -p 80"
 EOF
-cat <<'EOF' >/usr/local/bin/otbr-init.sh
+cat <<'EOF' >/usr/local/bin/otbr-post-start.sh
 #!/bin/sh
 
-# This script is executed after the otbr-agent service has started. It can be used to perform additional configuration or initialization tasks for the OpenThread Border Router.
-# Give otbr-agent a few seconds to establish the interface and network attach
+# OpenThread Border Router post-start script
+# Run custom commands for runtime configuration options
+
+# Wait for the otbr-agent service to be initialized
 #sleep 3
 
 # Configure routing and translation features
 #ot-ctl nat64 enable
 #ot-ctl dns server upstream enable
 EOF
-chmod +x /usr/local/bin/otbr-init.sh
+chmod +x /usr/local/bin/otbr-post-start.sh
 mkdir -p /etc/systemd/system/otbr-agent.service.d
-cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-init.conf
+cat <<'EOF' >/etc/systemd/system/otbr-agent.service.d/10-otbr-post-start.conf
 [Service]
-ExecStartPost=/usr/local/bin/otbr-init.sh
+ExecStartPost=/usr/local/bin/otbr-post-start.sh
 EOF
 systemctl enable -q dbus rsyslog otbr-agent otbr-web
 systemctl enable -q bind9 2>/dev/null || systemctl enable -q named 2>/dev/null || true

--- a/install/openthread-br-install.sh
+++ b/install/openthread-br-install.sh
@@ -66,7 +66,9 @@ $STD cmake -GNinja \
   -DOTBR_BACKBONE_ROUTER=ON \
   -DOTBR_SYSTEMD_UNIT_DIR=/etc/systemd/system \
   -DOT_FIREWALL=ON \
+  -DOTBR_NAT64=ON \
   -DOT_POSIX_NAT64_CIDR="192.168.255.0/24" \
+  -DOTBR_DNS_UPSTREAM_QUERY=ON \
   ..
 $STD ninja
 $STD ninja install


### PR DESCRIPTION
## ✍️ Description
This PR adds two things to the `openthread-br` scripts:
1. NAT64 support
2. Init script to run `ot-ctl` config commands after the `otbr-agent` service started

NAT64 is disabled by default but must be included in the `CMAKE` options in order for users to be able to enable it at runtime.

The docs on the website should be updated as well to include the init script as a additional config path (/usr/local/bin/otbr-init.sh).
Maybe an addidtional info message for this would also be nice. I thought something like "Some features like NAT64 or a custom MDNS hostname must be enabled at runtime using `ot-ctl` commands. The script at `/usr/local/bin/otbr-init.sh` can be used to specify those commands"

## 🔗 Related Issue

Fixes #16037

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
