### PR TITLE
fix romm: add missing /decode and /cache locations to Angie config

### DIFF
--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -42,16 +42,17 @@ $STD apt install -y \
   tzdata
 msg_ok "Installed Dependencies"
 
-msg_info "Installing Angie with mod_zip module"
+msg_info "Installing Angie with mod_zip and njs modules"
 setup_deb822_repo \
   "angie" \
   "https://angie.software/keys/angie-signing.gpg" \
   "https://download.angie.software/angie/debian/$(get_os_info version_id)" \
   "$(get_os_info codename)" \
   "main"
-$STD apt-get install -y angie angie-module-zip
+$STD apt-get install -y angie angie-module-zip angie-module-njs
+sed -i '1i load_module modules/ngx_http_js_module.so;' /etc/angie/angie.conf
 sed -i '1i load_module modules/ngx_http_zip_module.so;' /etc/angie/angie.conf
-msg_ok "Installed Angie with mod_zip module"
+msg_ok "Installed Angie with mod_zip and njs modules"
 PYTHON_VERSION="3.13" setup_uv
 NODE_VERSION="24" setup_nodejs
 setup_mariadb
@@ -63,7 +64,8 @@ mkdir -p /opt/romm \
   /var/lib/romm/resources \
   /var/lib/romm/assets/{saves,states,screenshots} \
   /var/lib/romm/library/roms \
-  /var/lib/romm/library/bios
+  /var/lib/romm/library/bios \
+  /var/lib/romm/cache
 msg_ok "Created directories"
 
 msg_info "Creating configuration file"
@@ -215,7 +217,34 @@ ln -sfn "$ROMM_BASE"/assets /opt/romm/frontend/dist/assets/romm/assets
 msg_ok "Set up RomM Frontend"
 
 msg_info "Configuring Angie"
+mkdir -p /etc/angie/js
+cat <<'EOF' >/etc/angie/js/decode.js
+// Decode a Base64 encoded string received as a query parameter named 'value',
+// and return the decoded value in the response body.
+function decodeBase64(r) {
+  var encodedValue = r.args.value;
+
+  if (!encodedValue) {
+    r.return(400, "Missing 'value' query parameter");
+    return;
+  }
+
+  try {
+    // Use Buffer to return raw bytes — atob() returns a JS string which r.return()
+    // would re-encode as UTF-8, corrupting any non-ASCII bytes (e.g. in filenames
+    // like "Pokémon") and causing CRC mismatches in the mod_zip manifest.
+    r.return(200, Buffer.from(encodedValue, 'base64'));
+  } catch (e) {
+    r.return(400, "Invalid Base64 encoding");
+  }
+}
+
+export default { decodeBase64 };
+EOF
+
 cat <<'EOF' >/etc/angie/http.d/romm.conf
+js_import /etc/angie/js/decode.js;
+
 upstream romm_backend {
     server 127.0.0.1:5000;
 }
@@ -282,10 +311,23 @@ server {
         internal;
         alias /var/lib/romm/library/;
     }
+
+    # Internally redirect cached zip file requests (Range-resumable downloads)
+    location /cache/ {
+        internal;
+        alias /var/lib/romm/cache/;
+    }
+
+    # Internal decoding endpoint, used to build .m3u entries for mod_zip
+    location /decode {
+        internal;
+        js_content decode.decodeBase64;
+    }
 }
 EOF
 
 sed -i "s|alias /var/lib/romm/library/;|alias ${ROMM_BASE}/library/;|" /etc/angie/http.d/romm.conf
+sed -i "s|alias /var/lib/romm/cache/;|alias ${ROMM_BASE}/cache/;|" /etc/angie/http.d/romm.conf
 rm -f /etc/angie/http.d/default.conf
 systemctl restart angie
 systemctl enable -q --now angie


### PR DESCRIPTION
## ✍️ Description

RomM assembles multi-file downloads (multi-disc games, `bin`/`cue` sets) with mod_zip. Alongside the real files, the manifest contains a generated `.m3u` entry pointing at `/decode?value=<base64>`, which the webserver is expected to decode with njs and return as the playlist body. Upstream RomM's own config does this:

```nginx
location /decode {
    internal;
    js_content decode.decodeBase64;
}
```

Our Angie config has no such location, so that subrequest falls through to the SPA catch-all (`try_files $uri $uri/ /index.html`) and returns `index.html` with a 200. mod_zip embeds the HTML page where the `.m3u` body should be. The declared entry size no longer matches the bytes served, every subsequent offset shifts, and the client receives a full-size archive whose central directory is unreachable:

```
$ ls -l "Metal Gear Solid (USA) (Disc 1) (v1.1).zip"
-rw-r--r--  1 user  staff  705615164
$ unzip -t "Metal Gear Solid (USA) (Disc 1) (v1.1).zip"
  End-of-central-directory signature not found.
$ xxd -s -128 "Metal Gear Solid (USA) (Disc 1) (v1.1).zip"
... 3d22 6d61 736b 2d69 636f 6e22 2068 7265   ="mask-icon" hre
```

The archive ends in RomM's own HTML `<head>`. Nothing errors and nothing is logged, so it surfaces to users as "downloads are corrupt".

This adds, to match upstream:

- `angie-module-njs` plus the `load_module` line for it.
- `/etc/angie/js/decode.js`, copied verbatim from [RomM's repo](https://github.com/rommapp/romm/blob/master/docker/nginx/js/decode.js).
- `js_import` and the `location /decode` block.
- `location /cache/` and the `cache` directory, which upstream uses for Range-resumable downloads and which is also currently missing.

Single-file ROMs are unaffected, which is why this hasn't been more visible.

## 🔗 Related Issue

No existing issue — found while debugging an affected container.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

Testing detail, so reviewers know what was and wasn't covered: the missing-`/decode` diagnosis was confirmed on an affected container by inspecting the produced archive (above), and the equivalent config was applied by hand on nginx there, after which multi-file downloads extracted cleanly. The script parses under `bash -n`. A full clean install on Angie was **not** run, so the `angie-module-njs` package name and the `ngx_http_js_module.so` module path deserve a maintainer's eye — they follow the existing `angie-module-zip` pattern in this same block, but I could not verify them on a live Angie install.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Model: `claude-opus-5` (Claude). Reasoning level is not exposed to the model, so it cannot be reported precisely. AGENTS.md was consulted; the change follows the surrounding block's existing conventions (`$STD`, `msg_info`/`msg_ok`, heredoc file creation, two-space indentation). Reviewed and diagnosed against a real affected container before submitting.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
