### PR TITLE
protonmail-bridge: install dbus-x11 so keychain fallback to pass works

### DIFF
--- a/install/protonmail-bridge-install.sh
+++ b/install/protonmail-bridge-install.sh
@@ -14,7 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Dependencies"
-$STD apt install -y pass
+$STD apt install -y pass dbus-x11
 msg_ok "Installed Dependencies"
 
 msg_info "Creating Service User"


### PR DESCRIPTION
## Problem

Fresh installs of the Proton Mail Bridge LXC fail to reach a usable state. The service logs a warning and never proceeds further:

```
WARN[...] Failed to add test credentials to keychain  error="failed to open dbus connection: exec: \"dbus-launch\": executable file not found in $PATH" helper="*keychain.SecretServiceDBusHelper"
```

No further log lines appear, no mail client can connect, and the service just sits there.

## Root cause

Bridge's keychain-resolution logic tries the Secret Service D-Bus helper first. Without `dbus-launch` (provided by `dbus-x11`), it can't even open a D-Bus connection to attempt that probe — this appears to abort the whole keychain-resolution loop before it ever reaches the `pass`-based helper that `protonmailbridge-configure` already sets up (this script intentionally uses `pass`, not Secret Service, as the keychain backend — no Secret Service provider is installed anywhere in this script).

With `dbus-x11` installed, the same Secret Service probe still fails (nothing provides `org.freedesktop.secrets`, which is expected — that's by design here), but it now fails *cleanly* instead of erroring on the missing binary, and the resolution loop proceeds to use the already-initialized `pass` store as intended.

## Fix

Add `dbus-x11` alongside `pass` in the dependency install step. One-line change.

## Verification

Confirmed on a live install:
- Before: warning above, no further progress, no mail client could connect.
- After: same Secret Service warning (expected/harmless), followed by successful startup on the `pass` backend. Apple Mail connected and has been syncing successfully since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)