### PR TITLE
fix(tools): stop a failed deploy from wiping the existing install

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2576,11 +2576,6 @@ _deploy_unpacked_archive() {
   local archive="$1" target="$2" workdir="$3"
   local filename="${archive##*/}"
 
-  mkdir -p "$target"
-  if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
-    find "${target:?}" -mindepth 1 -delete
-  fi
-
   if [[ "$filename" == *.zip ]]; then
     ensure_dependencies unzip
     unzip -q "$archive" -d "$workdir" || {
@@ -2607,38 +2602,44 @@ _deploy_unpacked_archive() {
     return 65
   fi
 
-  local top_entries inner_dir
+  local top_entries inner_dir source_dir
   top_entries=$(find "$workdir" -mindepth 1 -maxdepth 1)
   if [[ "$(echo "$top_entries" | wc -l)" -eq 1 && -d "$top_entries" ]]; then
     inner_dir="$top_entries"
-    shopt -s dotglob nullglob
-    if compgen -G "$inner_dir/*" >/dev/null; then
-      cp -r "$inner_dir"/* "$target/" || {
-        msg_error "Failed to copy contents from $inner_dir to $target"
-        shopt -u dotglob nullglob
-        return 252
-      }
-    else
-      msg_error "Inner directory is empty: $inner_dir"
-      shopt -u dotglob nullglob
-      return 252
-    fi
-    shopt -u dotglob nullglob
+    source_dir="$inner_dir"
   else
-    shopt -s dotglob nullglob
-    if compgen -G "$workdir/*" >/dev/null; then
-      cp -r "$workdir"/* "$target/" || {
-        msg_error "Failed to copy contents to $target"
-        shopt -u dotglob nullglob
-        return 252
-      }
+    source_dir="$workdir"
+  fi
+
+  shopt -s dotglob nullglob
+  if ! compgen -G "$source_dir/*" >/dev/null; then
+    if [[ -n "$inner_dir" ]]; then
+      msg_error "Inner directory is empty: $inner_dir"
     else
       msg_error "Unpacked archive is empty"
-      shopt -u dotglob nullglob
-      return 252
     fi
     shopt -u dotglob nullglob
+    return 252
   fi
+
+  # <target> is only touched once the payload is known good. Wiping earlier left
+  # CLEAN_INSTALL callers with an empty target directory whenever the download
+  # was truncated, the archive was unreadable, or it unpacked to nothing.
+  mkdir -p "$target"
+  if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
+    find "${target:?}" -mindepth 1 -delete
+  fi
+
+  if ! cp -r "$source_dir"/* "$target/"; then
+    if [[ -n "$inner_dir" ]]; then
+      msg_error "Failed to copy contents from $inner_dir to $target"
+    else
+      msg_error "Failed to copy contents to $target"
+    fi
+    shopt -u dotglob nullglob
+    return 252
+  fi
+  shopt -u dotglob nullglob
   return 0
 }
 


### PR DESCRIPTION
## ✍️ Description

`_deploy_unpacked_archive` clears the target directory **before** it extracts the archive. With `CLEAN_INSTALL=1`, any failure between the wipe and the copy therefore leaves the caller with an empty target and no way back: a truncated or corrupt download, an unreadable archive, an unsupported format, or an archive that unpacks to nothing.

Extraction only ever writes into `<workdir>`, never into `<target>`, so the wipe does not need to happen first. It now happens after the payload has been extracted **and** confirmed non-empty, immediately before the copy.

The two copy branches collapsed into one while doing this, because they differed only in which directory they read from. All four original error messages are preserved.

This surfaced while fixing `ct/pulse.sh` (#16311): a container whose update failed mid-download was left with an empty `/opt/pulse`.

### Behaviour matrix

Exercised the function directly on Debian 13 (GNU coreutils, `unzip`/`zip`/`p7zip-full` installed) across every archive format the function dispatches on. `keepme.txt` is a pre-existing file in the target, standing in for an installed application.

Failure cases, tested for `.tar.gz`, `.tgz`, `.zip` and `.7z`:

| Case | Upstream | This PR |
|---|---|---|
| corrupt archive | rc=251, target emptied | rc=251, **target intact** |
| valid archive, empty payload | rc=252, target emptied | rc=252, **target intact** |
| unsupported format | rc=65, target emptied | rc=65, **target intact** |

Success cases, also tested for all four formats, byte-identical between upstream and this PR:

| Case | Result, both |
|---|---|
| good archive, `CLEAN_INSTALL=1` | rc=0, target replaced with payload |
| good archive, `CLEAN_INSTALL=0` | rc=0, payload merged over existing contents |
| multi-file archive, no top-level dir | rc=0, target replaced |

Every return code, dotfile handling and single-top-level-directory stripping are unchanged. Only the failure paths differ, and only in that the existing install survives them. The tar cases were additionally re-run on macOS (bash 5.3) with identical results.

Peak disk usage is not increased. Before, the peak was archive + workdir + the target being refilled; now it is the old target + archive + workdir during extraction, then the same copy phase. At the margin this is safer rather than riskier: on a disk too small for that peak, the old order failed during the copy with the target already wiped, whereas this fails during extraction with the install untouched.

Callers audited: the three `prebuild` branches of `fetch_and_deploy_gh_release`, `fetch_and_deploy_codeberg_release` and `fetch_and_deploy_gl_release`. All use `|| return`, and none depends on the target directory existing after a failure.

**AI assistance:** written with Claude Opus 5 (`claude-opus-5`) in an interactive Claude Code session with extended reasoning. The matrix above was produced by exercising the function directly on both platforms, not reasoned about, and I have reviewed the diff.

## 🔗 Related Issue

N/A

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

