### PR TITLE
Fix: CouchDB Erlang cookie breaks vm.args (use hex)

### DIFF
--- a/install/apache-couchdb-install.sh
+++ b/install/apache-couchdb-install.sh
@@ -14,7 +14,9 @@ network_check
 update_os
 
 msg_info "Installing Apache CouchDB"
-ERLANG_COOKIE=$(openssl rand -base64 32)
+# hex so the cookie is alphanumeric and never needs quoting in Erlang vm.args;
+# base64 output can contain +/= which breaks -setcookie parsing (#16360)
+ERLANG_COOKIE=$(openssl rand -hex 32)
 ADMIN_PASS="$(openssl rand -base64 18 | cut -c1-13)"
 debconf-set-selections <<<"couchdb couchdb/cookie string $ERLANG_COOKIE"
 debconf-set-selections <<<"couchdb couchdb/mode select standalone"

--- a/install/apache-couchdb-install.sh
+++ b/install/apache-couchdb-install.sh
@@ -14,8 +14,6 @@ network_check
 update_os
 
 msg_info "Installing Apache CouchDB"
-# hex so the cookie is alphanumeric and never needs quoting in Erlang vm.args;
-# base64 output can contain +/= which breaks -setcookie parsing (#16360)
 ERLANG_COOKIE=$(openssl rand -hex 32)
 ADMIN_PASS="$(openssl rand -base64 18 | cut -c1-13)"
 debconf-set-selections <<<"couchdb couchdb/cookie string $ERLANG_COOKIE"


### PR DESCRIPTION
## ✍️ Description

On a fresh CouchDB install, `couchdb.service` fails to start. `ERLANG_COOKIE=$(openssl rand -base64 32)` produces base64 that can contain `+`, `/`, `=` (e.g. `H0czzjhyNtKN27icXsgXYa/Awyj1+owHdjxSzgwDXfU=`). CouchDB writes that value into `/opt/couchdb/etc/vm.args` as `-setcookie '<cookie>'`, and those characters break Erlang's vm.args parsing -> `couchdb.service` aborts on startup (#16360).

`openssl rand -hex 32` yields a 64-character hex string (only `[0-9a-f]`, e.g. `a682841889c7eb48c4070b43c6503e26f9b048ba55244f3322b6bf34912bf7c3`): alphanumeric, needs no quoting, always a valid Erlang cookie, same 256-bit entropy as the previous base64 of 32 bytes.

AI model: Claude Opus 4.8 (`claude-opus-4-8`, via Claude Code), reasoning effort high. Reviewed against the project's `AGENTS.md` and `.github/agents/pve-script-creator.agent.md`: a single `openssl` flag swap with no helper-function, variable, or structure impact, so it needs no correction.

## 🔗 Related Issue

Fixes #16360

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.