### PR TITLE
core - setup_nodejs: bypass npm allowScripts policy globally on npm >=11

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -7732,13 +7732,7 @@ setup_nodejs() {
     fi
   fi
 
-  # npm >=11 skips native-module install/rebuild scripts (better-sqlite3, bcrypt,
-  # argon2, ...) unless each package is explicitly allowlisted, silently leaving
-  # native deps unbuilt. Bypass the policy globally instead of allowlisting
-  # per script.
-  local npm_major
-  npm_major=$(npm -v 2>/dev/null | cut -d. -f1)
-  if [[ "${npm_major:-0}" -ge 11 ]]; then
+  if [[ "$(npm -v 2>/dev/null | cut -d. -f1)" -ge 11 ]]; then
     $STD npm config set dangerously-allow-all-scripts true --location=global 2>/dev/null || true
   fi
 

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -7732,6 +7732,16 @@ setup_nodejs() {
     fi
   fi
 
+  # npm >=11 skips native-module install/rebuild scripts (better-sqlite3, bcrypt,
+  # argon2, ...) unless each package is explicitly allowlisted, silently leaving
+  # native deps unbuilt. Bypass the policy globally instead of allowlisting
+  # per script.
+  local npm_major
+  npm_major=$(npm -v 2>/dev/null | cut -d. -f1)
+  if [[ "${npm_major:-0}" -ge 11 ]]; then
+    $STD npm config set dangerously-allow-all-scripts true --location=global 2>/dev/null || true
+  fi
+
   # Set a safe default heap limit for Node.js builds if not explicitly provided.
   # Priority:
   #   1) NODE_OPTIONS (caller/user override)


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
