### PR TITLE
Cloudflare-DDNS: store API token in a 600 env file and build the binary at install time

### DIFF
--- a/ct/cloudflare-ddns.sh
+++ b/ct/cloudflare-ddns.sh
@@ -11,7 +11,7 @@ var_cpu="${var_cpu:-2}"
 var_ram="${var_ram:-1024}"
 var_disk="${var_disk:-3}"
 var_os="${var_os:-debian}"
-var_version="${var_version:-12}"
+var_version="${var_version:-13}"
 var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
@@ -24,11 +24,35 @@ function update_script() {
   header_info
   check_container_storage
   check_container_resources
-  if [[ ! -f /etc/systemd/system/cloudflare-ddns.service ]]; then
+
+  if [[ ! -f /usr/local/bin/ddns ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  msg_error "There is no update function for ${APP}."
+
+  if check_for_gh_release "cloudflare-ddns" "favonia/cloudflare-ddns"; then
+    msg_info "Stopping Service"
+    systemctl stop cloudflare-ddns
+    msg_ok "Stopped Service"
+
+    setup_go
+    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cloudflare-ddns" "favonia/cloudflare-ddns" "tarball"
+
+    msg_info "Updating ${APP}"
+    cd /opt/cloudflare-ddns
+    export CGO_ENABLED=0 GOOS=linux
+    $STD go build -trimpath -ldflags="-s -w" -o /usr/local/bin/ddns ./cmd/ddns
+    msg_ok "Updated ${APP}"
+
+    msg_info "Removing Build Dependencies"
+    rm -rf /usr/local/go /usr/local/bin/go /usr/local/bin/gofmt /root/go /root/.cache/go-build /opt/cloudflare-ddns
+    msg_ok "Removed Build Dependencies"
+
+    msg_info "Starting Service"
+    systemctl start cloudflare-ddns
+    msg_ok "Started Service"
+    msg_ok "Updated successfully!"
+  fi
   exit
 }
 

--- a/install/cloudflare-ddns-install.sh
+++ b/install/cloudflare-ddns-install.sh
@@ -13,8 +13,6 @@ setting_up_container
 network_check
 update_os
 
-setup_go
-
 var_cf_api_token="default"
 read -rp "${TAB3}Enter the Cloudflare API token: " var_cf_api_token
 
@@ -53,23 +51,50 @@ while true; do
 done
 msg_ok "Configured Application"
 
+setup_go
+fetch_and_deploy_gh_release "cloudflare-ddns" "favonia/cloudflare-ddns" "tarball"
+
+msg_info "Building ${APPLICATION}"
+cd /opt/cloudflare-ddns
+export CGO_ENABLED=0 GOOS=linux
+$STD go build -trimpath -ldflags="-s -w" -o /usr/local/bin/ddns ./cmd/ddns
+msg_ok "Built ${APPLICATION}"
+
+# The binary is statically linked (CGO_ENABLED=0), so Go is only a build-time
+# dependency. Removing it keeps the container small; update_script reinstalls it
+# via setup_go when a rebuild is needed.
+msg_info "Removing Build Dependencies"
+rm -rf /usr/local/go /usr/local/bin/go /usr/local/bin/gofmt /root/go /root/.cache/go-build /opt/cloudflare-ddns
+msg_ok "Removed Build Dependencies"
+
 msg_info "Setting up service"
-mkdir -p /root/go
+useradd --system --no-create-home --shell /usr/sbin/nologin cloudflare-ddns 2>/dev/null || true
+cat <<EOF >/etc/cloudflare-ddns.env
+CLOUDFLARE_API_TOKEN=${var_cf_api_token}
+DOMAINS=${var_cf_domains}
+PROXIED=${var_cf_proxied}
+IP6_PROVIDER=${var_cf_ip6_provider}
+EOF
+chown root:root /etc/cloudflare-ddns.env
+chmod 600 /etc/cloudflare-ddns.env
 cat <<EOF >/etc/systemd/system/cloudflare-ddns.service
 [Unit]
-Description=Cloudflare DDNS Service (Go run)
-After=network.target
+Description=Cloudflare DDNS Service
+After=network-online.target
+Wants=network-online.target
 
 [Service]
-Environment="CLOUDFLARE_API_TOKEN=${var_cf_api_token}"
-Environment="DOMAINS=${var_cf_domains}"
-Environment="PROXIED=${var_cf_proxied}"
-Environment="IP6_PROVIDER=${var_cf_ip6_provider}"
-Environment="GOPATH=/root/go"
-Environment="GOCACHE=/tmp/go-build"
-ExecStart=/usr/local/bin/go run github.com/favonia/cloudflare-ddns/cmd/ddns@latest
+Type=simple
+User=cloudflare-ddns
+Group=cloudflare-ddns
+EnvironmentFile=/etc/cloudflare-ddns.env
+ExecStart=/usr/local/bin/ddns
 Restart=always
 RestartSec=300
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## ✍️ Description

Fixes the two defects reported in #16099.

**1. The Cloudflare API token was written into the unit file.** `/etc/systemd/system/cloudflare-ddns.service` is mode `644`, so the token was readable by every user in the container and exposed via `systemctl cat` / `systemctl show`. It now goes to `/etc/cloudflare-ddns.env` at `600 root:root`, referenced with `EnvironmentFile=`. systemd reads that file as PID 1 before dropping privileges, so the service user never needs access to the secret. `EnvironmentFile=` is already used by ~136 install scripts here.

**2. `ExecStart` was `go run …@latest`, recompiling the app from source on every service start.** That made the running version silently mutable, required the Go toolchain to stay installed permanently (269 MB), cost ~27 s and ~44 s of CPU per start, and meant the service could not start at all without reaching the module proxy. The binary is now built once at install time with `fetch_and_deploy_gh_release` + `CGO_ENABLED=0 go build`, following the pattern in `install/gatus-install.sh`, and the toolchain is removed afterwards (the binary is fully static — verified with `file`).

Because `fetch_and_deploy_gh_release` records the deployed version and honours `var_appversion`, this also made a **real `update_script` possible — there was none before**, only `msg_error "There is no update function"`.

Two smaller changes: `var_version` moves from Debian 12 to 13, and the service runs as a non-root `cloudflare-ddns` user with `NoNewPrivileges` / `ProtectSystem=strict` / `ProtectHome` / `PrivateTmp`. On the non-root point — the application prints `😦 You are running this updater as root, which is usually a bad idea` on every start under the current script, upstream's reference `docker-compose.yml` documents `user: "1000:1000"` + `cap_drop: [all]` as its default, and ~30 install scripts here already create a service user. **Happy to drop that part if you'd prefer a minimal diff** — it is independent of the two fixes.

`var_cpu` / `var_ram` are deliberately **unchanged**. I measured the build on a clean Debian 13 LXC varying only container memory: 1024 MB builds in ~26 s, 768 MB is OOM-killed (`compile: signal: killed`), 512 MB never OOMs but thrashes indefinitely. The existing `2`/`1024` from #5600 is correctly sized for a build — the problem was only that `go run` made that a permanent, per-start requirement.

**Not addressed:** the install is still interactive. I looked at making it unattended, but `build.func` exports a fixed allowlist of variables into the container, so a `var_cf_*` env path would be unreachable — that would need a `build.func` change and felt out of scope here.

### Verification

Tested on a clean Debian 13 unprivileged LXC on PVE 9.2.4, running the install script exactly as `build.func` invokes it (`lxc-attach` with the same exported environment), using a dummy token.

| Check | Before | After |
| --- | --- | --- |
| Token in `644` unit file | yes — unprivileged user could read it | not present |
| Unprivileged read of secret | succeeded | `Permission denied` |
| `systemctl show -p Environment` | printed the token | empty |
| Go toolchain retained | 269 MB | removed; binary `statically linked` |
| Start latency (cold) | ~27 s | 15 ms |
| Service user | root (app warns about this) | `cloudflare-ddns`, warning gone |
| `update_script` | did not exist | 1.16.1 → 1.16.2 upgrade verified |

`update_script` was exercised in-container with `PHS_SILENT=1` and a faked older version file: it stopped the service, reinstalled Go, rebuilt, removed the toolchain again, restarted, and **left `/etc/cloudflare-ddns.env` intact at `600 root:root`**. Service came back `active` with `NRestarts=0`.

## 🔗 Related Issue

Fixes #16099

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
