### PR TITLE
build.func: filter templates by host architecture during search

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -922,8 +922,10 @@ choose_and_set_storage_for_file() {
 _list_os_versions() {
   local ostype="${1:-}"
   [[ -n "$ostype" ]] || return 0
+  local arch
+  arch="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
   pveam available -section system 2>/dev/null |
-    grep -E '\.(tar\.zst|tar\.xz|tar\.gz)$' |
+    grep -E "_${arch}\.(tar\.zst|tar\.xz|tar\.gz)$" |
     awk '{print $2}' |
     sed -nE "s/^${ostype}-([0-9]+(\.[0-9]+)?).*/\1/p" |
     sort -u -V || true
@@ -936,8 +938,10 @@ _list_os_versions() {
 _list_templates() {
   local search="${1:-}" pattern="${2:-}"
   [[ -n "$search" ]] || return 0
+  local arch
+  arch="$(dpkg --print-architecture 2>/dev/null || echo amd64)"
   pveam available -section system 2>/dev/null |
-    grep -E '\.(tar\.zst|tar\.xz|tar\.gz)$' |
+    grep -E "_${arch}\.(tar\.zst|tar\.xz|tar\.gz)$" |
     awk '{print $2}' |
     grep -E "^${search}.*${pattern}" |
     sort -t - -k 2 -V || true
@@ -6721,7 +6725,8 @@ create_lxc_container() {
     # Step 1: Check local templates first (instant)
     mapfile -t LOCAL_TEMPLATES < <(
       pveam list "$TEMPLATE_STORAGE" 2>/dev/null |
-        awk -v search="${TEMPLATE_SEARCH}" -v pattern="${TEMPLATE_PATTERN}" '$1 ~ search && $1 ~ pattern {print $1}' |
+        awk -v search="${TEMPLATE_SEARCH}" -v pattern="${TEMPLATE_PATTERN}" -v arch="${ARCH}" \
+          '$1 ~ search && $1 ~ pattern && $1 ~ ("_" arch "\\.(tar\\.zst|tar\\.xz|tar\\.gz)$") {print $1}' |
         sed 's|.*/||' | sort -t - -k 2 -V
     )
 


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
_list_templates() and _list_os_versions() (used by the generic template search in create_lxc_container()) never filtered pveam available results by host architecture. 
=> Proxmox now support arm64 and now have arm64 templates. The Ordner is "funny". 

On a healthy, recently-updated template catalog this stays hidden because entries happen to sort amd64-before-arm64. When the catalog is stale or pveam update fails/times out (as in #16288, where the log explicitly shows a catalog update timeout), the ordering can differ and the wrong architecture gets picked — in this case an arm64 Alpine template got selected and deployed on an amd64 host, and pct start then failed.

## 🔗 Related Issue

Fixes #16288

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [x] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
