### PR TITLE
Include engine pull requests in the changelog

### DIFF
--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ["main"]
   workflow_dispatch:
+  # Fired by community-scripts/core when an engine pull request is merged, so a
+  # change there does not wait for the next push here. Optional: engine PRs are
+  # collected on every run regardless, this only decides how soon.
+  repository_dispatch:
+    types: [core-pr-merged]
 
 jobs:
   update-changelog-pull-request:
@@ -205,6 +210,77 @@ jobs:
                   }
                 }
 
+              }
+
+              // ── Engine pull requests ────────────────────────────────────────
+              // The engine lives in community-scripts/core, so its changes never
+              // show up in this repository's PR list -- and a fix there reaches
+              // every script here. The "💾 Core" category already existed for
+              // ProxmoxVE PRs labelled `core`; engine PRs land in the same place.
+              try {
+                const { data: corePulls } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: "core",
+                  base: "main",
+                  state: "closed",
+                  sort: "updated",
+                  direction: "desc",
+                  per_page: 100,
+                });
+
+                const coreCategory = categorizedPRs.find(category =>
+                  category.title.includes("Core") || category.labels.includes("core"));
+
+                // core carries GitHub's default label set, and most of its pull
+                // requests carry none at all, so map what maps and let the rest
+                // sit directly under the category.
+                const coreLabelAliases = {
+                  bug: "bugfix",
+                  bugfix: "bugfix",
+                  enhancement: "feature",
+                  feature: "feature",
+                  refactor: "refactor",
+                  "breaking change": "breaking change",
+                };
+                const corePriority = ["breaking change", "bugfix", "feature", "refactor"];
+
+                for (const pr of corePulls) {
+                  if (!pr.merged_at) continue;
+                  if (new Date(pr.merged_at) <= latestDateInChangelog) continue;
+
+                  const rawLabels = pr.labels.map(label => label.name.toLowerCase());
+                  if (rawLabels.some(l => ["invalid", "wontdo", "wontfix", "duplicate"].includes(l))) continue;
+
+                  if (!coreCategory) {
+                    console.log(`No Core category configured; skipping core#${pr.number}`);
+                    continue;
+                  }
+
+                  // core#N rather than #N: a bare number reads as a pull request
+                  // in this repository, so the link would lead somewhere other
+                  // than the text promises.
+                  const coreNote = `- ${pr.title} [@${pr.user.login}](https://github.com/${pr.user.login}) ([core#${pr.number}](${pr.html_url}))`;
+
+                  const mapped = rawLabels.map(l => coreLabelAliases[l]).filter(Boolean);
+                  let placed = false;
+                  if (coreCategory.subCategories && coreCategory.subCategories.length > 0) {
+                    for (const priorityLabel of corePriority) {
+                      if (!mapped.includes(priorityLabel)) continue;
+                      const subCategory = coreCategory.subCategories.find(sub =>
+                        sub.labels.includes(priorityLabel));
+                      if (subCategory) {
+                        subCategory.notes.push(coreNote);
+                        placed = true;
+                        break;
+                      }
+                    }
+                  }
+                  if (!placed) coreCategory.notes.push(coreNote);
+                }
+              } catch (error) {
+                // The engine repository being unreachable must not cost this
+                // repository its changelog.
+                console.error(`Could not read core pull requests: ${error}`);
               }
 
               return categorizedPRs;


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
A fix in community-scripts/core reaches every script here, and none of it appears in this changelog: the workflow only ever listed pull requests from this repository. The "💾 Core" category already existed, fed by ProxmoxVE PRs labelled `core`; engine PRs now land in the same place.

Entries read `([core#10](https://github.com/community-scripts/core/pull/10))` rather than a bare `#10`, which would read as a pull request here and send the reader somewhere other than the text promises.

core carries GitHub's default labels and most of its pull requests carry none, so `bug` and `enhancement` map onto the bugfix and feature subcategories and everything else sits directly under the category. The fetch is wrapped: the engine repository being unreachable must not cost this repository its changelog.

Also accepts a repository_dispatch, so core can ask for a run when a PR is merged there instead of waiting for the next push here. Optional -- engine PRs are collected on every run either way, this only decides how soon.

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
