### PR TITLE
fix(bazarr): store data in /var/lib/bazarr instead of inside /opt/bazarr

### DIFF
--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -28,6 +28,43 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
+
+  # One-time migration for installs created before Bazarr was given an explicit
+  # data directory. Bazarr defaults to <install dir>/data, so those installs keep
+  # config/ db/ backup/ cache/ log/ restore/ inside /opt/bazarr - the directory
+  # fetch_and_deploy_gh_release redeploys over. Move it to /var/lib/bazarr (already
+  # created and guarded on above) and pass -c, matching the -data= flag the other
+  # *arr scripts use. Runs outside the release check so installs already on the
+  # latest version still get migrated. Skipped entirely if the unit already names
+  # a data directory, so a hand-picked location is left alone.
+  if ! grep -qE -- "bazarr\.py.*[[:space:]](-c|--config)([[:space:]]|=)" /etc/systemd/system/bazarr.service 2>/dev/null; then
+    # Bail out before stopping anything, so a refusal leaves the install running.
+    if [[ -d /opt/bazarr/data && ! -L /opt/bazarr/data && -n "$(ls -A /var/lib/bazarr/ 2>/dev/null)" ]]; then
+      msg_error "/opt/bazarr/data and /var/lib/bazarr both contain data - refusing to merge them. Keep the copy you want in /var/lib/bazarr, remove /opt/bazarr/data, then run the update again."
+      exit 1
+    fi
+
+    msg_info "Moving Bazarr data to /var/lib/bazarr"
+    systemctl stop bazarr
+    if [[ -L /opt/bazarr/data ]]; then
+      # Symlinked to /var/lib/bazarr by hand as a workaround; -c replaces it.
+      rm -f /opt/bazarr/data
+    elif [[ -d /opt/bazarr/data ]]; then
+      # Copy first and only delete once it succeeded, so a failure here (a full
+      # disk, most likely) leaves the original database untouched.
+      if ! cp -a /opt/bazarr/data/. /var/lib/bazarr/; then
+        systemctl start bazarr
+        msg_error "Could not copy /opt/bazarr/data to /var/lib/bazarr - nothing was removed."
+        exit 1
+      fi
+      rm -rf /opt/bazarr/data
+    fi
+    sed -i -E "s|^(ExecStart=.*bazarr\.py.*)$|\1 -c /var/lib/bazarr|" /etc/systemd/system/bazarr.service
+    systemctl daemon-reload
+    systemctl start bazarr
+    msg_ok "Moved Bazarr data to /var/lib/bazarr"
+  fi
+
   if check_for_gh_release "bazarr" "morpheus65535/bazarr"; then
     msg_info "Stopping Service"
     systemctl stop bazarr

