### PR TITLE
fix(paperless-ngx): workaround migration graph crash on legacy 2.x to 3.x upgrade

### DIFF
--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -175,6 +175,30 @@ function update_script() {
       cd /opt/paperless
       $STD uv sync --all-extras
       cd /opt/paperless/src
+      # Workaround for paperless-ngx/paperless-ngx#13854:
+      # 0001_squashed.py in 3.x contains nested squashed-migration names in its
+      # replaces list that crash Django's graph builder when upgrading from 2.x.
+      # The individual migrations are already listed — remove the redundant duplicates.
+      msg_info "Applying migration graph workaround (paperless-ngx#13854)"
+      local _squash_refs=(
+        "0004_auto_20160114_1844_squashed_0011_auto_20160303_1929"
+        "0015_add_insensitive_to_match_squashed_0018_auto_20170715_1712"
+        "1006_auto_20201208_2209_squashed_1011_auto_20210101_2340"
+        "1016_auto_20210317_1351_squashed_1020_merge_20220518_1839"
+        "1022_paperlesstask_squashed_1036_alter_savedviewfilterrule_rule_type"
+        "1045_alter_customfieldinstance_value_monetary_squashed_1049_document_deleted_at_document_restored_at"
+        "0001_initial_squashed_0009_mailrule_assign_tags"
+        "0011_remove_mailrule_assign_tag_squashed_0024_alter_mailrule_name_and_more"
+      )
+      for _ref in "${_squash_refs[@]}"; do
+        sed -i "/${_ref}/d" /opt/paperless/src/documents/migrations/0001_squashed.py 2>/dev/null || true
+        sed -i "/${_ref}/d" /opt/paperless/src/paperless_mail/migrations/0001_squashed.py 2>/dev/null || true
+      done
+      sed -i "/django_celery_results.*0011_taskresult_periodic_task_name/d" \
+        /opt/paperless/src/documents/migrations/1022_paperlesstask_squashed_1036_alter_savedviewfilterrule_rule_type.py 2>/dev/null || true
+      sed -i "/django_celery_results.*0011_taskresult_periodic_task_name/d" \
+        /opt/paperless/src/documents/migrations/1026_transition_to_celery.py 2>/dev/null || true
+      msg_ok "Applied migration graph workaround"
       $STD uv run -- python manage.py migrate
       msg_ok "Updated Paperless-ngx"
 


### PR DESCRIPTION
<!--
AI note: This PR was written with Claude (Anthropic) assistance.
The fix was diagnosed and verified on a live system before filing.
-->

## ✍️ Description

Adds a workaround to `update_script()` that prevents `manage.py migrate` from crashing with `NodeNotFoundError` when upgrading from a legacy pip-based Paperless-ngx 2.x installation to 3.x.

**Root cause (upstream):** `0001_squashed.py` in both `documents` and `paperless_mail` contains nested squashed-migration names in its `replaces` list alongside the individual migrations they represent. Django's graph builder removes the intermediate squashed nodes when processing `0001_squashed`, then crashes when processing those same migrations' own `replaces` lists — the nodes are already gone. A secondary error occurs because `1022_paperlesstask_squashed_1036` and `1026_transition_to_celery` still declare a `django_celery_results` dependency removed from `INSTALLED_APPS` in 3.x.

**Fix:** Before calling `manage.py migrate`, remove the redundant nested squashed-migration references with `sed`. The workaround is idempotent — only removes lines if present, safe to run on future releases.

Affects users who installed via an older version of this helper script (pip-based, no uv) and upgrade to 3.x without the current bridge path. Upstream: paperless-ngx/paperless-ngx#13854.

## 🔗 Related Issue

n/a

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Verified live on Debian 12, pip-based 2.20.15 → 3.1.0 upgrade, PostgreSQL, 211 documents intact after migration.
- [X] **No security risks** – Only `sed` on local migration files; no secrets, no privilege escalation.

---

## 🤖 AI Assistance (**X** in brackets)

- [X] **AI was used** – Diagnosed and fixed on a live system with Claude (Anthropic) assistance. Fix reviewed and confirmed working before filing.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
