### PR TITLE
fix romm: deploy EmulatorJS and Ruffle after the frontend build

### DIFF
--- a/install/romm-install.sh
+++ b/install/romm-install.sh
@@ -136,8 +136,6 @@ else
 fi
 
 fetch_and_deploy_gh_release "romm" "rommapp/romm" "tarball"
-fetch_and_deploy_gh_release "ruffle" "ruffle-rs/ruffle" "prebuild" "latest" "/opt/romm/frontend/dist/assets/ruffle" "ruffle-*-web-selfhosted.zip"
-fetch_and_deploy_gh_release "EmulatorJS" "EmulatorJS/EmulatorJS" "prebuild" "v4.2.3" "/opt/romm/frontend/dist/assets/emulatorjs" "4.2.3.7z"
 
 msg_info "Creating environment file"
 sed -i 's/^supervised no/supervised systemd/' /etc/redis/redis.conf
@@ -213,6 +211,9 @@ ROMM_BASE=${ROMM_BASE:-/var/lib/romm}
 ln -sfn "$ROMM_BASE"/resources /opt/romm/frontend/dist/assets/romm/resources
 ln -sfn "$ROMM_BASE"/assets /opt/romm/frontend/dist/assets/romm/assets
 msg_ok "Set up RomM Frontend"
+
+fetch_and_deploy_gh_release "ruffle" "ruffle-rs/ruffle" "prebuild" "latest" "/opt/romm/frontend/dist/assets/ruffle" "ruffle-*-web-selfhosted.zip"
+fetch_and_deploy_gh_release "EmulatorJS" "EmulatorJS/EmulatorJS" "prebuild" "v4.2.3" "/opt/romm/frontend/dist/assets/emulatorjs" "4.2.3.7z"
 
 msg_info "Configuring Angie"
 cat <<'EOF' >/etc/angie/http.d/romm.conf


### PR DESCRIPTION
## ✍️ Description

`install/romm-install.sh` deploys the EmulatorJS and Ruffle payloads into `/opt/romm/frontend/dist/assets/` **before** the frontend is built. `npm run build` (Vite) empties `dist/` and regenerates it, so both payloads are destroyed. The `cp -rf /opt/romm/frontend/assets/*` that follows only restores the SVG logos, because that is all the source `assets/` directory contains.

The result is that every RomM LXC built by this script ends up with **no local in-browser emulator**:

```
/opt/romm/frontend/dist/assets/emulatorjs   ->  24K, 3 SVG logos, no data/
/opt/romm/frontend/dist/assets/ruffle       ->  16K, 2 logo files
```

**It does not fail loudly**, which is why it has gone unnoticed: RomM's player probes the local loader, gets the Angie 404 page (`text/html`) instead of JavaScript, logs `[Play] Local loader failed, trying CDN`, and silently falls back to `cdn.emulatorjs.org`. Play still works, so the container looks healthy — while every session depends on internet access and a third-party CDN, and the CDN build can drift from the pinned `v4.2.3`.

```
local  /assets/emulatorjs/data/loader.js        -> HTTP 404 (Content-Type: text/html)
public cdn.emulatorjs.org/4.2.3/data/loader.js  -> HTTP 200
```

This PR moves the two `fetch_and_deploy_gh_release` calls to **after** `msg_ok "Set up RomM Frontend"`. It is a pure reordering — no logic, no new dependencies, and no added comments. It also makes the install path consistent with `update_script()` in `ct/romm.sh`, which already deploys EmulatorJS **after** the frontend build for exactly this reason.

The calls are left at top level rather than inside the `msg_info`/`msg_ok` block, since `fetch_and_deploy_gh_release` prints its own status lines.

### Verification

Tested on a live RomM LXC (Debian 13, RomM 5.1.0) built by this script:

1. **Reproduced the cause.** Deployed the payload, then ran the script's own frontend build and observed the wipe:
   ```
   BEFORE build : 297M   loader=present
   AFTER build  :        loader=MISSING     <- Vite emptied dist/
   AFTER cp -rf : 296M   loader=present     <- only because assets/ was pre-seeded
   ```
2. **Verified the fix.** Cleared both payloads and both version markers (`/root/.emulatorjs`, `/root/.ruffle`) to reproduce fresh-install state, sourced `install.func` + `tools.func`, and ran the two lines exactly as this PR places them:
   ```
   fresh: markers=0 payloads=0
   emulatorjs loader.js : PRESENT
   ruffle ruffle.js     : PRESENT
   ```
3. **Confirmed serving.** `/assets/emulatorjs/data/loader.js` now returns `HTTP 200 application/javascript`, `/assets/ruffle/ruffle.js` returns 200, and the container is otherwise unchanged (`/api/heartbeat` 200, frontend 200, all services active).

Note for reviewers: `fetch_and_deploy_gh_release` is idempotent against `$HOME/.<app-lowercased>`, so it correctly no-ops on a container that already has the payload. That is right for updates, but it means a wiped `dist/` is never noticed on a re-run — reordering the install is the fix, not a marker change.

Written with AI assistance: **Claude Opus 5**, via Claude Code. Every claim above is a measured result from a real container rather than a model assertion, and the diff was reviewed by hand.

## 🔗 Related Issue

N/A — found while building a RomM LXC from this script. No existing issue or PR covers it (searched open/closed `romm` PRs and `romm emulatorjs` issues).

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
