### PR TITLE
fix(stirling-pdf): LibreOffice listener collides with unoserver on UNO port 2002, burning a core

### DIFF
--- a/ct/stirling-pdf.sh
+++ b/ct/stirling-pdf.sh
@@ -43,8 +43,20 @@ function update_script() {
     find /usr/lib -name "libicudata.so.*" -exec patchelf --clear-execstack {} \; || true
     msg_ok "Patched Native Libraries"
 
+    if [[ -f /etc/systemd/system/libreoffice-listener.service ]]; then
+      msg_info "Removing Conflicting LibreOffice Listener"
+      systemctl disable -q --now libreoffice-listener
+      rm -f /etc/systemd/system/libreoffice-listener.service
+      sed -i '/^Requires=libreoffice-listener.service$/d' /etc/systemd/system/stirlingpdf.service /etc/systemd/system/unoserver.service
+      sed -i 's/^After=syslog.target network.target libreoffice-listener.service$/After=syslog.target network.target unoserver.service/' /etc/systemd/system/stirlingpdf.service
+      sed -i 's/^After=libreoffice-listener.service$/After=network.target/' /etc/systemd/system/unoserver.service
+      systemctl daemon-reload
+      systemctl reset-failed libreoffice-listener.service 2>/dev/null || true
+      msg_ok "Removed Conflicting LibreOffice Listener"
+    fi
+
     msg_info "Stopping Services"
-    systemctl stop stirlingpdf libreoffice-listener unoserver
+    systemctl stop stirlingpdf unoserver
     msg_ok "Stopped Services"
 
     if [[ -f ~/.Stirling-PDF-login ]]; then
@@ -59,7 +71,7 @@ function update_script() {
     msg_ok "Font Cache Updated"
 
     msg_info "Starting Services"
-    systemctl start stirlingpdf libreoffice-listener unoserver
+    systemctl start unoserver stirlingpdf
     msg_ok "Started Services"
     msg_ok "Updated successfully!"
   fi

--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -132,27 +132,12 @@ $STD fc-cache -fv
 msg_ok "Font Cache Updated"
 
 msg_info "Creating Service"
-cat <<EOF >/etc/systemd/system/libreoffice-listener.service
-[Unit]
-Description=LibreOffice Headless Listener Service
-After=network.target
-
-[Service]
-Type=simple
-User=root
-Group=root
-ExecStart=/usr/lib/libreoffice/program/soffice --headless --invisible --nodefault --nofirststartwizard --nolockcheck --nologo --accept="socket,host=127.0.0.1,port=2002;urp;StarOffice.ComponentContext"
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
+# unoserver starts and supervises its own LibreOffice on UNO port 2002, so a separate
+# listener on that port only collides with it. Do not reintroduce one.
 cat <<EOF >/etc/systemd/system/stirlingpdf.service
 [Unit]
 Description=Stirling-PDF service
-After=syslog.target network.target libreoffice-listener.service
-Requires=libreoffice-listener.service
+After=syslog.target network.target unoserver.service
 
 [Service]
 SuccessExitStatus=143
@@ -173,8 +158,7 @@ EOF
 cat <<EOF >/etc/systemd/system/unoserver.service
 [Unit]
 Description=UnoServer RPC Interface
-After=libreoffice-listener.service
-Requires=libreoffice-listener.service
+After=network.target
 
 [Service]
 Type=simple
@@ -186,9 +170,8 @@ EnvironmentFile=/opt/Stirling-PDF/.env
 WantedBy=multi-user.target
 EOF
 
-systemctl enable -q --now libreoffice-listener
-systemctl enable -q --now stirlingpdf
 systemctl enable -q --now unoserver
+systemctl enable -q --now stirlingpdf
 msg_ok "Created Service"
 
 motd_ssh


### PR DESCRIPTION
## ✍️ Description

A follow-up to #16439 on the same script. That PR fixed the two bugs that made `unoserver` fail loudly; this one fixes a third that fails **silently** — every container built by this script burns 100% of a CPU core from boot, indefinitely, while reporting itself healthy.

**The script installs two LibreOffice instances that both want UNO port 2002.**

`libreoffice-listener.service` binds `127.0.0.1:2002`:

```
ExecStart=/usr/lib/libreoffice/program/soffice --headless ... --accept="socket,host=127.0.0.1,port=2002;urp;StarOffice.ComponentContext"
```

`unoserver.service` is then started with no `--uno-port`. unoserver's default UNO port **is also 2002**, and unoserver starts and supervises its *own* LibreOffice — so a second `soffice.bin` launches and tries to bind a port the listener already holds. It does not exit. It spins:

```
PID    TID    %CPU  COMMAND
13088  13091  98.5  URP Acceptor      <- 4h58m of CPU time in a 5h uptime
```

`URP Acceptor` is the thread that creates the UNO accept socket. `ss -lntp` confirms it never gets one — the listener owns 2002, and unoserver's child owns nothing.

**Why this is easy to miss.** Conversions still work, because unoserver's *client* side dials `127.0.0.1:2002` and reaches the listener's instance. So the app is fully functional: `systemctl --failed` is empty, both units report `active`, and application-level Office→PDF and OCR round trips all pass. I only found it on a container that had been idle for five hours and was still sitting at load average 1.5.

### The fix

Remove `libreoffice-listener.service` and let unoserver own its LibreOffice, which is how unoserver is designed to work. **Port 2002 is still served** — by unoserver's own child process — so nothing that connects to it changes. It is a net removal of 18 lines.

The two `Requires=libreoffice-listener.service` lines are dropped with it. `stirlingpdf.service`'s `After=` is repointed at `unoserver.service`, and the two `systemctl enable --now` calls are reordered so unoserver comes up first.

### The `update_script()` change

`update_script()` also stops and starts `libreoffice-listener` by name, which would fail once the unit no longer exists.

Beyond that, **every already-deployed container still has the collision**, and the update path is the only route that reaches them — so I added a guarded migration that removes the unit and repairs the two `Requires=` lines on existing installs. It is a no-op once applied.

I have kept that migration in a single `if [[ -f ... ]]` block so it is easy to drop if you would rather not carry migration logic here — happy to remove it and let the fix apply to new installs only. Just say the word.

## 🔗 Related Issue

None — found while running a container built from #16439. Same script, third distinct bug.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

### What was tested

Debian 13 unprivileged LXC on Proxmox VE 9.2.10, amd64.

A throwaway container was built **from this branch's install script**, driven through `build.func` exactly as normal (I pointed the two `_install_script` fetches at the local file, since `build.func` hardcodes `main`). It was destroyed afterwards.

**Fresh install from the patched script**

- Two units on disk, no `libreoffice-listener`. Both `active`, `systemctl --failed` empty.
- **`127.0.0.1:2002` is still listening** — owned by unoserver's own `soffice.bin`. Nothing that connects to 2002 loses its endpoint.
- No spinning process: `soffice.bin` sits at 0.6% CPU.
- `POST /api/v1/convert/file/pdf` with a `.docx` → `200`, valid PDF.
- `POST /api/v1/misc/ocr-pdf` (`languages=eng`, `ocrType=Force`) → `200`, and `pdftotext` read `QUICK BROWN FOX` back out of the rasterised page.
- Rebooted: came back with 2002/2003/8080 all listening, nothing failed, `/api/v1/info/status` → `200`.

**The bug reproduced on that same clean container**, by restoring the old unit files (so this is not specific to my host):

```
PID  TID  %CPU  COMMAND
918  921  96.4  URP Acceptor
```

…with the listener holding 2002 and `systemctl --failed` empty throughout.

**The `update_script()` migration**, run against that reproduced pre-fix state:

- Listener disabled and removed, both `Requires=` lines dropped, both `After=` lines repointed.
- Spinning thread gone; 2002 handed over to unoserver's instance.
- `systemctl --failed` empty — this needed the `reset-failed`, without which removing the unit leaves a permanent `libreoffice-listener.service not-found failed` entry. That showed up in testing and is why the line is there.
- Idempotent: the `-f` guard makes a second run a no-op.
- Rebooted afterwards; conversion through the app still returned `200` with a valid PDF.

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Written with Claude Code (model: Claude Opus 5, high reasoning effort). As with #16439, the scope is a targeted fix to an existing script rather than generated script content, so the script-creation guidance mostly does not apply. The diff was reviewed line by line, and every claim above was measured on a real container rather than reasoned about.

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
