### PR TITLE
fix(stirling-pdf): remove broken ExecStop using %n

### DIFF
--- a/install/stirling-pdf-install.sh
+++ b/install/stirling-pdf-install.sh
@@ -147,7 +147,6 @@ Group=root
 EnvironmentFile=/opt/Stirling-PDF/.env
 WorkingDirectory=/opt/Stirling-PDF
 ExecStart=/usr/bin/java -jar Stirling-PDF.jar
-ExecStop=/bin/kill -15 %n
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
## ✍️ Description

The generated `stirlingpdf.service` unit used:

```ini
ExecStop=/bin/kill -15 %n
```

systemd expands `%n` to the **unit name** (`stirlingpdf.service`), not a PID, so `/bin/kill` fails to parse it and logs a spurious `status=1/FAILURE` control-process error on every stop/restart. It does not block shutdown, but it is misleading when debugging unrelated issues.

**Fix:** Remove the `ExecStop` line. For `Type=simple`, systemd sends SIGTERM to the main PID on stop by default, and the existing `SuccessExitStatus=143` (128+15) already makes that a graceful, success-reported stop. The line is both redundant and broken.

Only affects newly created containers. Existing containers can be fixed with:

```bash
sed -i '/^ExecStop=/d' /etc/systemd/system/stirlingpdf.service
systemctl daemon-reload
```

> AI assistance: Claude Opus 4.8 (Claude Code), reasoning level: high.

## 🔗 Related Issue

Fixes #16807

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
