### PR TITLE
github action: post the command that tests a ct/ or install/ change

### DIFF
--- a/.github/workflows/pr-test-command.yml
+++ b/.github/workflows/pr-test-command.yml
@@ -1,0 +1,179 @@
+name: PR test command
+
+# A reviewer should not have to work out which URL exercises a pull request.
+# The engine and the scripts resolve independently, so pointing
+# COMMUNITY_SCRIPTS_URL at this PR's branch runs the changed ct/ and install/
+# scripts against the production engine. This posts that command, filled in.
+#
+# Only for scripts that already bootstrap from community-scripts/core: the older
+# one-liner ignores COMMUNITY_SCRIPTS_URL entirely, so a command built for it
+# would quietly install main and look like it passed.
+#
+# pull_request_target, so the comment can be posted on PRs from forks -- which is
+# most of them. Nothing from the pull request is checked out or executed here.
+# The file list, the branch name and the bootstrap line all come from the API,
+# the branch name is pattern-checked before it reaches the comment, and the body
+# is assembled in JavaScript, so no attacker-controlled string reaches a shell.
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+    paths:
+      - "ct/**"
+      - "install/**"
+
+jobs:
+  comment:
+    if: github.repository == 'community-scripts/ProxmoxVE'
+    runs-on: self-hosted
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const MARKER = '<!-- pr-test-command -->';
+            const MAX_APPS = 10;
+
+            const pr = context.payload.pull_request;
+            const head = pr.head.repo;            // null when the fork is gone
+            if (!head) return;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // Git allows backticks in a ref name, and this one ends up inside a
+            // fenced block. Anything outside the ordinary set is not worth
+            // rendering, so bail rather than escape.
+            const ref = pr.head.ref;
+            if (!/^[A-Za-z0-9._\/-]+$/.test(ref)) return;
+            const base = `https://raw.githubusercontent.com/${head.full_name}/${ref}`;
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+
+            // ct/foo.sh and install/foo-install.sh are the same app. A removed
+            // file has nothing left to run.
+            const apps = new Map();               // slug -> {ct, install}
+            for (const f of files) {
+              if (f.status === 'removed') continue;
+              let m = f.filename.match(/^ct\/([a-z0-9][a-z0-9._-]*)\.sh$/);
+              if (m) { apps.set(m[1], { ...apps.get(m[1]), ct: true }); continue; }
+              m = f.filename.match(/^install\/([a-z0-9][a-z0-9._-]*)-install\.sh$/);
+              if (m) apps.set(m[1], { ...apps.get(m[1]), install: true });
+            }
+            if (apps.size === 0) return;
+
+            // Read the ct script at the PR head to see which engine it loads.
+            // Read only -- it is never sourced or run.
+            async function bootstrapOf(slug) {
+              try {
+                const res = await github.rest.repos.getContent({
+                  owner: head.owner.login, repo: head.name,
+                  path: `ct/${slug}.sh`, ref: pr.head.sha,
+                });
+                if (!res.data.content) return 'unknown';
+                const text = Buffer.from(res.data.content, 'base64').toString('utf8');
+                const firstLines = text.split('\n').slice(0, 12).join('\n');
+                return /_cs_boot=/.test(firstLines) ? 'core' : 'legacy';
+              } catch (e) {
+                return e.status === 404 ? 'missing' : 'unknown';
+              }
+            }
+
+            const ready = [], legacy = [], missing = [];
+            for (const slug of [...apps.keys()].sort()) {
+              const kind = await bootstrapOf(slug);
+              if (kind === 'core') ready.push(slug);
+              else if (kind === 'legacy') legacy.push(slug);
+              else if (kind === 'missing') missing.push(slug);
+            }
+
+            const lines = [MARKER];
+
+            if (ready.length > 0) {
+              const shown = ready.slice(0, MAX_APPS);
+              lines.push(
+                '### Try this branch',
+                '',
+                'The engine and the scripts resolve independently, so this runs the changed',
+                '`ct/` and `install/` scripts against the **production** engine:',
+                '',
+              );
+              for (const slug of shown) {
+                lines.push(
+                  '```bash',
+                  `export COMMUNITY_SCRIPTS_URL=${base}`,
+                  `bash -c "$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/ct/${slug}.sh")"`,
+                  '```',
+                  '',
+                );
+              }
+              if (ready.length > shown.length) {
+                lines.push(
+                  `${ready.length - shown.length} more script(s) changed; same command, different slug.`,
+                  '',
+                );
+              }
+              lines.push(
+                'Both lines are needed. Each script pins `_CS_DEFAULT_URL` to `main`, and that',
+                'pin is what fills `COMMUNITY_SCRIPTS_URL` when the variable is unset — so',
+                'curling the branch URL on its own gives you the `ct/` script from this PR and',
+                'the `install/` script from `main`. Frequently the one you meant to test.',
+                '',
+                'The same command works on an Incus host: the engine detects the platform and',
+                'loads the matching backend, while the scripts still come from this branch.',
+                '',
+                '<details><summary>Useful while testing</summary>',
+                '',
+                '`dev_mode=net` logs every fetch with status and URL, which is the quickest way',
+                'to confirm the branch is really being used. `dev_mode=keep` stops a failed',
+                'build from deleting the container along with the evidence.',
+                '',
+                '```bash',
+                `export COMMUNITY_SCRIPTS_URL=${base}`,
+                `dev_mode=net,keep bash -c "$(curl -fsSL "$COMMUNITY_SCRIPTS_URL/ct/${shown[0]}.sh")"`,
+                '```',
+                '</details>',
+              );
+            }
+
+            if (legacy.length > 0) {
+              lines.push(
+                '',
+                ready.length > 0 ? '---' : '### Not testable this way yet',
+                '',
+                `\`${legacy.join('`, `')}\` still uses the older one-liner bootstrap, which`,
+                'resolves everything from `ProxmoxVE/main` and ignores `COMMUNITY_SCRIPTS_URL`.',
+                'There is no way to point it at this branch — test it from a checkout on the',
+                'host instead, or migrate the script to the `_cs_boot` bootstrap first.',
+              );
+            }
+
+            if (missing.length > 0) {
+              lines.push(
+                '',
+                `No \`ct/\` script found for \`${missing.join('`, `')}\`, so there is nothing to`,
+                'run. If the install script was renamed, its `ct/` counterpart needs the same',
+                'name.',
+              );
+            }
+
+            if (lines.length === 1) return;   // marker only, nothing worth saying
+            const body = lines.join('\n');
+
+            // Update in place rather than posting again on every push.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: pr.number, per_page: 100,
+            });
+            const mine = comments.find(c => c.body.includes(MARKER));
+            if (mine) {
+              if (mine.body !== body) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+              }
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+            }

