### PR TITLE
[FIX] Shelfmark: internal bypasser never starts under the gevent worker

### DIFF
--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -38,25 +38,14 @@ function update_script() {
     systemctl stop shelfmark
     msg_ok "Stopped Service(s)"
 
-    # chromium.service (headless, port 9222) was never used: Shelfmark's internal bypasser
-    # launches its own browser on a random port. With DOCKERMODE enabled below it is also
-    # killed by Shelfmark's orphan-process reaper on every bypass, then respawned by systemd.
-    if [[ -f /etc/systemd/system/chromium.service ]]; then
-      msg_info "Removing unused chromium service"
-      systemctl disable -q --now chromium
-      rm -f /etc/systemd/system/chromium.service
-      systemctl daemon-reload
-      msg_ok "Removed unused chromium service"
-    fi
-
-    # Shelfmark is served by the gunicorn gevent worker; without DOCKERMODE it runs the bypass
-    # browser in-process, where the CDP connection never completes and every bypass fails with
-    # "Pure CDP browser startup timed out after 45s". Internal bypasser only.
     if [[ $(sed -n '/_BYPASS=/s/[^=]*=//p' /etc/shelfmark/.env) == "true" ]] &&
       [[ $(sed -n '/BYPASSER=/s/[^=]*=//p' /etc/shelfmark/.env) == "false" ]]; then
-      msg_info "Isolating the bypasser from the gevent worker"
+      msg_info "Updating internal bypasser configuration"
+      systemctl disable -q --now chromium 2>/dev/null || true
+      rm -f /etc/systemd/system/chromium.service
+      systemctl daemon-reload
       sed -i '/DOCKERMODE=/s/false/true/' /etc/shelfmark/.env
-      msg_ok "Isolated the bypasser from the gevent worker"
+      msg_ok "Updated internal bypasser configuration"
     fi
 
     [[ -f /etc/systemd/system/flaresolverr.service ]] && if check_for_gh_release "flaresolverr" "Flaresolverr/Flaresolverr"; then

--- a/ct/shelfmark.sh
+++ b/ct/shelfmark.sh
@@ -36,8 +36,28 @@ function update_script() {
   if check_for_gh_release "shelfmark" "calibrain/shelfmark"; then
     msg_info "Stopping Service(s)"
     systemctl stop shelfmark
-    [[ -f /etc/systemd/system/chromium.service ]] && systemctl stop chromium
     msg_ok "Stopped Service(s)"
+
+    # chromium.service (headless, port 9222) was never used: Shelfmark's internal bypasser
+    # launches its own browser on a random port. With DOCKERMODE enabled below it is also
+    # killed by Shelfmark's orphan-process reaper on every bypass, then respawned by systemd.
+    if [[ -f /etc/systemd/system/chromium.service ]]; then
+      msg_info "Removing unused chromium service"
+      systemctl disable -q --now chromium
+      rm -f /etc/systemd/system/chromium.service
+      systemctl daemon-reload
+      msg_ok "Removed unused chromium service"
+    fi
+
+    # Shelfmark is served by the gunicorn gevent worker; without DOCKERMODE it runs the bypass
+    # browser in-process, where the CDP connection never completes and every bypass fails with
+    # "Pure CDP browser startup timed out after 45s". Internal bypasser only.
+    if [[ $(sed -n '/_BYPASS=/s/[^=]*=//p' /etc/shelfmark/.env) == "true" ]] &&
+      [[ $(sed -n '/BYPASSER=/s/[^=]*=//p' /etc/shelfmark/.env) == "false" ]]; then
+      msg_info "Isolating the bypasser from the gevent worker"
+      sed -i '/DOCKERMODE=/s/false/true/' /etc/shelfmark/.env
+      msg_ok "Isolated the bypasser from the gevent worker"
+    fi
 
     [[ -f /etc/systemd/system/flaresolverr.service ]] && if check_for_gh_release "flaresolverr" "Flaresolverr/Flaresolverr"; then
       msg_info "Stopping FlareSolverr service"
@@ -79,7 +99,6 @@ function update_script() {
 
     msg_info "Starting Service(s)"
     systemctl start shelfmark
-    [[ -f /etc/systemd/system/chromium.service ]] && systemctl start chromium
     msg_ok "Started Service(s)"
     msg_ok "Updated successfully!"
   fi

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -116,10 +116,6 @@ else
     chromium-common \
     chromium \
     python3-tk
-  # DOCKERMODE gates whether Shelfmark runs the bypass browser in a helper process
-  # isolated from gunicorn/gevent. We serve Shelfmark with the gevent worker, so without
-  # it the CDP browser starts inside the monkey-patched loop and every bypass fails with
-  # "Pure CDP browser startup timed out after 45s".
   sed -i '/DOCKERMODE=/s/false/true/' /etc/shelfmark/.env
   msg_ok "Installed internal bypasser dependencies"
 fi

--- a/install/shelfmark-install.sh
+++ b/install/shelfmark-install.sh
@@ -116,6 +116,11 @@ else
     chromium-common \
     chromium \
     python3-tk
+  # DOCKERMODE gates whether Shelfmark runs the bypass browser in a helper process
+  # isolated from gunicorn/gevent. We serve Shelfmark with the gevent worker, so without
+  # it the CDP browser starts inside the monkey-patched loop and every bypass fails with
+  # "Pure CDP browser startup timed out after 45s".
+  sed -i '/DOCKERMODE=/s/false/true/' /etc/shelfmark/.env
   msg_ok "Installed internal bypasser dependencies"
 fi
 
@@ -165,22 +170,6 @@ KillMode=mixed
 WantedBy=multi-user.target
 EOF
 
-if [[ "$DEPLOYMENT_TYPE" == "1" ]]; then
-  cat <<EOF >/etc/systemd/system/chromium.service
-[Unit]
-Description=Chromium Headless Browser
-After=network.target
-
-[Service]
-User=root
-ExecStart=/usr/bin/chromium --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --hide-scrollbars
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-EOF
-  systemctl enable -q --now chromium
-fi
 if [[ "$DEPLOYMENT_TYPE" == "2" ]]; then
   cat <<EOF >/etc/systemd/system/flaresolverr.service
 [Unit]


### PR DESCRIPTION
## ✍️ Description

The internal captcha bypasser (deployment type 1) has never worked in the LXC.

Shelfmark is served by `gunicorn --worker-class geventwebsocket.gunicorn.workers.GeventWebSocketWorker`. Upstream's `DOCKERMODE` flag controls whether the bypass browser runs in a helper process — its own docstring says "Run the browser bypass in a helper process isolated from gunicorn/gevent" ([`internal_bypasser.py`](https://github.com/calibrain/shelfmark/blob/main/shelfmark/bypass/internal_bypasser.py)):

```python
if env.DOCKERMODE and os.environ.get(_BYPASS_CHILD_ENV) != "1":
    return _get_via_subprocess(url, retry, cancel_flag)
return _run_bypass_in_current_process(url, retry, cancel_flag)
```

With `DOCKERMODE=false` the SeleniumBase CDP browser starts inside the gevent-monkey-patched loop, its asyncio websocket never completes the connect, and every bypass fails:

```
Pure CDP browser startup timed out after 45s
```

Searches then burn their full retry budget (~2.5 min) and surface in the UI as "Unable to reach download source. Network restricted or mirrors are blocked." The flag is misnamed upstream — it gates gevent isolation, not Docker — so a bare-metal install behind gunicorn needs it too.

**Changes:**

1. `install/`: set `DOCKERMODE=true` for deployment type 1 only. External-bypasser and disabled installs are untouched.
2. `ct/`: migrate existing type-1 installs on update (guarded on `USE_CF_BYPASS=true` + `USING_EXTERNAL_BYPASSER=false`).
3. Remove `chromium.service`. Nothing in Shelfmark connects to port 9222 (`grep -rn 9222` over the source returns nothing) — the bypasser launches its own browser on a random port — so it was ~226 MB of idle Chromium. With `DOCKERMODE=true` it is additionally killed by Shelfmark's orphan-process reaper (`pkill -f chromium`) on every bypass and immediately respawned by systemd, since an LXC shares its PID namespace with the app. The update script disables and removes it.

Both files pass `bash -n`. Happy to split the `chromium.service` removal into its own PR if you'd rather keep this to the one-line fix.

## 🔗 Related Issue

No existing issue. Both lines date to the original ProxmoxVED migration (aab9d4232, #11371).

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Model: Claude Opus 5 (1M context), high reasoning effort, via Claude Code. Diagnosis and patch reviewed and verified by me on a live LXC.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 🧪 How Has This Been Tested?

On a live Debian 13 LXC installed with this script (deployment type 1, Shelfmark v1.3.7):

- **Before:** every Anna's Archive search → `Pure CDP browser startup timed out after 45s`, 10 retries, "mirrors are blocked". Zero results, ever.
- **After (`DOCKERMODE=true`):** `Bypass successful using _bypass_method_cdp_gui_click` → `Extracted 9 protection cookies` → `Found 24 releases via ISBN`, ~25 s, results render in the UI.
- Verified the same CDP startup succeeds standalone outside gunicorn, confirming gevent as the cause.
- Confirmed nothing binds or connects to 9222 after removing `chromium.service`; searches unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ln3yVj3sWHG2c6T78W1we
