### PR TITLE
fireshare: source fireshare.env during update

### DIFF
--- a/ct/fireshare.sh
+++ b/ct/fireshare.sh
@@ -57,11 +57,9 @@ function update_script() {
     $STD .venv/bin/python -m pip install --upgrade --break-system-packages pip
     $STD .venv/bin/python -m pip install --no-cache-dir --break-system-packages --ignore-installed app/server
     cp .venv/bin/fireshare /usr/local/bin/fireshare
-    export FLASK_APP="/opt/fireshare/app/server/fireshare:create_app()"
-    export DATA_DIRECTORY=/opt/fireshare-data
-    export IMAGE_DIRECTORY=/opt/fireshare-images
-    export VIDEO_DIRECTORY=/opt/fireshare-videos
-    export PROCESSED_DIRECTORY=/opt/fireshare-processed
+    set -a
+    source /opt/fireshare/fireshare.env
+    set +a
     $STD uv run flask db upgrade
     cd /opt/fireshare/app/client
     $STD npm install


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description


## 🔗 Related Issue

Fixes #16698

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [x] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
