### PR TITLE
fix(apache-tika): handle upstream's switch from jar to zip distribution

### DIFF
--- a/ct/apache-tika.sh
+++ b/ct/apache-tika.sh
@@ -35,11 +35,15 @@ function update_script() {
     msg_ok "Stopped Service"
 
     msg_info "Updating ${APP} to v${RELEASE}"
-    cd /opt/apache-tika
-    curl -fsSL -o tika-server-standard-${RELEASE}.jar "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.jar"
-    mv --force tika-server-standard.jar tika-server-standard-prev-version.jar
-    mv tika-server-standard-${RELEASE}.jar tika-server-standard.jar
-    rm -rf /opt/apache-tika/tika-server-standard-prev-version.jar
+    # As of 4.0.0, upstream ships tika-server-standard as a zip instead of a
+    # standalone jar: tika-server-standard-<version>.jar inside it is a thin
+    # launcher whose manifest Class-Path depends on a sibling lib/ (and
+    # plugins/) directory that has to move in lockstep with it.
+    # fetch_and_deploy_from_url handles the zip/tar/deb extraction itself;
+    # CLEAN_INSTALL=1 replaces the whole directory instead of leaving the
+    # previous version's lib/ jars mixed in with the new ones.
+    CLEAN_INSTALL=1 fetch_and_deploy_from_url "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.zip" /opt/apache-tika
+    mv "/opt/apache-tika/tika-server-standard-${RELEASE}.jar" /opt/apache-tika/tika-server-standard.jar
     echo "${RELEASE}" >/opt/${APP}_version.txt
     msg_ok "Updated ${APP} to v${RELEASE}"
 

--- a/ct/apache-tika.sh
+++ b/ct/apache-tika.sh
@@ -35,13 +35,6 @@ function update_script() {
     msg_ok "Stopped Service"
 
     msg_info "Updating ${APP} to v${RELEASE}"
-    # As of 4.0.0, upstream ships tika-server-standard as a zip instead of a
-    # standalone jar: tika-server-standard-<version>.jar inside it is a thin
-    # launcher whose manifest Class-Path depends on a sibling lib/ (and
-    # plugins/) directory that has to move in lockstep with it.
-    # fetch_and_deploy_from_url handles the zip/tar/deb extraction itself;
-    # CLEAN_INSTALL=1 replaces the whole directory instead of leaving the
-    # previous version's lib/ jars mixed in with the new ones.
     CLEAN_INSTALL=1 fetch_and_deploy_from_url "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.zip" /opt/apache-tika
     mv "/opt/apache-tika/tika-server-standard-${RELEASE}.jar" /opt/apache-tika/tika-server-standard.jar
     echo "${RELEASE}" >/opt/${APP}_version.txt

--- a/install/apache-tika-install.sh
+++ b/install/apache-tika-install.sh
@@ -36,11 +36,6 @@ JAVA_VERSION="21" setup_java
 
 msg_info "Installing Apache Tika"
 RELEASE="$(curl -fsSL https://dlcdn.apache.org/tika/ | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1)"
-# As of 4.0.0, upstream ships tika-server-standard as a zip instead of a
-# standalone jar: tika-server-standard-<version>.jar inside it is a thin
-# launcher whose manifest Class-Path depends on a sibling lib/ (and
-# plugins/) directory that has to be deployed alongside it -
-# fetch_and_deploy_from_url handles that extraction.
 fetch_and_deploy_from_url "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.zip" /opt/apache-tika
 mv "/opt/apache-tika/tika-server-standard-${RELEASE}.jar" /opt/apache-tika/tika-server-standard.jar
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt

--- a/install/apache-tika-install.sh
+++ b/install/apache-tika-install.sh
@@ -35,11 +35,14 @@ msg_ok "Installed Dependencies"
 JAVA_VERSION="21" setup_java
 
 msg_info "Installing Apache Tika"
-mkdir -p /opt/apache-tika
-cd /opt/apache-tika
 RELEASE="$(curl -fsSL https://dlcdn.apache.org/tika/ | grep -oP '(?<=href=")[0-9]+\.[0-9]+\.[0-9]+(?=/")' | sort -V | tail -n1)"
-curl -fsSL "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.jar" -o tika-server-standard-${RELEASE}.jar
-mv tika-server-standard-${RELEASE}.jar tika-server-standard.jar
+# As of 4.0.0, upstream ships tika-server-standard as a zip instead of a
+# standalone jar: tika-server-standard-<version>.jar inside it is a thin
+# launcher whose manifest Class-Path depends on a sibling lib/ (and
+# plugins/) directory that has to be deployed alongside it -
+# fetch_and_deploy_from_url handles that extraction.
+fetch_and_deploy_from_url "https://dlcdn.apache.org/tika/${RELEASE}/tika-server-standard-${RELEASE}.zip" /opt/apache-tika
+mv "/opt/apache-tika/tika-server-standard-${RELEASE}.jar" /opt/apache-tika/tika-server-standard.jar
 echo "${RELEASE}" >/opt/${APPLICATION}_version.txt
 msg_ok "Installed Apache Tika"
 


### PR DESCRIPTION
<!-- Model: Claude Sonnet 5, reasoning effort: medium -->

## ✍️ Description

Apache Tika 4.0.0 stopped publishing `tika-server-standard` as a standalone executable jar and now ships it as a `.zip`. Both `install/apache-tika-install.sh` and `ct/apache-tika.sh`'s `update_script()` still `curl` a `tika-server-standard-${RELEASE}.jar` directly, which now 404s — install and update are both currently broken for the 4.0.0 release.

Pointing the URL at the `.zip` instead isn't enough on its own: inside it, `tika-server-standard-4.0.0.jar` is a ~48KB thin launcher jar whose manifest `Class-Path` resolves ~150 dependency jars from a sibling `lib/` directory (plus a `plugins/` tree) — the old ~76MB fat/shaded jar doesn't exist in this release anymore. The whole archive has to be extracted together, not just the top-level jar renamed.

Both scripts now use `fetch_and_deploy_from_url` (already the pattern in other scripts, e.g. `ct/technitiumdns.sh`, `install/ntopng-install.sh`) instead of hand-rolling curl+unzip:

- `install/apache-tika-install.sh`: `fetch_and_deploy_from_url "…/tika-server-standard-${RELEASE}.zip" /opt/apache-tika`, then rename the versioned launcher jar back to the unversioned `tika-server-standard.jar` the systemd unit expects.
- `ct/apache-tika.sh` `update_script()`: same call with `CLEAN_INSTALL=1` so a later update replaces `lib/`/`plugins/` wholesale instead of leaving a previous version's jars mixed in with the new ones.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## Test plan

- Ran the actual `ct/apache-tika.sh` from this branch (sourcing `build.func`/`tools.func` live from this repo's `main`, unmodified) against a live LXC container previously on Tika 3.3.2, non-interactively (`TERM=linux`, stdin closed — the same silent path the community-scripts update flow uses), targeting the current latest release (4.0.0):
  - `fetch_and_deploy_from_url` correctly auto-detected the zip, extracted `bin/`, `lib/`, `plugins/`, `tika-server-standard-4.0.0.jar` into `/opt/apache-tika`
  - `mv` renamed the versioned jar to the unversioned `tika-server-standard.jar` the existing systemd unit's `ExecStart` expects — unit file itself is unchanged
  - `systemctl start apache-tika` came up clean, no classpath/`NoClassDefFoundError` errors
  - `curl http://localhost:9998/version` → `Apache Tika 4.0.0`
  - Re-ran `update_script()` a second time (simulating a later release) to confirm `CLEAN_INSTALL=1` replaces the directory instead of leaving old `lib/` jars behind
- `bash -n` on both changed scripts
- Fresh-install path (`install/apache-tika-install.sh`) shares the same `fetch_and_deploy_from_url` call verified above, but wasn't separately exercised through full container creation on Proxmox
