### PR TITLE
fix: clean yarn cache after mealie frontend build to prevent disk growth

### DIFF
--- a/ct/mealie.sh
+++ b/ct/mealie.sh
@@ -75,6 +75,7 @@ STARTEOF
     cd /opt/mealie/frontend
     $STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
     $STD yarn generate
+    $STD yarn cache clean
     msg_ok "Built Frontend"
 
     msg_info "Copying Built Frontend"

--- a/install/mealie-install.sh
+++ b/install/mealie-install.sh
@@ -48,6 +48,7 @@ $STD sed -i "s|value: data.buildId,|value: \"v${MEALIE_VERSION}\",|g" "$SITE_SET
 $STD sed -i "s|value: data.production ? i18n.t(\"about.production\") : i18n.t(\"about.development\"),|value: \"bare-metal\",|g" "$SITE_SETTINGS"
 $STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
 $STD yarn generate
+$STD yarn cache clean
 msg_ok "Built Frontend"
 
 msg_info "Copying Built Frontend"


### PR DESCRIPTION
## ✍️ Description
Mealie's frontend build (`yarn install` + `yarn generate`) runs on every initial install and every update, but the script never runs `yarn cache clean` afterward. Yarn's global package cache lives outside `/opt/mealie` (typically `~/.cache/yarn`), so it isn't scoped to the app directory and isn't touched by the script's clean-install logic. Each update pulls a slightly different `yarn.lock`, fetches whatever's new, and leaves the old cached tarballs behind — so the cache grows indefinitely across updates. This is confusing to diagnose because `du` on `/opt/mealie` shows nothing, since the space is being consumed elsewhere.

This PR adds `$STD yarn cache clean` immediately after `$STD yarn generate` in both `install/mealie-install.sh` (initial install) and `ct/mealie.sh` (`update_script()`), so the cache is reclaimed after every build rather than accumulating over time.

This was reported upstream in `mealie-recipes/mealie#7813`, where it was determined the growth actually originates in this script rather than in Mealie itself.

Claude was used for root cause, but the fix was implemented, reviewed, and tested manually against a live Mealie LXC.

## 🔗 Related Issue
Fixes # mealie issue [#7813](https://github.com/mealie-recipes/mealie/issues/7813)

## ✅ Prerequisites (**X** in brackets)
- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)
> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
