### PR TITLE
core: fix read prompt input directly from /dev/tty

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -5337,7 +5337,7 @@ EOF
 
     local response=""
     local read_rc
-    read -t 60 -r response
+    read -t 60 -r response </dev/tty
     read_rc=$?
     if [[ $read_rc -eq 0 ]]; then
       case "${response:-1}" in


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. -->

## ✍️ Description
Update the interactive read call in build.func to read from /dev/tty instead of standard input. This ensures the timeout prompt still accepts user input even when stdin is redirected or consumed by another stream.


## 🔗 Related Issue

Fixes #16123

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
