### PR TITLE
fix(salt): write version cache to ~/.salt, not /~.salt

### DIFF
--- a/ct/salt.sh
+++ b/ct/salt.sh
@@ -36,7 +36,7 @@ function update_script() {
     sed -i "s/^\(Pin: version \).*/\1${RELEASE}/" /etc/apt/preferences.d/salt-pin-1001
     $STD apt update
     $STD apt upgrade -y
-    echo "${RELEASE}" >/~.salt
+    echo "${RELEASE}" >~/.salt
     msg_ok "Updated successfully!"
   fi
   exit

--- a/install/salt-install.sh
+++ b/install/salt-install.sh
@@ -29,7 +29,7 @@ Pin: version ${RELEASE}
 Pin-Priority: 1001
 EOF
 $STD apt install -y salt-master
-echo "${RELEASE}" >/~.salt
+echo "${RELEASE}" >~/.salt
 msg_ok "Installed Salt"
 
 motd_ssh


### PR DESCRIPTION
## ✍️ Description

`install/salt-install.sh` and `ct/salt.sh` both redirect the release version to `/~.salt` instead of `~/.salt`.

Bash only performs tilde expansion at the start of a word, so `/~.salt` is a literal path: it creates a file named `~.salt` in the container root and never writes `$HOME/.salt` — the file `check_for_gh_release` reads (`misc/tools.func`, `current_file="$HOME/.${app_lc}"`).

So `check_for_gh_release "salt" "saltstack/salt"` always sees an empty current version and returns 0. Every `update` run reports `Update available: salt not installed → <latest>` and re-runs the apt pin rewrite plus `apt update && apt upgrade -y`. The container can never report itself as up to date, and a stray `/~.salt` is left behind.

Existing containers self-heal: after this change the next `update` run persists `~/.salt` correctly and subsequent runs report no update. The leftover `/~.salt` is inert, so I kept this to the two-character fix rather than adding cleanup logic.

Bash tilde-expansion behaviour, for reference:

    ~/.salt  ->  /root/.salt
    /~.salt  ->  /~.salt        (~ is not at word start)

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

> Testing scope, stated plainly: this was **not** run on a live Proxmox host. I verified it with a standalone bash repro that executes the actual lines extracted from both files (as root, in a `bash:5` container matching the LXC environment) against the version-check logic of `check_for_gh_release` lifted verbatim from `misc/tools.func`. Before the fix the write lands on `/~.salt` and every check returns "update available"; after the fix it lands on `/root/.salt` and the check correctly flips to "no update available" until upstream publishes a newer tag. `bash -n` passes on both files and `shellcheck` output is unchanged.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – prepared with AI assistance (Claude) and reviewed/verified by me.

> To be accurate about the checkbox above: this is a two-character fix to an existing script, so the script-creator agent guidance wasn't used to author anything — the AI assistance here was in finding the bug, building the repro, and drafting this description.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
