### PR TITLE
Rename CI credentials to org-wide names, demote non-secrets to variables

### DIFF
--- a/.github/workflows/auto-update-app-headers.yml
+++ b/.github/workflows/auto-update-app-headers.yml
@@ -24,15 +24,15 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ vars.GHAPP_HEADERS_ID }}
+          private-key: ${{ secrets.GHAPP_HEADERS_PRIVATE_KEY }}
 
       - name: Generate a token for PR approval and merge
         id: generate-token-merge
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID_APPROVE_AND_MERGE }}
-          private-key: ${{ secrets.APP_KEY_APPROVE_AND_MERGE }}
+          app-id: ${{ vars.GHAPP_MERGEBOT_ID }}
+          private-key: ${{ secrets.GHAPP_MERGEBOT_PRIVATE_KEY }}
 
       # Step 1: Checkout repository
       - name: Checkout repository

--- a/.github/workflows/changelog-archive.yml
+++ b/.github/workflows/changelog-archive.yml
@@ -21,15 +21,15 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ vars.GHAPP_HEADERS_ID }}
+          private-key: ${{ secrets.GHAPP_HEADERS_PRIVATE_KEY }}
 
       - name: Generate a token for PR approval and merge
         id: generate-token-merge
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID_APPROVE_AND_MERGE }}
-          private-key: ${{ secrets.APP_KEY_APPROVE_AND_MERGE }}
+          app-id: ${{ vars.GHAPP_MERGEBOT_ID }}
+          private-key: ${{ secrets.GHAPP_MERGEBOT_PRIVATE_KEY }}
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/changelog-pr.yml
+++ b/.github/workflows/changelog-pr.yml
@@ -26,15 +26,15 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ vars.GHAPP_HEADERS_ID }}
+          private-key: ${{ secrets.GHAPP_HEADERS_PRIVATE_KEY }}
 
       - name: Generate a token for PR approval and merge
         id: generate-token-merge
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.APP_ID_APPROVE_AND_MERGE }}
-          private-key: ${{ secrets.APP_KEY_APPROVE_AND_MERGE }}
+          app-id: ${{ vars.GHAPP_MERGEBOT_ID }}
+          private-key: ${{ secrets.GHAPP_MERGEBOT_PRIVATE_KEY }}
 
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/close_issue_in_dev.yaml
+++ b/.github/workflows/close_issue_in_dev.yaml
@@ -128,7 +128,7 @@ jobs:
         if: steps.find_issue.outputs.issue_numbers != ''
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.PAT_MICHEL }}
+          GH_TOKEN: ${{ secrets.GH_CROSS_REPO_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           ISSUE_NUMBERS: ${{ steps.find_issue.outputs.issue_numbers }}
         run: |
@@ -147,8 +147,8 @@ jobs:
       - name: Set is_dev to false in PocketBase
         if: steps.get_slugs.outputs.count != '0'
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
           PR_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}

--- a/.github/workflows/delete-pocketbase-entry-on-removal.yml
+++ b/.github/workflows/delete-pocketbase-entry-on-removal.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Mark as deleted in PocketBase
         if: steps.slugs.outputs.count != '0'
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
         run: |
@@ -175,8 +175,8 @@ jobs:
       - name: Generate CT stubs for deleted scripts
         if: steps.slugs.outputs.count != '0'
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
         run: |

--- a/.github/workflows/notify-breaking-change.yml
+++ b/.github/workflows/notify-breaking-change.yml
@@ -33,8 +33,8 @@ jobs:
     steps:
       - name: Notify site of breaking change
         env:
-          INGEST_SECRET: ${{ secrets.BREAKING_CHANGE_INGEST_SECRET }}
-          SITE_URL: ${{ secrets.FRONTEND_URL || vars.SITE_URL || 'https://community-scripts.org' }}
+          INGEST_SECRET: ${{ secrets.FRONTEND_ADVISORY_SECRET }}
+          SITE_URL: ${{ vars.FRONTEND_URL || 'https://community-scripts.org' }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/pocketbase-ai-bot.yml
+++ b/.github/workflows/pocketbase-ai-bot.yml
@@ -28,26 +28,26 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PB_BOT_APP_ID }}
-          private-key: ${{ secrets.PB_BOT_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.GHAPP_PBBOT_ID }}
+          private-key: ${{ secrets.GHAPP_PBBOT_PRIVATE_KEY }}
 
       - name: Run PocketBase AI bot
         env:
           # GitHub REST as the bot identity
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
-          PB_BOT_APP_ID: ${{ secrets.PB_BOT_APP_ID }}
+          PB_BOT_APP_ID: ${{ vars.GHAPP_PBBOT_ID }}
           # GitHub Models inference uses the built-in token (needs models: read)
           MODELS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Built-in token for git/PR ops (CT-defaults sync), mirroring the slash bot
           GH_DEFAULT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_MODEL: openai/gpt-4o
           # PocketBase
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
-          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+          FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+          REVALIDATE_SECRET: ${{ secrets.FRONTEND_INGEST_SECRET }}
           # Event context
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_ID: ${{ github.event.comment.id }}

