### PR TITLE
Apache Tika: Remove software-properties-common from Apache Tika install

### DIFF
--- a/install/apache-tika-install.sh
+++ b/install/apache-tika-install.sh
@@ -15,7 +15,6 @@ update_os
 
 msg_info "Installing Dependencies"
 $STD apt-get install -y \
-  software-properties-common \
   gdal-bin \
   tesseract-ocr \
   tesseract-ocr-eng \


### PR DESCRIPTION
## ✍️ Description

`software-properties-common` does not exist in Debian 13

## 🔗 Related Issue

Fixes #16053
Introduced in https://github.com/community-scripts/ProxmoxVE/pull/16036

## Site note

`install/kiwix-install.sh` and `install/dotnetaspwebapi-install.sh` also reference software-properties-common — potentially the same latent bug if either targets trixie
Out of scope for this issue, so I left them alone.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
