### PR TITLE
VictoriaMetrics: use github_api_call for release lookups so GITHUB_TOKEN is honored

### DIFF
--- a/install/victoriametrics-install.sh
+++ b/install/victoriametrics-install.sh
@@ -15,9 +15,11 @@ update_os
 
 msg_info "Getting latest version of VictoriaMetrics"
 
-victoriametrics_release=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases" |
-  jq -r --arg a "$(arch_resolve)" '.[] | select(.assets[].name | match("^victoria-metrics-linux-" + $a + "-v[0-9.]+.tar.gz$")) | .tag_name' |
+vm_releases_json="$(mktemp)"
+github_api_call "https://api.github.com/repos/VictoriaMetrics/VictoriaMetrics/releases" "$vm_releases_json"
+victoriametrics_release=$(jq -r --arg a "$(arch_resolve)" '.[] | select(.assets[].name | match("^victoria-metrics-linux-" + $a + "-v[0-9.]+.tar.gz$")) | .tag_name' "$vm_releases_json" |
   head -n 1)
+rm -f "$vm_releases_json"
 victoriametrics_filename="victoria-metrics-linux-$(arch_resolve)-${victoriametrics_release}.tar.gz"
 vmutils_filename="vmutils-linux-$(arch_resolve)-${victoriametrics_release}.tar.gz"
 msg_ok "Got version $victoriametrics_release of VictoriaMetrics"
@@ -28,12 +30,13 @@ fetch_and_deploy_gh_release "vmutils" "VictoriaMetrics/VictoriaMetrics" "prebuil
 read -r -p "${TAB3}Would you like to add VictoriaLogs? <y/N> " prompt
 
 if [[ ${prompt,,} =~ ^(y|yes)$ ]]; then
-  vmlogs_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaLogs/releases/latest" |
-    jq -r '.assets[].name' |
+  vl_release_json="$(mktemp)"
+  github_api_call "https://api.github.com/repos/VictoriaMetrics/VictoriaLogs/releases/latest" "$vl_release_json"
+  vmlogs_filename=$(jq -r '.assets[].name' "$vl_release_json" |
     grep -E "^victoria-logs-linux-$(arch_resolve)-v[0-9.]+\.tar\.gz$")
-  vlutils_filename=$(curl -fsSL "https://api.github.com/repos/VictoriaMetrics/VictoriaLogs/releases/latest" |
-    jq -r '.assets[].name' |
+  vlutils_filename=$(jq -r '.assets[].name' "$vl_release_json" |
     grep -E "^vlutils-linux-$(arch_resolve)-v[0-9.]+\.tar\.gz$")
+  rm -f "$vl_release_json"
   fetch_and_deploy_gh_release "victorialogs" "VictoriaMetrics/VictoriaLogs" "prebuild" "latest" "/opt/victoriametrics" "$vmlogs_filename"
   fetch_and_deploy_gh_release "vlutils" "VictoriaMetrics/VictoriaLogs" "prebuild" "latest" "/opt/victoriametrics" "$vlutils_filename"
 fi


### PR DESCRIPTION
## ✍️ Description

`install/victoriametrics-install.sh` resolved release tags with three raw unauthenticated `curl` calls to `api.github.com` (one against `VictoriaMetrics/releases`, two identical ones against `VictoriaLogs/releases/latest`). These ignore `GITHUB_TOKEN` even when the user exported it, so on a shared/depleted unauthenticated bucket (60/hr per public IP) the install dies with `curl: (22)` **after the container is created** — while `fetch_and_deploy_gh_release` two lines later and `check_for_gh_release` in the update path authenticate correctly.

This PR resolves the tags via the existing `github_api_call()` helper from `misc/tools.func` (auth header when `GITHUB_TOKEN` is set, retries, proper rate-limit diagnosis), the same way `install/proxmox-backup-server-install.sh` already does. The `jq` filters are unchanged; they now read from a temp file instead of a pipe. The two identical VictoriaLogs API calls are collapsed into one.

Testing: the transformed resolution logic was executed against the live API and produces byte-identical results to the old pipelines — VictoriaMetrics tag `v1.150.0`, VictoriaLogs assets `victoria-logs-linux-amd64-v1.52.0.tar.gz` / `vlutils-linux-amd64-v1.52.0.tar.gz` — and the failure mode it fixes was hit during a real build on 2026-08-19 (403 on the raw call, 200 with the token, verified via `X-RateLimit-Limit` headers; details in the linked issue). `bash -n` passes. A full container rebuild was not re-run.

AI assistance: written with Claude Code (model claude-fable-5); reviewed and tested as described above.

## 🔗 Related Issue

Fixes #16606

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
