### PR TITLE
Add cleanup for old Cloudflared repository files

### DIFF
--- a/install/cloudflared-install.sh
+++ b/install/cloudflared-install.sh
@@ -14,6 +14,7 @@ network_check
 update_os
 
 msg_info "Installing Cloudflared"
+cleanup_old_repo_files "cloudflared"
 setup_deb822_repo \
   "cloudflared" \
   "https://pkg.cloudflare.com/cloudflare-main.gpg" \


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description

Fixes an issue affecting existing Cloudflared LXCs where `apt update` fails because both the legacy Cloudflare APT repository and the newer Deb822 repository definition are present with different `Signed-By` key paths.

The affected container contained:

```text
/etc/apt/sources.list.d/cloudflared.list
```

using:

```text
/usr/share/keyrings/cloudflare-public-v2.gpg
```

while the newer repository configuration created:

```text
/etc/apt/sources.list.d/cloudflared.sources
```

using:

```text
/etc/apt/keyrings/cloudflared.gpg
```

This caused APT to fail with:

```text
Error: Conflicting values set for option Signed-By regarding source https://pkg.cloudflare.com/cloudflared/ any:
/usr/share/keyrings/cloudflare-public-v2.gpg != /etc/apt/keyrings/cloudflared.gpg
Error: The list of sources could not be read.
```

The fix adds:

```bash
cleanup_old_repo_files "cloudflared"
```

before `setup_deb822_repo`, allowing the legacy repository definition to be cleaned up before the new Cloudflared repository is configured.

The issue was reproduced on an existing Cloudflared LXC. Removing the legacy `cloudflared.list` resolved the APT conflict immediately, after which `apt update` and the Cloudflared update completed successfully without affecting the existing tunnel configuration.

This follows the project's existing helper-function approach rather than implementing custom repository cleanup logic.

AI assistance was used to help diagnose the issue, review the proposed change, and prepare this pull request.

**AI model:** ChatGPT — GPT-5.6 Sol  
**Reasoning:** Enabled

The contribution was reviewed against `AGENTS.md` and `.github/agents/pve-script-creator.agent.md`, including the requirement to use existing project helper functions rather than implementing duplicate functionality.

## 🔗 Related Issue

No separate issue opened.

Related to #16749.

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – The failure was reproduced and the equivalent repository cleanup was confirmed to resolve the issue.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`[AGENTS.md](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md)`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`[.github/agents/pve-script-creator.agent.md](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md)`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

Not applicable — this is a bug fix and does not introduce a breaking change.

<!--
```breaking-change
severity: warning
action: warn
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```
-->