### PR TITLE
ImmichFrame: check .NET SDK before update deployment

### DIFF
--- a/ct/immichframe.sh
+++ b/ct/immichframe.sh
@@ -30,6 +30,11 @@ function update_script() {
     exit
   fi
 
+  if ! dotnet --list-sdks 2>/dev/null | grep -q '^8\.'; then
+    msg_error ".NET SDK 8.0 is required to update ${APP}. Install it before retrying."
+    exit
+  fi
+
   if check_for_gh_release "immichframe" "immichFrame/ImmichFrame"; then
     msg_info "Stopping Service"
     systemctl stop immichframe


### PR DESCRIPTION
## ✍️ Description

Adds a .NET SDK 8 preflight check before ImmichFrame checks for and deploys a release update. If an older backup has removed the SDK, the updater now exits before stopping the service or recording/deploying the new release, avoiding a half-updated container when `dotnet publish` would fail.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.