### PR TITLE
Medusa: convert the non-free unrar source to deb822 format

### DIFF
--- a/install/medusa-install.sh
+++ b/install/medusa-install.sh
@@ -19,12 +19,16 @@ $STD apt install -y \
   git-core \
   mediainfo
 
-cat <<EOF >/etc/apt/sources.list.d/non-free.list
-deb https://deb.debian.org/debian trixie main contrib non-free non-free-firmware
+cat <<EOF >/etc/apt/sources.list.d/non-free.sources
+Types: deb
+URIs: https://deb.debian.org/debian
+Suites: trixie
+Components: non-free non-free-firmware
+Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOF
 $STD apt update
 $STD apt install -y unrar
-rm /etc/apt/sources.list.d/non-free.list
+rm /etc/apt/sources.list.d/non-free.sources
 msg_ok "Installed Dependencies"
 
 msg_info "Installing Medusa"


### PR DESCRIPTION
## ✍️ Description

Follow-up to #16072, requested by @CrazyWolf13 in [review](https://github.com/community-scripts/ProxmoxVE/pull/16072#issuecomment-5091709381) — that PR fixed Medusa's suite but left it in the legacy one-line format. #16072 was already merged, hence a new PR.

Converts Medusa's temporary `unrar` source to deb822, matching `mylar3` and `sabnzbd`:

```bash
cat <<EOF >/etc/apt/sources.list.d/non-free.sources
Types: deb
URIs: https://deb.debian.org/debian
Suites: trixie
Components: non-free non-free-firmware
Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
EOF
```

Three things to flag:

- **The cleanup `rm` is renamed too** (`non-free.list` → `non-free.sources`). Easy to miss, and missing it would leave the source behind permanently — the exact problem #16072 fixed in mylar3.
- **Dropped the redundant `main` and `contrib` components.** The base `debian.sources` already provides both for trixie, so declaring them again made every Medusa build emit:

  ```
  W: Target Packages (main/binary-amd64/Packages) is configured multiple times in
     /etc/apt/sources.list.d/debian.sources:1 and /etc/apt/sources.list.d/non-free.list:1
  ```

  Only `non-free` is needed for `unrar`. The new block produces no warnings.
- **Kept the original `https://`** rather than switching to the `http://` that mylar3/sabnzbd use — this PR is a format change, and the URL scheme wasn't part of the request.

## 🔗 Related Issue

Follow-up to #16072. No separate issue.

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – See below.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues. `Signed-By` pins the source to the Debian archive keyring, which the legacy one-line entry did not do.

**Testing** — on a live Debian 13 LXC built from this repo:

- Applied the exact block above: `apt update` completes with **no warnings and no errors**, versus the duplicate-`main`/`contrib` warnings the current one-line entry produces (reproduced, quoted above).
- `apt-cache policy unrar` → `1:7.1.8-1` from `trixie/non-free`, i.e. unchanged from #16072.
- Ran the renamed `rm` and confirmed the source file is gone afterwards, leaving only the base `debian.sources`.

One environment note that may be useful to others: `Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg` matches what this repo's Debian 13 LXC template already uses in its base `debian.sources`, so the two agree. The `debian:trixie` **Docker** image instead references `debian-archive-keyring.pgp`, and mixing the two spellings for the same suite makes apt fail with `Conflicting values set for option Signed-By`. Not an issue for LXC builds, but worth knowing if anyone tests these scripts in Docker.

If you'd like, I'm happy to do the same deb822 conversion for the other install scripts still writing one-line `.list` files (`flaresolverr`, `globaleaks`, `immich`, `neo4j`, `omv`, `shelfmark`, `twingate-connector`) — as a separate PR, since those are unrelated to this one.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [X] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
