### PR TITLE
romm: remove stale 1.x alembic migrations on update

### DIFF
--- a/ct/romm.sh
+++ b/ct/romm.sh
@@ -44,10 +44,6 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "romm" "rommapp/romm" "tarball" "latest" "/opt/romm"
 
-    # Defensive cleanup: remove stale 1.x migration files from older romm
-    # releases. Pre-v2.4 romm shipped dot-version migrations (1.6.2_, 1.7.1_,
-    # 1.8.x, 2.0.0_) alongside the 4-digit series, causing alembic to fail
-    # with "Multiple head revisions" on upgrade. No-op on clean installs.
     find /opt/romm/backend/alembic/versions -maxdepth 1 -type f -name '1.*.py' -delete 2>/dev/null || true
     find /opt/romm/backend/alembic/versions -maxdepth 1 -type f -name '2.0.0_.py' -delete 2>/dev/null || true
     find /opt/romm/backend -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true

--- a/ct/romm.sh
+++ b/ct/romm.sh
@@ -44,6 +44,14 @@ function update_script() {
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "romm" "rommapp/romm" "tarball" "latest" "/opt/romm"
 
+    # Defensive cleanup: remove stale 1.x migration files from older romm
+    # releases. Pre-v2.4 romm shipped dot-version migrations (1.6.2_, 1.7.1_,
+    # 1.8.x, 2.0.0_) alongside the 4-digit series, causing alembic to fail
+    # with "Multiple head revisions" on upgrade. No-op on clean installs.
+    find /opt/romm/backend/alembic/versions -maxdepth 1 -type f -name '1.*.py' -delete 2>/dev/null || true
+    find /opt/romm/backend/alembic/versions -maxdepth 1 -type f -name '2.0.0_.py' -delete 2>/dev/null || true
+    find /opt/romm/backend -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
     restore_backup
 
     msg_info "Updating ROMM"


### PR DESCRIPTION
## ✍️ Description

RomM releases before v2.4 shipped dot-version alembic migration files (`1.6.2_.py`, `1.6.3_.py`, `1.7.1_.py`, `1.8_.py`, `1.8.1_.py`, `1.8.2_.py`, `1.8.3_.py`, `2.0.0_.py`) alongside the current 4-digit series in `backend/alembic/versions/`.

When an existing romm LXC (originally deployed from a pre-v2.4 release) is upgraded via this script, these legacy files survive in the install directory. The next `alembic upgrade head` then fails with:

```
ERROR: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
```

This blocks the entire upgrade and leaves the backend unable to start.

### Fix

Add a defensive cleanup step in `update_script` that runs immediately after `fetch_and_deploy_gh_release`. It removes any leftover 1.x and `2.0.0_` migration files plus stale `__pycache__` directories, so alembic sees a clean migration history.

The cleanup is a no-op on fresh installs (no legacy files to remove) and only touches `/opt/romm/backend/alembic/versions/` plus `__pycache__` folders.

### Reproduction

1. Install romm from a release that contained the 1.x migrations (anything before v2.4) — or manually copy a few of the 1.x files into a current install.
2. Run the community-script update path.
3. `alembic upgrade head` fails with the multiple-heads error.

### Verification

After applying this patch on a polluted install, `alembic heads` returns a single head and `alembic upgrade head` completes normally. Manually verified on a romm LXC: went from 0 platforms / 1209 orphaned ROMs to 63 platforms / 1209 properly linked ROMs after the cleanup and a rescan.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
