### PR TITLE
UmlautAdaptarr: use the Debian 13 Microsoft repo with its 2025 signing key

### DIFF
--- a/ct/umlautadaptarr.sh
+++ b/ct/umlautadaptarr.sh
@@ -29,6 +29,18 @@ function update_script() {
     exit
   fi
 
+  if grep -qs "packages.microsoft.com/debian/12" /etc/apt/sources.list.d/microsoft*.sources; then
+    msg_info "Migrating Microsoft Repository to Debian 13"
+    setup_deb822_repo \
+      "microsoft" \
+      "https://packages.microsoft.com/keys/microsoft-2025.asc" \
+      "https://packages.microsoft.com/debian/13/prod/" \
+      "trixie" \
+      "main"
+    rm -f /usr/share/keyrings/microsoft-prod.gpg
+    msg_ok "Migrated Microsoft Repository to Debian 13"
+  fi
+
   if check_for_gh_release "UmlautAdaptarr" "PCJones/Umlautadaptarr"; then
     msg_info "Stopping Service"
     systemctl stop umlautadaptarr

--- a/install/umlautadaptarr-install.sh
+++ b/install/umlautadaptarr-install.sh
@@ -16,9 +16,9 @@ update_os
 msg_info "Installing Dependencies"
 setup_deb822_repo \
   "microsoft" \
-  "https://packages.microsoft.com/keys/microsoft.asc" \
-  "https://packages.microsoft.com/debian/12/prod/" \
-  "bookworm" \
+  "https://packages.microsoft.com/keys/microsoft-2025.asc" \
+  "https://packages.microsoft.com/debian/13/prod/" \
+  "trixie" \
   "main"
 $STD apt install -y \
   dotnet-sdk-8.0 \


### PR DESCRIPTION
## ✍️ Description

`ct/umlautadaptarr.sh` builds a **Debian 13** container (`var_version="${var_version:-13}"`), but the installer configures Microsoft's **Debian 12** prod repo:

```bash
setup_deb822_repo \
  "microsoft" \
  "https://packages.microsoft.com/keys/microsoft.asc" \
  "https://packages.microsoft.com/debian/12/prod/" \
  "bookworm" \
  "main"
```

This is the last script in the repo still pointing at `packages.microsoft.com/debian/12`; six others already use the Debian 13 repo.

### Why it is still on bookworm — and why that reason no longer holds

The move to `debian/13` was made once and reverted in #8392, because `apt` failed with *"OpenPGP signature verification failed"* (#8385). The diagnosis recorded at the time was that Microsoft hadn't populated the trixie repo yet.

That wasn't the cause. Looking at the revert diff in #8392, the URL and suite were changed to trixie **but the signing key was left as `microsoft.asc`** — and the two repos are signed by different, disjoint keys:

| Repo | InRelease signed by | Key file |
|---|---|---|
| `debian/12/prod` (bookworm) | `EB3E94ADBE1229CF` | `microsoft.asc` |
| `debian/13/prod` (trixie) | `EE4D7792F748182B` | `microsoft-2025.asc` |

So the failure was a key mismatch, not a missing package set. Reverting the URL back to `debian/12` made the error disappear because `microsoft.asc` is the correct key *for that repo* — which is why the misdiagnosis looked confirmed.

I reproduced the original failure exactly, in a clean `debian:trixie` container, using the pre-revert configuration (debian/13 + `microsoft.asc`):

```
W: OpenPGP signature verification failed: https://packages.microsoft.com/debian/13/prod trixie InRelease:
   Sub-process /usr/bin/sqv returned an error code (1), error message is:
   Missing key EE4D7792F748182B, which is needed to verify signature.
E: The repository 'https://packages.microsoft.com/debian/13/prod trixie InRelease' is not signed.
```

That is verbatim the error from #8385, and it names the missing key.

The trixie repo is also demonstrably populated with the packages this script needs, at the same patch level as bookworm:

```
dotnet-sdk-8.0           8.0.423-1
aspnetcore-runtime-8.0   8.0.29-1
```

### The change

Point at `debian/13/prod` + `trixie` **and** swap the key to `microsoft-2025.asc`. This makes the call byte-identical to `install/technitiumdns-install.sh`, and matches `igotify`, `mail-archiver`, `rdtclient`, `fileflows` and `immichframe`, all of which already run this repo on Debian 13.

Worth noting Debian trixie has no native `dotnet-sdk-8.0` / `aspnetcore-runtime-8.0` (verified on a stock Debian 13 container with `main` + `contrib`), so the Microsoft repo is genuinely required — this can't be solved by dropping it.

## 🔗 Related Issue

Fixes #8385 — closed by the #8392 revert (a workaround), not by a fix. Also relates to #8388.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – See below.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues. The new key is fetched over HTTPS from `packages.microsoft.com` and pinned via `Signed-By`, exactly as the six existing Debian 13 scripts do; the repo's signature is now actually verifiable, which it would not be under the pre-revert config.

**Testing** — in a clean `debian:trixie` container:

1. **Reproduced the original bug** with the pre-revert config (debian/13 + `microsoft.asc`) — the #8385 error, quoted above.
2. **Applied this PR's config** (debian/13 + `microsoft-2025.asc`) — `apt update` succeeds with the repo signature verified, no warnings.
3. **Installed the exact packages the script installs**, successfully:

   ```
   # apt install -y dotnet-sdk-8.0 aspnetcore-runtime-8.0   →  exit 0
   # dotnet --list-sdks
   8.0.423 [/usr/share/dotnet/sdk]
   # dotnet --list-runtimes | grep -i aspnet
   Microsoft.AspNetCore.App 8.0.29 [/usr/share/dotnet/shared/Microsoft.AspNetCore.App]
   ```

I tested the dependency setup this PR changes, not a full UmlautAdaptarr LXC build — the rest of the script is untouched.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
