### PR TITLE
fix(dispatcharr): add recordings and dvr queues to celery worker

### DIFF
--- a/install/dispatcharr-install.sh
+++ b/install/dispatcharr-install.sh
@@ -174,7 +174,7 @@ cd /opt/dispatcharr
 set -a
 source .env
 set +a
-exec uv run celery -A dispatcharr worker -l info -c 4
+exec uv run celery -A dispatcharr worker -l info -c 4 -Q celery,recordings,dvr,default
 EOF
 chmod +x /opt/dispatcharr/start-celery.sh
 


### PR DESCRIPTION
## ✍️ Description
Fixes an issue in the Dispatcharr installation configuration where scheduled DVR recordings are not available with the status message `"recording playback not available yet"`.

### Root Cause
The `dispatcharr-celery` worker service was invoked without explicit queue arguments (`-Q`), causing Celery to bind exclusively to the default `celery` queue. Dispatcharr dispatches background DVR and recording tasks to separate `recordings` and `dvr` Redis queues, which went unconsumed.

### Changes
* Updated the `dispatcharr-install.sh` to include the missing queues: `-Q celery,recordings,dvr`.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