--- a/.github/workflows/pr-test-command.yml
+++ b/.github/workflows/pr-test-command.yml
@@ -1,19 +1,11 @@
 name: PR test command
 
-# A reviewer should not have to work out which URL exercises a pull request.
-# The engine and the scripts resolve independently, so pointing
-# COMMUNITY_SCRIPTS_URL at this PR's branch runs the changed ct/ and install/
-# scripts against the production engine. This posts that command, filled in.
+# Posts a ready-to-run test command for reviewers.
+# It uses this PR’s script branch with the production engine, since both resolve
+# independently. Only scripts using community-scripts/core are supported.
 #
-# Only for scripts that already bootstrap from community-scripts/core: the older
-# one-liner ignores COMMUNITY_SCRIPTS_URL entirely, so a command built for it
-# would quietly install main and look like it passed.
-#
-# pull_request_target, so the comment can be posted on PRs from forks -- which is
-# most of them. Nothing from the pull request is checked out or executed here.
-# The file list, the branch name and the bootstrap line all come from the API,
-# the branch name is pattern-checked before it reaches the comment, and the body
-# is assembled in JavaScript, so no attacker-controlled string reaches a shell.
+# pull_request_target allows comments on fork PRs. No PR code is checked out or
+# executed; API inputs are validated and the comment is assembled in JavaScript.
 
 on:
   pull_request_target:


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
Reviewing a script change meant working out the URL yourself, and the obvious guess is wrong: curling the branch URL alone gives you the ct/ script from the PR and the install/ script from main, because each script pins _CS_DEFAULT_URL to main and that pin is what fills COMMUNITY_SCRIPTS_URL when it is unset. Frequently the install script is the only thing that changed.

So the comment spells out both lines, per changed app.

Only for scripts already on the core bootstrap. The older one-liner resolves everything from ProxmoxVE/main and ignores the variable, so a command built for it would install main and look like it passed --  worse than no comment. Those are named instead, with what to do about them.


May later add addons/pve/vm too, for now only ct/install


## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [x] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