--- a/ct/bazarr.sh
+++ b/ct/bazarr.sh
@@ -29,16 +29,7 @@ function update_script() {
     exit
   fi
 
-  # One-time migration for installs created before Bazarr was given an explicit
-  # data directory. Bazarr defaults to <install dir>/data, so those installs keep
-  # config/ db/ backup/ cache/ log/ restore/ inside /opt/bazarr - the directory
-  # fetch_and_deploy_gh_release redeploys over. Move it to /var/lib/bazarr (already
-  # created and guarded on above) and pass -c, matching the -data= flag the other
-  # *arr scripts use. Runs outside the release check so installs already on the
-  # latest version still get migrated. Skipped entirely if the unit already names
-  # a data directory, so a hand-picked location is left alone.
   if ! grep -qE -- "bazarr\.py.*[[:space:]](-c|--config)([[:space:]]|=)" /etc/systemd/system/bazarr.service 2>/dev/null; then
-    # Bail out before stopping anything, so a refusal leaves the install running.
     if [[ -d /opt/bazarr/data && ! -L /opt/bazarr/data && -n "$(ls -A /var/lib/bazarr/ 2>/dev/null)" ]]; then
       msg_error "/opt/bazarr/data and /var/lib/bazarr both contain data - refusing to merge them. Keep the copy you want in /var/lib/bazarr, remove /opt/bazarr/data, then run the update again."
       exit 1
@@ -47,11 +38,8 @@ function update_script() {
     msg_info "Moving Bazarr data to /var/lib/bazarr"
     systemctl stop bazarr
     if [[ -L /opt/bazarr/data ]]; then
-      # Symlinked to /var/lib/bazarr by hand as a workaround; -c replaces it.
       rm -f /opt/bazarr/data
     elif [[ -d /opt/bazarr/data ]]; then
-      # Copy first and only delete once it succeeded, so a failure here (a full
-      # disk, most likely) leaves the original database untouched.
       if ! cp -a /opt/bazarr/data/. /var/lib/bazarr/; then
         systemctl start bazarr
         msg_error "Could not copy /opt/bazarr/data to /var/lib/bazarr - nothing was removed."

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -25,12 +25,6 @@ $STD uv pip install -r /opt/bazarr/requirements.txt --python /opt/bazarr/venv/bi
 msg_ok "Installed Bazarr"
 
 msg_info "Creating Service"
-# -c keeps config/ db/ backup/ cache/ log/ restore/ in /var/lib/bazarr. Without it
-# Bazarr defaults to <install dir>/data (resolved from its own source file, not the
-# working directory), which puts the database inside the directory every update
-# redeploys over. Same intent as the -data= flag the other *arr scripts pass.
-# Note: Bazarr re-execs itself once while loading its config, so a single
-# "exited with status code -100" in the journal right after start is normal.
 cat <<EOF >/etc/systemd/system/bazarr.service
 [Unit]
 Description=Bazarr Daemon

--- a/install/bazarr-install.sh
+++ b/install/bazarr-install.sh
@@ -25,6 +25,12 @@ $STD uv pip install -r /opt/bazarr/requirements.txt --python /opt/bazarr/venv/bi
 msg_ok "Installed Bazarr"
 
 msg_info "Creating Service"
+# -c keeps config/ db/ backup/ cache/ log/ restore/ in /var/lib/bazarr. Without it
+# Bazarr defaults to <install dir>/data (resolved from its own source file, not the
+# working directory), which puts the database inside the directory every update
+# redeploys over. Same intent as the -data= flag the other *arr scripts pass.
+# Note: Bazarr re-execs itself once while loading its config, so a single
+# "exited with status code -100" in the journal right after start is normal.
 cat <<EOF >/etc/systemd/system/bazarr.service
 [Unit]
 Description=Bazarr Daemon
@@ -36,7 +42,7 @@ UMask=0002
 Restart=on-failure
 RestartSec=5
 Type=simple
-ExecStart=/opt/bazarr/venv/bin/python3 /opt/bazarr/bazarr.py
+ExecStart=/opt/bazarr/venv/bin/python3 /opt/bazarr/bazarr.py -c /var/lib/bazarr
 KillSignal=SIGINT
 TimeoutStopSec=20
 SyslogIdentifier=bazarr


### PR DESCRIPTION
## ✍️ Description

`/var/lib/bazarr` is created by the installer and used by `update_script()` as the "is Bazarr installed"
guard, but nothing ever pointed Bazarr at it. Bazarr defaults its data directory to `<install dir>/data`
(resolved from its own source file in `bazarr/app/get_args.py`, not from `WorkingDirectory`), so a stock
container keeps `config/ db/ backup/ cache/ log/ restore/` in `/opt/bazarr/data` — the directory
`fetch_and_deploy_gh_release` redeploys over — while `/var/lib/bazarr` stays empty.

This passes the data directory explicitly, the same intent as the `-data=` flag `sonarr`, `radarr`,
`lidarr`, `prowlarr` and `readarr` already use:

```
ExecStart=/opt/bazarr/venv/bin/python3 /opt/bazarr/bazarr.py -c /var/lib/bazarr
```

`bazarr.py` re-execs its child with `sys.argv[1:]`, so `-c` survives the restart Bazarr performs while
loading its config.

`update_script()` gains a one-time migration for existing installs, which is most of the change:

- Sits **outside** the `check_for_gh_release` block, so containers already on the latest Bazarr are
  migrated on their next `update` instead of waiting for a new release.
- Skipped entirely when the unit already names a data directory (`-c` / `--config`), so a hand-picked
  location is left alone.
- If both `/opt/bazarr/data` and `/var/lib/bazarr` hold data it refuses to merge them — and does so
  **before** stopping the service, so a refusal leaves the install running.
- Copies first and only removes the source once that succeeded, so a mid-migration failure (a full disk)
  leaves the original database in place; the service is restarted on that path.
- An existing `/opt/bazarr/data` → `/var/lib/bazarr` symlink (a known community workaround) is simply
  dropped, since `-c` replaces it.

Also adds a short comment noting that Bazarr re-execs itself once on config load, so a single
`exited with status code -100` in the journal right after start is normal rather than a crash loop.

## 🔗 Related Issue

Fixes #16097

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## Testing

Debian 13 LXCs built with `ct/bazarr.sh` on PVE 9.2.4, Bazarr 1.6.0.

| Case | Result |
| --- | --- |
| Stock install, real `/opt/bazarr/data` | contents moved; apikey and a marker file identical; `PRAGMA integrity_check` → `ok`; `/opt/bazarr/data` gone; service active; HTTP 200 |
| `/opt/bazarr/data` → `/var/lib/bazarr` symlink in place | symlink dropped, `-c` added, data intact, HTTP 200 |
| Both locations populated | refused; nothing deleted on either side; unit unchanged; **service still active, HTTP 200** |
| Re-run after migrating | no-op — migration skipped, only the release check runs |
| Empty `/var/lib/bazarr`, no `data/` (fresh-install condition) | Bazarr creates `backup cache config db log restore` there; HTTP 200; `/opt/bazarr/data` not recreated |
| `find /opt/bazarr -mindepth 1 -delete` (the `CLEAN_INSTALL=1` path) | on the fixed layout the database, config and apikey survive; on the stock layout the same line destroys them |

The db file's md5 changes across the migration because the WAL is checkpointed when the service
restarts; `PRAGMA integrity_check` returns `ok` and the apikey, alembic revision and table count are
unchanged.
