### PR TITLE
mealie: copy Nuxt generate output and use pnpm when lockfile is present

### DIFF
--- a/ct/mealie.sh
+++ b/ct/mealie.sh
@@ -31,7 +31,6 @@ function update_script() {
   fi
   if check_for_gh_release "mealie" "mealie-recipes/mealie"; then
     PYTHON_VERSION="3.12" setup_uv
-    NODE_MODULE="yarn" NODE_VERSION="24" setup_nodejs
 
     msg_info "Stopping Service"
     systemctl stop mealie
@@ -65,6 +64,14 @@ STARTEOF
     $STD uv sync --frozen --extra pgsql
     msg_ok "Installed Python Dependencies"
 
+    if [[ -f /opt/mealie/frontend/pnpm-lock.yaml ]]; then
+      FRONTEND_PKG="pnpm"
+      NODE_MODULE="pnpm@11" NODE_VERSION="24" setup_nodejs
+    else
+      FRONTEND_PKG="yarn"
+      NODE_MODULE="yarn" NODE_VERSION="24" setup_nodejs
+    fi
+
     msg_info "Building Frontend"
     MEALIE_VERSION=$(<$HOME/.mealie)
     SITE_SETTINGS=$(find /opt/mealie/frontend -name "site-settings.vue" -path "*/admin/*" | head -1)
@@ -73,14 +80,28 @@ STARTEOF
     $STD sed -i "s|value: data.production ? i18n.t(\"about.production\") : i18n.t(\"about.development\"),|value: \"bare-metal\",|g" "$SITE_SETTINGS"
     export NUXT_TELEMETRY_DISABLED=1
     cd /opt/mealie/frontend
-    $STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
-    $STD yarn generate
-    $STD yarn cache clean
+    if [[ "${FRONTEND_PKG}" == "pnpm" ]]; then
+      $STD pnpm install --prefer-offline --frozen-lockfile
+      $STD pnpm generate
+      $STD pnpm store prune
+    else
+      $STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
+      $STD yarn generate
+      $STD yarn cache clean
+    fi
     msg_ok "Built Frontend"
 
     msg_info "Copying Built Frontend"
+    if [[ -n "$(ls -A /opt/mealie/frontend/.output/public 2>/dev/null)" ]]; then
+      FRONTEND_SRC="/opt/mealie/frontend/.output/public"
+    elif [[ -n "$(ls -A /opt/mealie/frontend/dist 2>/dev/null)" ]]; then
+      FRONTEND_SRC="/opt/mealie/frontend/dist"
+    else
+      msg_error "Frontend build output not found"
+      exit
+    fi
     mkdir -p /opt/mealie/mealie/frontend
-    cp -r /opt/mealie/frontend/dist/* /opt/mealie/mealie/frontend/
+    cp -r "${FRONTEND_SRC}/." /opt/mealie/mealie/frontend/
     msg_ok "Copied Frontend"
 
     setup_nltk "averaged_perceptron_tagger_eng" "/nltk_data"

--- a/install/mealie-install.sh
+++ b/install/mealie-install.sh
@@ -29,9 +29,16 @@ msg_ok "Installed Dependencies"
 
 PYTHON_VERSION="3.12" setup_uv
 PG_VERSION="16" setup_postgresql
-NODE_MODULE="yarn" NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "mealie" "mealie-recipes/mealie" "tarball"
 PG_DB_NAME="mealie_db" PG_DB_USER="mealie_user" PG_DB_GRANT_SUPERUSER="true" setup_postgresql_db
+
+if [[ -f /opt/mealie/frontend/pnpm-lock.yaml ]]; then
+  FRONTEND_PKG="pnpm"
+  NODE_MODULE="pnpm@11" NODE_VERSION="24" setup_nodejs
+else
+  FRONTEND_PKG="yarn"
+  NODE_MODULE="yarn" NODE_VERSION="24" setup_nodejs
+fi
 
 msg_info "Installing Python Dependencies with uv"
 cd /opt/mealie
@@ -46,14 +53,28 @@ SITE_SETTINGS=$(find /opt/mealie/frontend -name "site-settings.vue" -path "*/adm
 $STD sed -i "s|https://github.com/mealie-recipes/mealie/commit/|https://github.com/mealie-recipes/mealie/releases/tag/|g" "$SITE_SETTINGS"
 $STD sed -i "s|value: data.buildId,|value: \"v${MEALIE_VERSION}\",|g" "$SITE_SETTINGS"
 $STD sed -i "s|value: data.production ? i18n.t(\"about.production\") : i18n.t(\"about.development\"),|value: \"bare-metal\",|g" "$SITE_SETTINGS"
-$STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
-$STD yarn generate
-$STD yarn cache clean
+if [[ "${FRONTEND_PKG}" == "pnpm" ]]; then
+  $STD pnpm install --prefer-offline --frozen-lockfile
+  $STD pnpm generate
+  $STD pnpm store prune
+else
+  $STD yarn install --prefer-offline --frozen-lockfile --non-interactive --production=false --network-timeout 1000000
+  $STD yarn generate
+  $STD yarn cache clean
+fi
 msg_ok "Built Frontend"
 
 msg_info "Copying Built Frontend"
+if [[ -n "$(ls -A /opt/mealie/frontend/.output/public 2>/dev/null)" ]]; then
+  FRONTEND_SRC="/opt/mealie/frontend/.output/public"
+elif [[ -n "$(ls -A /opt/mealie/frontend/dist 2>/dev/null)" ]]; then
+  FRONTEND_SRC="/opt/mealie/frontend/dist"
+else
+  msg_error "Frontend build output not found"
+  exit
+fi
 mkdir -p /opt/mealie/mealie/frontend
-cp -r /opt/mealie/frontend/dist/* /opt/mealie/mealie/frontend/
+cp -r "${FRONTEND_SRC}/." /opt/mealie/mealie/frontend/
 msg_ok "Copied Frontend"
 
 setup_nltk "averaged_perceptron_tagger_eng" "/nltk_data"


### PR DESCRIPTION
## ✍️ Description

Updating or installing Mealie 3.24+ left the UI empty (`{"detail":"Not Found"}` at `/`) because two things drifted from upstream:

1. **Copy path.** `yarn generate` / `pnpm generate` now writes to `frontend/.output/public`, but the script always copied from `frontend/dist/*`. If `dist/` is missing, that copy is a no-op, so `/opt/mealie/mealie/frontend/` stays empty and FastAPI has nothing to serve at `/`.
2. **Package manager.** Mealie 3.24 dropped `yarn.lock` for `pnpm-lock.yaml`. Yarn then resolved latest deps (e.g. `isomorphic-dompurify@3.22.0`) and hit a Node engine mismatch.

This keeps older releases working by inspecting the tree after deploy:

- Use **pnpm@11** when `pnpm-lock.yaml` is present, otherwise yarn
- Copy from `.output/public` if it has files, else `dist/`
- Fail loudly if neither output exists

Applies to both `install/mealie-install.sh` and `ct/mealie.sh`.

## ✅ Prerequisites

- [x] **Self-review completed**
- [x] **Tested thoroughly** - Changes work as expected.
- [x] **No security risks**

## 🤖 AI Assistance

- [x] **AI was used** – scripts were modified using AGENTS.md / pve-script-creator guidance and reviewed to match project guidelines on Grok 4.6 High Reasoning.

Note: I personally checked other `ct/` `/ install/` scripts (Trilium, Bazarr, Wishlist) and matched their patterns.

## 🛠️ Type of Change

- [x] 🐞 **Bug fix**