### PR TITLE
core: skip mount points during backup and clean installs

### DIFF
--- a/misc/tools.func
+++ b/misc/tools.func
@@ -1336,6 +1336,10 @@ create_backup() {
       msg_warn "Skipping backup of '${path}' (not found)"
       continue
     fi
+    if mountpoint -q "$path" 2>/dev/null; then
+      msg_warn "Skipping backup of '${path}' (is a mount point)"
+      continue
+    fi
     dest="${store}/files${path}"
     if ! mkdir -p "$(dirname "$dest")" || ! cp -a "$path" "$dest"; then
       msg_error "Backup of '${path}' failed - aborting update"
@@ -2538,7 +2542,7 @@ _deploy_source_tarball() {
 
   mkdir -p "$target"
   if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
-    find "${target:?}" -mindepth 1 -delete
+    find "${target:?}" -mindepth 1 \( -type d -exec mountpoint -q {} \; -prune \) -o -delete
   fi
 
   tar --no-same-owner -xzf "$tarball" -C "$workdir" || {
@@ -2627,7 +2631,7 @@ _deploy_unpacked_archive() {
   # was truncated, the archive was unreadable, or it unpacked to nothing.
   mkdir -p "$target"
   if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
-    find "${target:?}" -mindepth 1 -delete
+    find "${target:?}" -mindepth 1 \( -type d -exec mountpoint -q {} \; -prune \) -o -delete
   fi
 
   if ! cp -r "$source_dir"/* "$target/"; then
@@ -9368,7 +9372,7 @@ fetch_and_deploy_from_url() {
   mkdir -p "$directory"
 
   if [[ "${CLEAN_INSTALL:-0}" == "1" ]]; then
-    find "${directory:?}" -mindepth 1 -delete
+    find "${directory:?}" -mindepth 1 \( -type d -exec mountpoint -q {} \; -prune \) -o -delete
   fi
 
   local unpack_tmp

--- a/misc/tools.func
+++ b/misc/tools.func
@@ -2528,9 +2528,9 @@ _download_source_tarball() {
 # directory). Extracts <tarball_path> into <workdir>, then copies the contents
 # of that top-level directory into <target>.
 #
-#   - Honors CLEAN_INSTALL=1 (wipes <target> first, dotfiles included — back
-#     up config dotfiles like .env via create_backup and call restore_backup
-#     BEFORE any build step that sources them).
+#   - Honors CLEAN_INSTALL=1 (wipes <target> first, dotfiles included, mount
+#     points preserved — back up config dotfiles like .env via create_backup
+#     and call restore_backup BEFORE any build step that sources them).
 #   - Does NOT own <workdir>: the caller creates it and is responsible for its
 #     cleanup (typically via a RETURN trap on its tmpdir).
 #   - cp failures are non-fatal here, matching the previous inline behavior.
@@ -2568,9 +2568,9 @@ _deploy_source_tarball() {
 # a single top-level directory, that directory is stripped (its contents land
 # directly in <target>); otherwise the archive contents are copied as-is.
 #
-#   - Honors CLEAN_INSTALL=1 (wipes <target> first, dotfiles included — back
-#     up config dotfiles like .env via create_backup and call restore_backup
-#     BEFORE any build step that sources them).
+#   - Honors CLEAN_INSTALL=1 (wipes <target> first, dotfiles included, mount
+#     points preserved — back up config dotfiles like .env via create_backup
+#     and call restore_backup BEFORE any build step that sources them).
 #   - Does NOT own <workdir>: the caller creates it and cleans it up.
 #
 # Returns: 0 on success, 65 on unsupported format, 251 on extraction failure,


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
Prevent accidental deletion or backup of mount points:
- In create_backup(), skip paths that are mount points with a warning
- In _deploy_source_tarball(), _deploy_unpacked_archive(), and fetch_and_deploy_from_url(), use find with mountpoint pruning to avoid deleting mount point directories during CLEAN_INSTALL


## 🔗 Related Issue

Fixes #16513

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [x] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [x] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
