### PR TITLE
fix non cloud init vms getting stuck at iso base size

### DIFF
--- a/vm/debian-13-vm.sh
+++ b/vm/debian-13-vm.sh
@@ -578,6 +578,13 @@ fi
 
 msg_ok "Customized image"
 
+msg_info "Expanding root filesystem to ${DISK_SIZE}"
+GROWN_FILE=$(mktemp --suffix=.qcow2)
+qemu-img create -f qcow2 "$GROWN_FILE" "$DISK_SIZE" >/dev/null
+virt-resize --quiet --expand /dev/sda1 "$WORK_FILE" "$GROWN_FILE" >/dev/null
+mv -f "$GROWN_FILE" "$WORK_FILE"
+msg_ok "Expanded root filesystem to ${DISK_SIZE}"
+
 STORAGE_TYPE=$(pvesm status -storage "$STORAGE" | awk 'NR>1 {print $2}')
 case $STORAGE_TYPE in
 nfs | dir)
@@ -659,13 +666,6 @@ DESCRIPTION=$(
 EOF
 )
 qm set $VMID -description "$DESCRIPTION" >/dev/null
-if [ -n "$DISK_SIZE" ]; then
-  msg_info "Resizing disk to $DISK_SIZE GB"
-  qm resize $VMID scsi0 ${DISK_SIZE} >/dev/null
-else
-  msg_info "Using default disk size of $DEFAULT_DISK_SIZE GB"
-  qm resize $VMID scsi0 ${DEFAULT_DISK_SIZE} >/dev/null
-fi
 
 msg_ok "Created a Debian 13 VM ${CL}${BL}(${HN})"
 if [ "$START_VM" == "yes" ]; then

--- a/vm/debian-vm.sh
+++ b/vm/debian-vm.sh
@@ -519,6 +519,20 @@ echo -en "\e[1A\e[0K"
 FILE=$(basename $URL)
 msg_ok "Downloaded ${CL}${BL}${FILE}${CL}"
 
+if ! command -v virt-resize &>/dev/null; then
+  msg_info "Installing libguestfs-tools"
+  apt-get update >/dev/null 2>&1
+  apt-get install -y libguestfs-tools >/dev/null 2>&1
+  msg_ok "Installed libguestfs-tools"
+fi
+
+msg_info "Expanding root filesystem to ${DISK_SIZE}"
+GROWN_FILE=$(mktemp --suffix=.qcow2)
+qemu-img create -f qcow2 "$GROWN_FILE" "$DISK_SIZE" >/dev/null
+virt-resize --quiet --expand /dev/sda1 "$FILE" "$GROWN_FILE" >/dev/null
+mv -f "$GROWN_FILE" "$FILE"
+msg_ok "Expanded root filesystem to ${DISK_SIZE}"
+
 STORAGE_TYPE=$(pvesm status -storage $STORAGE | awk 'NR>1 {print $2}')
 case $STORAGE_TYPE in
 nfs | dir)
@@ -596,13 +610,6 @@ DESCRIPTION=$(
 EOF
 )
 qm set "$VMID" -description "$DESCRIPTION" >/dev/null
-if [ -n "$DISK_SIZE" ]; then
-  msg_info "Resizing disk to $DISK_SIZE GB"
-  qm resize $VMID scsi0 ${DISK_SIZE} >/dev/null
-else
-  msg_info "Using default disk size of $DEFAULT_DISK_SIZE GB"
-  qm resize $VMID scsi0 ${DEFAULT_DISK_SIZE} >/dev/null
-fi
 
 msg_ok "Created a Debian 12 VM ${CL}${BL}(${HN})"
 if [ "$START_VM" == "yes" ]; then

--- a/vm/docker-vm.sh
+++ b/vm/docker-vm.sh
@@ -659,8 +659,11 @@ fi
 
 # Resize disk to target size
 msg_info "Resizing disk image to ${DISK_SIZE}"
-qemu-img resize "$WORK_FILE" "${DISK_SIZE}" >/dev/null 2>&1
-msg_ok "Resized disk image"
+GROWN_FILE=$(mktemp --suffix=.qcow2)
+qemu-img create -f qcow2 "$GROWN_FILE" "${DISK_SIZE}" >/dev/null
+virt-resize --quiet --expand /dev/sda1 "$WORK_FILE" "$GROWN_FILE" >/dev/null
+mv -f "$GROWN_FILE" "$WORK_FILE"
+msg_ok "Resized disk image and expanded root filesystem"
 
 # ==============================================================================
 # VM CREATION


### PR DESCRIPTION
## ✍️ Description
fixes vms getting set to vm image size and not configured size

## 🔗 Related Issue

Fixes #16190

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
