### PR TITLE
fix(ampache): update to PHP 8.5 asset, auto-upgrade PHP on update

### DIFF
--- a/ct/ampache.sh
+++ b/ct/ampache.sh
@@ -39,7 +39,15 @@ function update_script() {
       /opt/ampache/public/play/.htaccess \
       /opt/ampache/advanced-config
 
-    fetch_and_deploy_gh_release "Ampache" "ampache/ampache" "prebuild" "latest" "/opt/ampache" "ampache-*_all_php8.4.zip"
+    if ! dpkg -l 2>/dev/null | grep -q "libapache2-mod-php8.5"; then
+      PHP_VERSION="8.5" PHP_APACHE="YES" setup_php
+      sed -i -e 's/upload_max_filesize = .*/upload_max_filesize = 100M/' \
+        -e 's/post_max_size = .*/post_max_size = 100M/' \
+        -e 's/max_execution_time = .*/max_execution_time = 600/' \
+        -e 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.5/apache2/php.ini
+    fi
+
+    fetch_and_deploy_gh_release "Ampache" "ampache/ampache" "prebuild" "latest" "/opt/ampache" "ampache-*_all_php8.5.zip"
 
     restore_backup
     chmod 664 /opt/ampache/public/rest/.htaccess /opt/ampache/public/play/.htaccess

--- a/install/ampache-install.sh
+++ b/install/ampache-install.sh
@@ -27,11 +27,11 @@ $STD apt install -y \
   libvpx-dev
 msg_ok "Installed dependencies"
 
-PHP_VERSION="8.4" PHP_APACHE="YES" setup_php
+PHP_VERSION="8.5" PHP_APACHE="YES" setup_php
 setup_mariadb
 MARIADB_DB_USER="ampache" MARIADB_DB_NAME="ampache" setup_mariadb_db
 
-fetch_and_deploy_gh_release "ampache" "ampache/ampache" "prebuild" "latest" "/opt/ampache" "ampache-*_all_php8.4.zip"
+fetch_and_deploy_gh_release "ampache" "ampache/ampache" "prebuild" "latest" "/opt/ampache" "ampache-*_all_php8.5.zip"
 
 msg_info "Setting up Ampache"
 rm -rf /var/www/html
@@ -58,7 +58,7 @@ msg_info "Configuring PHP"
 sed -i -e 's/upload_max_filesize = .*/upload_max_filesize = 100M/' \
   -e 's/post_max_size = .*/post_max_size = 100M/' \
   -e 's/max_execution_time = .*/max_execution_time = 600/' \
-  -e 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.4/apache2/php.ini
+  -e 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.5/apache2/php.ini
 $STD a2enmod rewrite
 $STD systemctl restart apache2
 msg_ok "Configured PHP"


### PR DESCRIPTION
## ✍️ Description

Ampache 8.0.0 dropped the `ampache-*_all_php8.4.zip` prebuilt release asset in favor of `php8.5`, so `fetch_and_deploy_gh_release` in both the install and update scripts could no longer find a matching asset.

- `install/ampache-install.sh`: provisions PHP 8.5 (`setup_php`), updated the release asset glob to `ampache-*_all_php8.5.zip`, and pointed the php.ini tuning at `/etc/php/8.5/apache2/php.ini`.
- `ct/ampache.sh` (`update_script`): updated the release asset glob to `php8.5`, and added a check that upgrades existing containers still running PHP 8.4 to PHP 8.5 (via `setup_php`, with the same php.ini tuning) before fetching the new release, so existing installs aren't stuck looking for an asset that no longer exists.

## 🔗 Related Issue

Fixes #16482

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.