--- a/.github/workflows/pocketbase-bot.yml
+++ b/.github/workflows/pocketbase-bot.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - name: Execute PocketBase bot command
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
           COMMENT_BODY: ${{ github.event.comment.body }}
@@ -31,12 +31,12 @@ jobs:
           ACTOR: ${{ github.event.comment.user.login }}
           ACTOR_ASSOCIATION: ${{ github.event.comment.author_association }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FRONTEND_URL: ${{ secrets.FRONTEND_URL }}
-          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+          FRONTEND_URL: ${{ vars.FRONTEND_URL }}
+          REVALIDATE_SECRET: ${{ secrets.FRONTEND_INGEST_SECRET }}
           # Screenshot attaching is delegated to the frontend, which owns the
           # fetching and validation. Without this the subcommand says so rather
           # than failing halfway.
-          SCREENSHOT_IMPORT_SECRET: ${{ secrets.SCREENSHOT_IMPORT_SECRET }}
+          SCREENSHOT_IMPORT_SECRET: ${{ secrets.FRONTEND_INGEST_SECRET }}
         run: |
           node << 'ENDSCRIPT'
           (async function () {

--- a/.github/workflows/push-json-to-pocketbase.yml
+++ b/.github/workflows/push-json-to-pocketbase.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Push to PocketBase
         if: steps.changed.outputs.count != '0'
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
         run: |

--- a/.github/workflows/sync-to-incus.yml
+++ b/.github/workflows/sync-to-incus.yml
@@ -10,8 +10,8 @@ name: Sync ct/install to Incus
 # script. We therefore only fire a repository_dispatch and let that single
 # source of truth do the work (and auto-approve + merge its own PR).
 #
-# Auth: the "push-app-to-main" GitHub App (vars.PUSH_MAIN_APP_ID /
-# secrets.PUSH_MAIN_APP_SECRET), scoped to community-scripts/Incus. It has
+# Auth: the "push-app-to-main" GitHub App (vars.GHAPP_SYNC_ID /
+# secrets.GHAPP_SYNC_PRIVATE_KEY), scoped to community-scripts/Incus. It has
 # contents:write, which repository_dispatch requires (community-scripts-pr-app
 # only has pull_requests:write, so it cannot dispatch). The app must be
 # installed on the Incus repo.
@@ -38,8 +38,8 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PUSH_MAIN_APP_ID }}
-          private-key: ${{ secrets.PUSH_MAIN_APP_SECRET }}
+          app-id: ${{ vars.GHAPP_SYNC_ID }}
+          private-key: ${{ secrets.GHAPP_SYNC_PRIVATE_KEY }}
           owner: community-scripts
           repositories: Incus
 

--- a/.github/workflows/update-script-timestamp-on-sh-change.yml
+++ b/.github/workflows/update-script-timestamp-on-sh-change.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Update script timestamps in PocketBase
         if: steps.slugs.outputs.count != '0'
         env:
-          POCKETBASE_URL: ${{ secrets.POCKETBASE_URL }}
-          POCKETBASE_COLLECTION: ${{ secrets.POCKETBASE_COLLECTION }}
+          POCKETBASE_URL: ${{ vars.POCKETBASE_URL }}
+          POCKETBASE_COLLECTION: ${{ vars.POCKETBASE_COLLECTION }}
           POCKETBASE_ADMIN_EMAIL: ${{ secrets.POCKETBASE_ADMIN_EMAIL }}
           POCKETBASE_ADMIN_PASSWORD: ${{ secrets.POCKETBASE_ADMIN_PASSWORD }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}


### PR DESCRIPTION

<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
- Added 4 new ORG Secrets and 6 ORG Vars
- Removed 17 Secrets in VE / VED 
- Removed several vars
- Recreated all secrets and vars

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
