### PR TITLE
fix: resolve Node.js version drift

### DIFF
--- a/.github/workflows/check-node-versions.yml
+++ b/.github/workflows/check-node-versions.yml
@@ -242,7 +242,7 @@ jobs:
             checked=$((checked + 1))
 
             # Extract our NODE_VERSION
-            our_version=$(grep -oP 'NODE_VERSION="(\d+)"' "$script" | head -1 | grep -oP '\d+' || echo "")
+            our_version=$(grep -oP 'NODE_VERSION=\K"?\d+' "$script" | head -1 | grep -oP '\d+' || echo "")
             if [[ -z "$our_version" ]]; then
               if grep -q 'NODE_VERSION=\$(' "$script"; then
                 our_version="dynamic"

--- a/ct/cross-seed.sh
+++ b/ct/cross-seed.sh
@@ -25,7 +25,7 @@ function update_script() {
   check_container_storage
   check_container_resources
 
-  NODE_VERSION="24" setup_nodejs
+  NODE_VERSION="26" setup_nodejs
   ensure_dependencies build-essential
 
   if command -v cross-seed &>/dev/null; then

--- a/ct/docmost.sh
+++ b/ct/docmost.sh
@@ -27,8 +27,8 @@ function update_script() {
     msg_error "No ${APP} Installation Found!"
     exit
   fi
-  if ! command -v node >/dev/null || [[ "$(/usr/bin/env node -v | grep -oP '^v\K[0-9]+')" != "22" ]]; then
-    NODE_VERSION="22" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/docmost/docmost/main/package.json | jq -r '.packageManager | split("@")[1]')" setup_nodejs
+  if ! command -v node >/dev/null || [[ "$(/usr/bin/env node -v | grep -oP '^v\K[0-9]+')" != "26" ]]; then
+    NODE_VERSION="26" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/docmost/docmost/main/package.json | jq -r '.packageManager | split("@")[1]')" setup_nodejs
   fi
   export NODE_OPTIONS="--max_old_space_size=4096"
 

--- a/ct/outline.sh
+++ b/ct/outline.sh
@@ -29,7 +29,7 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
+  NODE_VERSION="26" NODE_MODULE="corepack" setup_nodejs
 
   if check_for_gh_release "outline" "outline/outline"; then
     msg_info "Stopping Services"

--- a/ct/termix.sh
+++ b/ct/termix.sh
@@ -30,7 +30,7 @@ function update_script() {
     exit
   fi
 
-  NODE_VERSION="24" setup_nodejs
+  NODE_VERSION="26" setup_nodejs
 
   if check_for_gh_tag "guacd" "apache/guacamole-server"; then
     msg_info "Stopping guacd"

--- a/install/cross-seed-install.sh
+++ b/install/cross-seed-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="24" setup_nodejs
+NODE_VERSION="26" setup_nodejs
 
 msg_info "Setup Cross-Seed"
 $STD npm install cross-seed@latest -g

--- a/install/docmost-install.sh
+++ b/install/docmost-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   make
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/docmost/docmost/main/package.json | jq -r '.packageManager | split("@")[1]')" setup_nodejs
+NODE_VERSION="26" NODE_MODULE="pnpm@$(curl -s https://raw.githubusercontent.com/docmost/docmost/main/package.json | jq -r '.packageManager | split("@")[1]')" setup_nodejs
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="docmost_db" PG_DB_USER="docmost_user" setup_postgresql_db
 fetch_and_deploy_gh_release "docmost" "docmost/docmost" "tarball"

--- a/install/outline-install.sh
+++ b/install/outline-install.sh
@@ -20,7 +20,7 @@ $STD apt install -y \
   redis
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
+NODE_VERSION="26" NODE_MODULE="corepack" setup_nodejs
 PG_VERSION="16" setup_postgresql
 PG_DB_NAME="outline" PG_DB_USER="outline" setup_postgresql_db
 

--- a/install/oxicloud-install.sh
+++ b/install/oxicloud-install.sh
@@ -17,7 +17,7 @@ msg_info "Installing Dependencies"
 $STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="24" setup_nodejs
+NODE_VERSION="26" setup_nodejs
 PG_VERSION="17" setup_postgresql
 PG_DB_NAME="oxicloud" PG_DB_USER="oxicloud" setup_postgresql_db
 fetch_and_deploy_gh_release "OxiCloud" "DioCrafts/OxiCloud" "tarball" "latest" "/opt/oxicloud"

--- a/install/ps5-mqtt-install.sh
+++ b/install/ps5-mqtt-install.sh
@@ -19,7 +19,7 @@ $STD apt install -y \
   ca-certificates
 msg_ok "Installed Dependencies"
 
-NODE_VERSION="22" NODE_MODULE="playactor" setup_nodejs
+NODE_VERSION="24" NODE_MODULE="playactor" setup_nodejs
 fetch_and_deploy_gh_release "ps5-mqtt" "FunkeyFlo/ps5-mqtt" "tarball"
 
 msg_info "Configuring PS5-MQTT"

--- a/install/sync-in-install.sh
+++ b/install/sync-in-install.sh
@@ -13,7 +13,7 @@ setting_up_container
 network_check
 update_os
 
-NODE_VERSION="22" setup_nodejs
+NODE_VERSION="24" setup_nodejs
 setup_mariadb
 MARIADB_DB_NAME="sync_in" MARIADB_DB_USER="sync_in" setup_mariadb_db
 

--- a/install/termix-install.sh
+++ b/install/termix-install.sh
@@ -54,7 +54,7 @@ cd /opt
 rm -rf /opt/guacamole-server
 msg_ok "Built Guacamole Server (guacd)"
 
-NODE_VERSION="24" setup_nodejs
+NODE_VERSION="26" setup_nodejs
 fetch_and_deploy_gh_release "termix" "Termix-SSH/Termix" "tarball"
 
 msg_info "Building Frontend"


### PR DESCRIPTION
## ✍️ Description

Resolve the Node.js version drift reported by the automated dependency check.

- Align `cross-seed`, `docmost`, `outline`, `oxicloud`, and `termix` with upstream Node.js 26.
- Align `ps5-mqtt` and `sync-in` with upstream Node.js 24.
- Keep container update paths consistent with fresh installs.
- Teach the drift checker to recognize unquoted numeric `NODE_VERSION` assignments, preventing false positives for `fireshare` and `foldergram`.

The root cause was upstream projects moving to newer Node.js majors, combined with a checker regex that only recognized double-quoted assignments.

## 🔗 Related Issue

Fixes 
## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

## Validation

- `bash -n` for all changed install and container scripts
- YAML parsing and embedded Bash syntax validation for the drift workflow
- Focused version assertions for all nine reported entries
- Confirmed the NodeSource Node.js 26 repository is available
- `git diff --check`