### PR TITLE
fix(pulse): keep the container recoverable when an update fails

### DIFF
--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -35,22 +35,34 @@ function update_script() {
     systemctl stop pulse*.service
     msg_ok "Stopped Services"
 
-    if [[ -f /opt/pulse/pulse ]]; then
-      rm -f /opt/pulse/pulse
+    if ! CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz"; then
+      msg_error "Download or deployment failed - check network connectivity and GitHub API availability"
+      if systemctl start pulse 2>/dev/null || systemctl start pulse-backend 2>/dev/null; then
+        msg_ok "Restarted the previously installed ${APP}"
+      else
+        msg_error "${APP} could not be restarted - reinstall it or restore the container from a backup"
+      fi
+      exit 250
     fi
-
-    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz"
     ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
     mkdir -p /etc/pulse
     chown pulse:pulse /etc/pulse
     chown -R pulse:pulse /opt/pulse
     chmod 700 /etc/pulse
+    UNIT_WAS_ENABLED=0
     if [[ -f "$SERVICE_PATH"/pulse-backend.service ]]; then
+      if [[ $(systemctl is-enabled pulse-backend) == enabled ]]; then
+        UNIT_WAS_ENABLED=1
+      fi
+      systemctl disable -q pulse-backend.service 2>/dev/null || true
       mv "$SERVICE_PATH"/pulse-backend.service "$SERVICE_PATH"/pulse.service
     fi
     sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
       -e 's/^Environment="API.*$//' "$SERVICE_PATH"/pulse.service
     systemctl daemon-reload
+    if [[ "$UNIT_WAS_ENABLED" == "1" ]]; then
+      systemctl enable -q pulse
+    fi
     if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
       usermod -s /usr/sbin/nologin pulse
     fi

--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -20,7 +20,155 @@ variables
 color
 catch_errors
 
+function pulse_enable_unit_from_state() {
+  local unit="$1"
+  local state="$2"
+
+  case "$state" in
+  enabled)
+    systemctl enable -q "$unit" || return
+    ;;
+  enabled-runtime)
+    systemctl enable -q --runtime "$unit" || return
+    ;;
+  esac
+  return 0
+}
+
+function pulse_prepare_update_backup() {
+  local backup_root="$1"
+  local service_path="$2"
+  local version_file="$3"
+  local unit
+
+  mkdir -p "$backup_root/systemd" || return
+  for unit in pulse.service pulse-backend.service; do
+    if [[ -e "$service_path/$unit" || -L "$service_path/$unit" ]]; then
+      cp -a "$service_path/$unit" "$backup_root/systemd/$unit" || return
+    fi
+  done
+  if [[ -e "$version_file" || -L "$version_file" ]]; then
+    cp -a "$version_file" "$backup_root/version" || return
+  fi
+  if [[ -e /usr/local/bin/pulse || -L /usr/local/bin/pulse ]]; then
+    cp -a /usr/local/bin/pulse "$backup_root/usr-local-bin-pulse" || return
+  fi
+}
+
+function pulse_apply_update() {
+  local backup_root="$1"
+  local service_path="$2"
+  local backend_enablement="$3"
+
+  msg_info "Stopping Services"
+  systemctl stop pulse*.service || return
+  msg_ok "Stopped Services"
+
+  mv /opt/pulse "$backup_root/pulse" || return
+  CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz" || return
+  if [[ ! -x /opt/pulse/bin/pulse ]]; then
+    msg_error "The deployed archive does not contain an executable Pulse binary"
+    return 252
+  fi
+
+  ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse || return
+  mkdir -p /etc/pulse || return
+  chown pulse:pulse /etc/pulse || return
+  chown -R pulse:pulse /opt/pulse || return
+  chmod 700 /etc/pulse || return
+  if [[ -f "$service_path/pulse-backend.service" ]]; then
+    systemctl disable -q pulse-backend.service 2>/dev/null || true
+    mv "$service_path/pulse-backend.service" "$service_path/pulse.service" || return
+  fi
+  sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
+    -e 's/^Environment="API.*$//' "$service_path/pulse.service" || return
+  systemctl daemon-reload || return
+  if [[ -f "$backup_root/systemd/pulse-backend.service" ]]; then
+    pulse_enable_unit_from_state pulse.service "$backend_enablement" || return
+  fi
+
+  msg_info "Starting Services"
+  systemctl start pulse || return
+  systemctl is-active -q pulse || return
+  msg_ok "Started Services"
+
+  if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
+    usermod -s /usr/sbin/nologin pulse || msg_warn "Could not disable shell access for the pulse user"
+  fi
+}
+
+function pulse_restore_update() {
+  local backup_root="$1"
+  local service_path="$2"
+  local version_file="$3"
+  local pulse_enablement="$4"
+  local backend_enablement="$5"
+  local restore_failed=0
+  local unit
+
+  msg_error "Update failed - restoring the previous ${APP} installation"
+  systemctl stop pulse.service pulse-backend.service 2>/dev/null || true
+
+  if [[ -d "$backup_root/pulse" ]]; then
+    rm -rf /opt/pulse || restore_failed=1
+    if [[ "$restore_failed" == "0" ]]; then
+      mv "$backup_root/pulse" /opt/pulse || restore_failed=1
+    fi
+  elif [[ ! -d /opt/pulse ]]; then
+    restore_failed=1
+  fi
+
+  rm -f /usr/local/bin/pulse || restore_failed=1
+  if [[ -e "$backup_root/usr-local-bin-pulse" || -L "$backup_root/usr-local-bin-pulse" ]]; then
+    cp -a "$backup_root/usr-local-bin-pulse" /usr/local/bin/pulse || restore_failed=1
+  fi
+
+  for unit in pulse.service pulse-backend.service; do
+    rm -f "$service_path/$unit" || restore_failed=1
+    if [[ -e "$backup_root/systemd/$unit" || -L "$backup_root/systemd/$unit" ]]; then
+      cp -a "$backup_root/systemd/$unit" "$service_path/$unit" || restore_failed=1
+    fi
+  done
+
+  if [[ -e "$backup_root/version" || -L "$backup_root/version" ]]; then
+    cp -a "$backup_root/version" "$version_file" || restore_failed=1
+  else
+    rm -f "$version_file" || restore_failed=1
+  fi
+
+  systemctl daemon-reload || restore_failed=1
+  systemctl disable -q pulse.service 2>/dev/null || true
+  systemctl disable -q pulse-backend.service 2>/dev/null || true
+  pulse_enable_unit_from_state pulse.service "$pulse_enablement" || restore_failed=1
+  pulse_enable_unit_from_state pulse-backend.service "$backend_enablement" || restore_failed=1
+
+  if systemctl start pulse 2>/dev/null || systemctl start pulse-backend 2>/dev/null; then
+    if [[ "$restore_failed" == "0" ]]; then
+      msg_ok "Restored and restarted the previous ${APP} installation"
+    else
+      msg_warn "Restarted ${APP}, but some rollback steps need manual verification"
+    fi
+  else
+    restore_failed=1
+    msg_error "${APP} could not be restarted - reinstall it or restore the container from a backup"
+  fi
+
+  if [[ "$restore_failed" == "0" ]]; then
+    rm -rf "$backup_root" || msg_warn "Rollback succeeded, but the snapshot remains at $backup_root"
+  else
+    msg_error "Rollback was incomplete; the snapshot remains at $backup_root"
+  fi
+  return 0
+}
+
 function update_script() {
+  local service_path="/etc/systemd/system"
+  local version_file="$HOME/.pulse"
+  local backup_root=""
+  local pulse_enablement=""
+  local backend_enablement=""
+  local update_exit_code=0
+
   header_info
   check_container_storage
   check_container_resources
@@ -30,46 +178,24 @@ function update_script() {
   fi
 
   if check_for_gh_release "pulse" "rcourtman/Pulse"; then
-    SERVICE_PATH="/etc/systemd/system"
-    msg_info "Stopping Services"
-    systemctl stop pulse*.service
-    msg_ok "Stopped Services"
-
-    if ! CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz"; then
-      msg_error "Download or deployment failed - check network connectivity and GitHub API availability"
-      if systemctl start pulse 2>/dev/null || systemctl start pulse-backend 2>/dev/null; then
-        msg_ok "Restarted the previously installed ${APP}"
-      else
-        msg_error "${APP} could not be restarted - reinstall it or restore the container from a backup"
-      fi
-      exit 250
-    fi
-    ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
-    mkdir -p /etc/pulse
-    chown pulse:pulse /etc/pulse
-    chown -R pulse:pulse /opt/pulse
-    chmod 700 /etc/pulse
-    UNIT_WAS_ENABLED=0
-    if [[ -f "$SERVICE_PATH"/pulse-backend.service ]]; then
-      if [[ $(systemctl is-enabled pulse-backend) == enabled ]]; then
-        UNIT_WAS_ENABLED=1
-      fi
-      systemctl disable -q pulse-backend.service 2>/dev/null || true
-      mv "$SERVICE_PATH"/pulse-backend.service "$SERVICE_PATH"/pulse.service
-    fi
-    sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
-      -e 's/^Environment="API.*$//' "$SERVICE_PATH"/pulse.service
-    systemctl daemon-reload
-    if [[ "$UNIT_WAS_ENABLED" == "1" ]]; then
-      systemctl enable -q pulse
-    fi
-    if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
-      usermod -s /usr/sbin/nologin pulse
+    backup_root=$(mktemp -d /opt/.pulse-update.XXXXXX) || exit 73
+    if ! pulse_prepare_update_backup "$backup_root" "$service_path" "$version_file"; then
+      rm -rf "$backup_root"
+      msg_error "Could not prepare a rollback snapshot; the running installation was not changed"
+      exit 74
     fi
 
-    msg_info "Starting Services"
-    systemctl start pulse
-    msg_ok "Started Services"
+    pulse_enablement=$(systemctl is-enabled pulse.service 2>/dev/null || true)
+    backend_enablement=$(systemctl is-enabled pulse-backend.service 2>/dev/null || true)
+
+    if pulse_apply_update "$backup_root" "$service_path" "$backend_enablement"; then
+      rm -rf "$backup_root" || msg_warn "Updated successfully, but could not remove the temporary rollback snapshot"
+    else
+      update_exit_code=$?
+      pulse_restore_update "$backup_root" "$service_path" "$version_file" "$pulse_enablement" "$backend_enablement"
+      exit "$update_exit_code"
+    fi
+
     msg_ok "Updated successfully!"
   fi
   exit

--- a/ct/pulse.sh
+++ b/ct/pulse.sh
@@ -20,155 +20,7 @@ variables
 color
 catch_errors
 
-function pulse_enable_unit_from_state() {
-  local unit="$1"
-  local state="$2"
-
-  case "$state" in
-  enabled)
-    systemctl enable -q "$unit" || return
-    ;;
-  enabled-runtime)
-    systemctl enable -q --runtime "$unit" || return
-    ;;
-  esac
-  return 0
-}
-
-function pulse_prepare_update_backup() {
-  local backup_root="$1"
-  local service_path="$2"
-  local version_file="$3"
-  local unit
-
-  mkdir -p "$backup_root/systemd" || return
-  for unit in pulse.service pulse-backend.service; do
-    if [[ -e "$service_path/$unit" || -L "$service_path/$unit" ]]; then
-      cp -a "$service_path/$unit" "$backup_root/systemd/$unit" || return
-    fi
-  done
-  if [[ -e "$version_file" || -L "$version_file" ]]; then
-    cp -a "$version_file" "$backup_root/version" || return
-  fi
-  if [[ -e /usr/local/bin/pulse || -L /usr/local/bin/pulse ]]; then
-    cp -a /usr/local/bin/pulse "$backup_root/usr-local-bin-pulse" || return
-  fi
-}
-
-function pulse_apply_update() {
-  local backup_root="$1"
-  local service_path="$2"
-  local backend_enablement="$3"
-
-  msg_info "Stopping Services"
-  systemctl stop pulse*.service || return
-  msg_ok "Stopped Services"
-
-  mv /opt/pulse "$backup_root/pulse" || return
-  CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz" || return
-  if [[ ! -x /opt/pulse/bin/pulse ]]; then
-    msg_error "The deployed archive does not contain an executable Pulse binary"
-    return 252
-  fi
-
-  ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse || return
-  mkdir -p /etc/pulse || return
-  chown pulse:pulse /etc/pulse || return
-  chown -R pulse:pulse /opt/pulse || return
-  chmod 700 /etc/pulse || return
-  if [[ -f "$service_path/pulse-backend.service" ]]; then
-    systemctl disable -q pulse-backend.service 2>/dev/null || true
-    mv "$service_path/pulse-backend.service" "$service_path/pulse.service" || return
-  fi
-  sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
-    -e 's/^Environment="API.*$//' "$service_path/pulse.service" || return
-  systemctl daemon-reload || return
-  if [[ -f "$backup_root/systemd/pulse-backend.service" ]]; then
-    pulse_enable_unit_from_state pulse.service "$backend_enablement" || return
-  fi
-
-  msg_info "Starting Services"
-  systemctl start pulse || return
-  systemctl is-active -q pulse || return
-  msg_ok "Started Services"
-
-  if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
-    usermod -s /usr/sbin/nologin pulse || msg_warn "Could not disable shell access for the pulse user"
-  fi
-}
-
-function pulse_restore_update() {
-  local backup_root="$1"
-  local service_path="$2"
-  local version_file="$3"
-  local pulse_enablement="$4"
-  local backend_enablement="$5"
-  local restore_failed=0
-  local unit
-
-  msg_error "Update failed - restoring the previous ${APP} installation"
-  systemctl stop pulse.service pulse-backend.service 2>/dev/null || true
-
-  if [[ -d "$backup_root/pulse" ]]; then
-    rm -rf /opt/pulse || restore_failed=1
-    if [[ "$restore_failed" == "0" ]]; then
-      mv "$backup_root/pulse" /opt/pulse || restore_failed=1
-    fi
-  elif [[ ! -d /opt/pulse ]]; then
-    restore_failed=1
-  fi
-
-  rm -f /usr/local/bin/pulse || restore_failed=1
-  if [[ -e "$backup_root/usr-local-bin-pulse" || -L "$backup_root/usr-local-bin-pulse" ]]; then
-    cp -a "$backup_root/usr-local-bin-pulse" /usr/local/bin/pulse || restore_failed=1
-  fi
-
-  for unit in pulse.service pulse-backend.service; do
-    rm -f "$service_path/$unit" || restore_failed=1
-    if [[ -e "$backup_root/systemd/$unit" || -L "$backup_root/systemd/$unit" ]]; then
-      cp -a "$backup_root/systemd/$unit" "$service_path/$unit" || restore_failed=1
-    fi
-  done
-
-  if [[ -e "$backup_root/version" || -L "$backup_root/version" ]]; then
-    cp -a "$backup_root/version" "$version_file" || restore_failed=1
-  else
-    rm -f "$version_file" || restore_failed=1
-  fi
-
-  systemctl daemon-reload || restore_failed=1
-  systemctl disable -q pulse.service 2>/dev/null || true
-  systemctl disable -q pulse-backend.service 2>/dev/null || true
-  pulse_enable_unit_from_state pulse.service "$pulse_enablement" || restore_failed=1
-  pulse_enable_unit_from_state pulse-backend.service "$backend_enablement" || restore_failed=1
-
-  if systemctl start pulse 2>/dev/null || systemctl start pulse-backend 2>/dev/null; then
-    if [[ "$restore_failed" == "0" ]]; then
-      msg_ok "Restored and restarted the previous ${APP} installation"
-    else
-      msg_warn "Restarted ${APP}, but some rollback steps need manual verification"
-    fi
-  else
-    restore_failed=1
-    msg_error "${APP} could not be restarted - reinstall it or restore the container from a backup"
-  fi
-
-  if [[ "$restore_failed" == "0" ]]; then
-    rm -rf "$backup_root" || msg_warn "Rollback succeeded, but the snapshot remains at $backup_root"
-  else
-    msg_error "Rollback was incomplete; the snapshot remains at $backup_root"
-  fi
-  return 0
-}
-
 function update_script() {
-  local service_path="/etc/systemd/system"
-  local version_file="$HOME/.pulse"
-  local backup_root=""
-  local pulse_enablement=""
-  local backend_enablement=""
-  local update_exit_code=0
-
   header_info
   check_container_storage
   check_container_resources
@@ -178,24 +30,46 @@ function update_script() {
   fi
 
   if check_for_gh_release "pulse" "rcourtman/Pulse"; then
-    backup_root=$(mktemp -d /opt/.pulse-update.XXXXXX) || exit 73
-    if ! pulse_prepare_update_backup "$backup_root" "$service_path" "$version_file"; then
-      rm -rf "$backup_root"
-      msg_error "Could not prepare a rollback snapshot; the running installation was not changed"
-      exit 74
+    SERVICE_PATH="/etc/systemd/system"
+    msg_info "Stopping Services"
+    systemctl stop pulse*.service
+    msg_ok "Stopped Services"
+
+    if ! CLEAN_INSTALL=1 fetch_and_deploy_gh_release "pulse" "rcourtman/Pulse" "prebuild" "latest" "/opt/pulse" "pulse-v*-linux-$(arch_resolve).tar.gz"; then
+      msg_error "Download or deployment failed - check network connectivity and GitHub API availability"
+      if systemctl start pulse 2>/dev/null || systemctl start pulse-backend 2>/dev/null; then
+        msg_ok "Restarted the previously installed ${APP}"
+      else
+        msg_error "${APP} could not be restarted - reinstall it or restore the container from a backup"
+      fi
+      exit 250
+    fi
+    ln -sf /opt/pulse/bin/pulse /usr/local/bin/pulse
+    mkdir -p /etc/pulse
+    chown pulse:pulse /etc/pulse
+    chown -R pulse:pulse /opt/pulse
+    chmod 700 /etc/pulse
+    UNIT_WAS_ENABLED=0
+    if [[ -f "$SERVICE_PATH"/pulse-backend.service ]]; then
+      if [[ $(systemctl is-enabled pulse-backend) == enabled ]]; then
+        UNIT_WAS_ENABLED=1
+      fi
+      systemctl disable -q pulse-backend.service 2>/dev/null || true
+      mv "$SERVICE_PATH"/pulse-backend.service "$SERVICE_PATH"/pulse.service
+    fi
+    sed -i -e 's|pulse/pulse|pulse/bin/pulse|' \
+      -e 's/^Environment="API.*$//' "$SERVICE_PATH"/pulse.service
+    systemctl daemon-reload
+    if [[ "$UNIT_WAS_ENABLED" == "1" ]]; then
+      systemctl enable -q pulse
+    fi
+    if grep -q 'pulse-home:/bin/bash' /etc/passwd; then
+      usermod -s /usr/sbin/nologin pulse
     fi
 
-    pulse_enablement=$(systemctl is-enabled pulse.service 2>/dev/null || true)
-    backend_enablement=$(systemctl is-enabled pulse-backend.service 2>/dev/null || true)
-
-    if pulse_apply_update "$backup_root" "$service_path" "$backend_enablement"; then
-      rm -rf "$backup_root" || msg_warn "Updated successfully, but could not remove the temporary rollback snapshot"
-    else
-      update_exit_code=$?
-      pulse_restore_update "$backup_root" "$service_path" "$version_file" "$pulse_enablement" "$backend_enablement"
-      exit "$update_exit_code"
-    fi
-
+    msg_info "Starting Services"
+    systemctl start pulse
+    msg_ok "Started Services"
     msg_ok "Updated successfully!"
   fi
   exit


### PR DESCRIPTION
## ✍️ Description

Three related fixes to `update_script()` in `ct/pulse.sh`. All are about the same thing: a failed or migrating update currently leaves the container in a state the operator cannot recover from.

**1. The pre-fetch `rm -f /opt/pulse/pulse` is a vestige and is actively harmful.**

On a v5-layout container that file *is* the Pulse binary, and `pulse-backend.service` points `ExecStart` at it. It is deleted after the service is stopped and before anything is downloaded, so a failed download leaves the container with no binary at all.

It is also redundant. It was added back when the fetch call had no `CLEAN_INSTALL=1` (226a5bce, 2025-09-09), so it was the only thing clearing the old binary. `CLEAN_INSTALL=1` was added later and `_deploy_unpacked_archive` now wipes the target anyway.

**2. A failed fetch leaves Pulse stopped.**

`catch_errors` sets `set -Ee` with an ERR trap, so a 403 rate limit, DNS failure or truncated download exits through the error handler and never reaches `systemctl start`. The fetch is now guarded and the previously installed Pulse is restarted, reporting honestly whether that restart worked. Exit code 250 matches `error_handler.func`'s "App: Download failed or version not determined", consistent with `ct/ollama.sh`.

**3. The `pulse-backend.service` to `pulse.service` rename drops boot enablement.**

The installer created and enabled `pulse-backend.service` up to a403da9f (2025-08-14) and switched to `pulse.service` at 226a5bce. Containers built in that window have a wants symlink pointing at the old name; the `mv` leaves it dangling and nothing enables the new name, so Pulse stops starting at boot. The unit is now re-enabled after the rename, but only when it was enabled beforehand, so an operator who deliberately disabled autostart keeps that.

### Testing

Throwaway unprivileged LXC on PVE 9.2.5, Debian 13, systemd 257. Each behaviour checked unpatched and patched.

| Scenario | Before | After |
|---|---|---|
| Unit rename, was enabled | `pulse` reports `disabled`, wants symlink dangling, no boot start | `enabled`, symlink correct |
| Unit rename, operator had disabled autostart | n/a | stays `disabled` |
| Download fails mid-update (v5 layout) | both units inactive and `/opt/pulse` holds only `VERSION`, binary gone | "Restarted the previously installed Pulse", binary intact |
| Happy path v5 to v6 | n/a | `pulse.service` active + enabled, old unit gone, `Pulse v6.1.2`, listening on 7655 |
| Happy path v6 to v6 (common case) | n/a | active + enabled, unchanged behaviour |
| Download fails, v6 to v6 | n/a | restarted, binary intact |

The download failures were produced by blackholing the release asset hosts while leaving `api.github.com` reachable, so the update check succeeds and the failure lands on the download, which is the window at issue.

No `create_backup`/`restore_backup` is needed here: Pulse keeps its state in `/etc/pulse`, outside the app dir, which is the design `AGENTS.md` says to prefer.

I maintain Pulse and am a co-author of this script.

**AI assistance:** written with Claude Opus 5 (`claude-opus-5`) in an interactive Claude Code session with extended reasoning. Every claim in this PR was reproduced on real hardware before submitting, and I have reviewed the diff.

## 🔗 Related Issue

N/A

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
