### PR TITLE
fix(stirling-pdf): unoserver installed into the venv, and login mode truncates .env

### DIFF
--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -34,7 +34,11 @@ msg_ok "Installed Dependencies"
 PYTHON_VERSION="3.12" setup_uv
 JAVA_VERSION="25" setup_java
 
-read -r -p "${TAB3}Do you want to use Stirling-PDF with Login? (no/n = without Login) [Y/n] " response
+if ! read -r -p "${TAB3}Do you want to use Stirling-PDF with Login? (no/n = without Login) [Y/n] " response; then
+  # No interactive stdin (EOF): fall back to the no-login install instead of
+  # silently selecting login, which the -z test below would otherwise do.
+  response="n"
+fi
 response=${response,,} # Convert to lowercase
 login_mode="false"
 if [[ "$response" == "y" || "$response" == "yes" || -z "$response" ]]; then
@@ -72,7 +76,10 @@ $STD uv pip install \
   pillow \
   pdf2image
 $STD apt install -y python3-uno python3-pip
-$STD pip3 install --break-system-packages --timeout=120 unoserver
+# Install unoserver for the system Python, not the venv activated above: `uno` is
+# provided by python3-uno for /usr/bin/python3 only, and unoserver.service expects
+# /usr/local/bin/unoserver. A bare `pip3` here resolves to the venv's pip.
+$STD /usr/bin/python3 -m pip install --break-system-packages --timeout=120 unoserver
 ln -sf /opt/.venv/bin/python3 /usr/local/bin/python3
 ln -sf /opt/.venv/bin/pip /usr/local/bin/pip
 msg_ok "Installed Python Dependencies"
@@ -104,7 +111,7 @@ PATH=/opt/.venv/bin:/usr/lib/libreoffice/program:/usr/local/sbin:/usr/local/bin:
 EOF
 
 if [[ "$login_mode" == "true" ]]; then
-  cat <<EOF >/opt/Stirling-PDF/.env
+  cat <<EOF >>/opt/Stirling-PDF/.env
 # activate Login
 DISABLE_ADDITIONAL_FEATURES=false
 SECURITY_ENABLELOGIN=true


### PR DESCRIPTION
## ✍️ Description

Three small fixes to `install/stirling-pdf-install.sh`. Apologies for the earlier issues that missed the template — reopening this as a PR instead, as suggested.

**1. `unoserver` is installed into the venv, so the service never starts.**

The script activates the venv, then installs unoserver with a bare `pip3`:

```bash
export PATH="/opt/.venv/bin:$PATH"
source /opt/.venv/bin/activate
...
$STD pip3 install --break-system-packages --timeout=120 unoserver
```

`pip3` therefore resolves to `/opt/.venv/bin/pip3`, so unoserver lands in `/opt/.venv/bin/` while `unoserver.service` expects `/usr/local/bin/unoserver`:

```
unoserver.service: Failed at step EXEC spawning /usr/local/bin/unoserver: No such file or directory
```

Symlinking the two is not a fix — the venv is Python 3.12 and `python3-uno` targets the system 3.13, so it can never import `uno`:

```
/usr/bin/python3        3.13.5    import uno -> OK
/opt/.venv/bin/python3  3.12.13   import uno -> ModuleNotFoundError
```

Calling `/usr/bin/python3 -m pip` explicitly installs to `/usr/local/bin/unoserver` with a `#!/usr/bin/python3` shebang. Verified this works with the venv still active, so no deactivation or `VIRTUAL_ENV` unset is needed — pip targets its own interpreter's prefix.

**2. The login branch truncates `.env` instead of appending.**

`cat <<EOF >/opt/Stirling-PDF/.env` overwrites the file written ~20 lines earlier, discarding `JAVA_BASE_OPTS`, `UNO_PATH`, `URE_BOOTSTRAP`, `PYTHONPATH`, `LD_LIBRARY_PATH` and `STIRLING_TEMPFILES_DIRECTORY`. On a login-mode install `.env` ends up with only the four login keys, so LibreOffice/unoserver conversion is broken while the UI looks healthy. Changed to `>>`.

**3. EOF on stdin silently selects login mode.**

`-z "$response"` treats "no input" as yes, so a non-interactive run picks login mode — which, before fix 2, was also the broken one. `read` returns non-zero on EOF, so this now falls back to the no-login install. Interactive behaviour is unchanged: pressing Enter still selects the `[Y/n]` default.

## 🔗 Related Issue

Supersedes #16430 and #16431 (closed for not using the template).

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

### What was tested

Debian 13 unprivileged LXC on Proxmox VE 9.2.10, amd64, default settings, verbose.

- **Reproduced** on a clean container built by the current script answering *yes* to the login prompt: `.env` contained only the 4 login keys, `unoserver.service` was in a crash loop, and the binary was in `/opt/.venv/bin`.
- **Fix 1** verified under the script's real conditions (venv activated, `which pip3` = `/opt/.venv/bin/pip3`): the patched command installs to `/usr/local/bin/unoserver`, shebang `#!/usr/bin/python3`, nothing left in the venv.
- **Fix 2** verified by applying the `>>` outcome: all 11 base keys restored alongside the 4 login keys, all three services (`stirlingpdf`, `libreoffice-listener`, `unoserver`) then active, and a `unoconvert` txt→docx→pdf round trip over the RPC socket succeeded. Login mode confirmed still enforced (401 unauthenticated).
- **Full application path** verified on a no-login container built from this script with these fixes applied: `POST /api/v1/convert/file/pdf` with a `.docx` returned a valid PDF, and `POST /api/v1/misc/ocr-pdf` produced a PDF whose text layer read back correctly with `pdftotext`.
- **Not covered:** an authenticated application-level conversion on the login-mode instance — 2.14.3 wants an account-minted API key rather than basic auth, and `POST /login` is not supported. The conversion path itself is shared and is covered by the two bullets above.

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Written with Claude Code (model: Claude Opus 5). To be precise about scope: this is a three-line targeted fix to an existing script rather than generated script content, so the script-creation guidance largely does not apply here. Every change was reproduced and verified on real Proxmox hosts as described above, and the diff was reviewed line by line before submission.

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
