### PR TITLE
Mylar3 & Medusa: use trixie non-free for unrar, not bookworm

### DIFF
--- a/install/medusa-install.sh
+++ b/install/medusa-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
   mediainfo
 
 cat <<EOF >/etc/apt/sources.list.d/non-free.list
-deb https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb https://deb.debian.org/debian trixie main contrib non-free non-free-firmware
 EOF
 $STD apt update
 $STD apt install -y unrar

--- a/install/mylar3-install.sh
+++ b/install/mylar3-install.sh
@@ -17,8 +17,9 @@ msg_info "Installing Dependencies"
 cat <<EOF >/etc/apt/sources.list.d/non-free.sources
 Types: deb
 URIs: http://deb.debian.org/debian
-Suites: bookworm
+Suites: trixie
 Components: non-free non-free-firmware
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOF
 $STD apt update
 $STD apt install -y unrar


### PR DESCRIPTION
## ✍️ Description

`ct/mylar3.sh` and `ct/medusa.sh` both build **Debian 13** containers (`var_version="${var_version:-13}"`), but their install scripts add a **Debian 12 (bookworm)** apt source purely to obtain `unrar`:

```bash
# install/mylar3-install.sh
cat <<EOF >/etc/apt/sources.list.d/non-free.sources
Types: deb
URIs: http://deb.debian.org/debian
Suites: bookworm
Components: non-free non-free-firmware
EOF
```

```bash
# install/medusa-install.sh
deb https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
```

### Why this is not cosmetic

The base image only enables the `main` component, so **trixie's `non-free` is never enabled anywhere**. The bookworm source is therefore the *only* place `unrar` is offered, and both containers deterministically install the Debian 12 build rather than the trixie one.

Observed on a freshly built Mylar3 LXC — `unrar 1:6.2.6-1+deb12u1` instead of trixie's `1:7.1.8-1`.

Reproduced on that container by restoring the current `Suites: bookworm` block:

```
# apt-cache policy unrar        (with the bookworm source as shipped)
unrar:
  Version table:
     1:6.2.6-1+deb12u1 500
        500 http://deb.debian.org/debian bookworm/non-free amd64 Packages
```

`unrar` is the only package the source exists for, but nothing scopes it to that package. Mylar3 also **never removes the source**, so `bookworm/non-free` *and* `bookworm/non-free-firmware` stay permanently enabled at the default priority on a Debian 13 system:

```
 500 http://deb.debian.org/debian bookworm/non-free amd64 Packages
     release v=12.15,o=Debian,a=oldstable,n=bookworm,l=Debian,c=non-free,b=amd64
 500 http://deb.debian.org/debian bookworm/non-free-firmware amd64 Packages
     release v=12.15,o=Debian,a=oldstable,n=bookworm,l=Debian,c=non-free-firmware,b=amd64
```

There is no pinning, so any later `apt install` / `apt upgrade` can continue to resolve non-free packages against oldstable. (Medusa `rm`s its list file after installing, so only the wrong-build-of-`unrar` half applies there.)

### The fix

Point the suite at `trixie`. This is exactly what **`install/sabnzbd-install.sh`** already does for the *same* dependency on the *same* Debian 13 base — it is the in-repo reference implementation for this pattern:

```bash
# install/sabnzbd-install.sh — already correct
Types: deb
URIs: http://deb.debian.org/debian/
Suites: trixie
Components: non-free
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
```

I also added the matching `Signed-By:` line to Mylar3 so it mirrors sabnzbd (Medusa's one-line `.list` entry is left in its existing format — suite word only).

I deliberately **hardcoded** the suite rather than deriving it from the container's `/etc/os-release`, per the maintainer response on #14615 ("We just support the default version we put in a script"). The scripts' default is Debian 13, so the source should say trixie.

### Scope of the sweep

I grepped all 557 install scripts for hardcoded suites and vendor repos to check for siblings:

| Script | Finding |
|---|---|
| `mylar3` | **Fixed** — bookworm source on a Debian 13 CT, never removed |
| `medusa` | **Fixed** — bookworm source on a Debian 13 CT, removed after install |
| `sabnzbd` | Already correct — used as the reference above |
| `frigate` | `Suites: bookworm`, but `var_version` is `12` — **correct, not touched** |
| `resiliosync` | Vendor repo, no Debian suite — not affected |
| `erpnext`, `photoprism`, `lobehub`, `forgejo-runner` | "bookworm" only in upstream artifact filenames / container tags, not apt suites — not affected |

One more of the same *class* turned up that I have **not** touched here, to keep this PR focused — happy to follow up if you'd like it: `install/umlautadaptarr-install.sh` builds a Debian 13 CT but adds the Microsoft `debian/12` prod repo with suite `bookworm`. That one also needs the signing key swapped (`microsoft.asc` → `microsoft-2025.asc`), so it is a bigger change than a suite word.

## 🔗 Related Issue

None — found while building a Mylar3 LXC. No existing issue or PR covers it (searched issues and PRs for `mylar` and `bookworm`).

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – See below.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues. Adding `Signed-By:` narrows trust for the new source rather than widening it.

**Testing** — on a live Debian 13 Mylar3 LXC built by this script:

- Applied the exact block this PR ships (`Suites: trixie` + `Signed-By:`). `apt update` succeeds with no warnings and `/usr/share/keyrings/debian-archive-keyring.gpg` is present on the stock Debian 13 template.
- `apt-cache policy unrar` then reports `1:7.1.8-1` from `trixie/non-free`, and no bookworm entries remain.
- Restored the shipped `Suites: bookworm` block to confirm the failure mode, captured above, then reverted.

The Medusa change is the same one-word suite correction against the same Debian 13 base and the same `unrar` package, verified by the `apt-cache policy` output above; I did not separately build a Medusa container.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
