### PR TITLE
ironclaw: support 1.x (Reborn), update to v1.4.0

### DIFF
--- a/ct/ironclaw.sh
+++ b/ct/ironclaw.sh
@@ -34,34 +34,114 @@ variables
 color
 catch_errors
 
+# IronClaw 1.x ("Reborn") is a ground-up rearchitecture of 0.29.x: the config
+# home moved from /root/.ironclaw/.env to /root/.ironclaw/reborn/ and the
+# service is a systemd *user* unit (ironclaw-reborn.service) installed by the
+# binary itself via `ironclaw service install`. Pre-1.0 installs used a
+# system-scope unit named ironclaw.service, whose CLI no longer exists in 1.x.
+ironclaw_running() {
+  if command -v pgrep >/dev/null 2>&1; then
+    pgrep -x ironclaw >/dev/null 2>&1
+  else
+    local p
+    for p in /proc/[0-9]*/comm; do
+      [[ "$(cat "$p" 2>/dev/null)" == "ironclaw" ]] && return 0
+    done
+    return 1
+  fi
+}
+
+# Returns 1 if a daemon is still running after the stop attempts - the live
+# executable would then block the binary replacement with ETEXTBSY.
+stop_ironclaw_service() {
+  systemctl --user stop ironclaw-reborn 2>/dev/null \
+    || systemctl stop ironclaw-reborn 2>/dev/null \
+    || systemctl stop ironclaw 2>/dev/null \
+    || rc-service ironclaw stop 2>/dev/null \
+    || true
+  local i
+  for i in 1 2 3 4 5; do
+    ironclaw_running || return 0
+    sleep 1
+  done
+  return 1
+}
+
+start_ironclaw_service() {
+  /usr/local/bin/ironclaw service start 2>/dev/null \
+    || systemctl --user start ironclaw-reborn 2>/dev/null \
+    || systemctl start ironclaw 2>/dev/null
+}
+
+back_up_ironclaw_configuration() {
+  if [[ -d /root/.ironclaw/reborn ]]; then
+    msg_info "Backing up Configuration"
+    tar -czf /root/ironclaw-reborn.bak.tar.gz -C /root/.ironclaw reborn
+    msg_ok "Backed up Configuration"
+  elif [[ -f /root/.ironclaw/.env ]]; then
+    msg_info "Backing up Configuration"
+    cp /root/.ironclaw/.env /root/ironclaw.env.bak
+    msg_ok "Backed up Configuration"
+  fi
+}
+
+restore_ironclaw_configuration() {
+  if [[ -f /root/ironclaw-reborn.bak.tar.gz ]]; then
+    msg_info "Restoring Configuration"
+    rm -rf /root/.ironclaw/reborn
+    tar -xzf /root/ironclaw-reborn.bak.tar.gz -C /root/.ironclaw
+    rm -f /root/ironclaw-reborn.bak.tar.gz
+    msg_ok "Restored Configuration"
+  elif [[ -f /root/ironclaw.env.bak ]]; then
+    msg_info "Restoring Configuration"
+    cp /root/ironclaw.env.bak /root/.ironclaw/.env
+    rm -f /root/ironclaw.env.bak
+    msg_ok "Restored Configuration"
+  fi
+}
+
+# Pre-1.0 system units cannot run the 1.x binary (incompatible CLI); remove
+# them so `systemctl start ironclaw` does not keep failing on every boot.
+remove_ironclaw_legacy_unit() {
+  if systemctl list-unit-files 2>/dev/null | grep -q '^ironclaw\.service'; then
+    msg_info "Removing legacy pre-1.0 system unit (ironclaw.service)"
+    systemctl disable --now ironclaw 2>/dev/null || true
+    rm -f /etc/systemd/system/ironclaw.service
+    systemctl daemon-reload
+    msg_ok "Removed legacy unit"
+  fi
+}
+
 update_deb_based() {
   if [[ ! -f /usr/local/bin/ironclaw ]]; then
     msg_error "No ${APP} Installation Found!"
     exit
   fi
 
-  RELEASE="ironclaw-v0.29.1"
-  if check_for_gh_release "ironclaw-bin" "nearai/ironclaw" "${RELEASE}" "IronClaw 1.0 (Reborn) is a ground-up rearchitecture with an incompatible CLI/config format; pinned until this script supports it"; then
+  RELEASE="ironclaw-v1.4.0"
+  if check_for_gh_release "ironclaw-bin" "nearai/ironclaw" "${RELEASE}" "verified against IronClaw 1.4 (Reborn); bump once a newer release is tested"; then
     msg_info "Stopping Service"
-    systemctl stop ironclaw
+    if ! stop_ironclaw_service; then
+      msg_error "An ${APP} process is still running and could not be stopped - update aborted"
+      exit 1
+    fi
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /root/.ironclaw/.env /root/ironclaw.env.bak
-    msg_ok "Backed up Configuration"
+    back_up_ironclaw_configuration
 
     fetch_and_deploy_gh_release "ironclaw-bin" "nearai/ironclaw" "prebuild" "${RELEASE}" "/usr/local/bin" \
       "ironclaw-$(uname -m)-unknown-linux-gnu.tar.gz"
     chmod +x /usr/local/bin/ironclaw
 
-    msg_info "Restoring Configuration"
-    cp /root/ironclaw.env.bak /root/.ironclaw/.env
-    rm -f /root/ironclaw.env.bak
-    msg_ok "Restored Configuration"
+    restore_ironclaw_configuration
+    remove_ironclaw_legacy_unit
 
     msg_info "Starting Service"
-    systemctl start ironclaw
-    msg_ok "Started Service"
+    if start_ironclaw_service; then
+      msg_ok "Started Service"
+    else
+      msg_warn "Could not start the service automatically. Inside the container run: ${BGN}/usr/local/bin/ironclaw service install${CL} (pre-1.0 installs) or ${BGN}/usr/local/bin/ironclaw service start${CL}"
+    fi
     msg_ok "Updated successfully!"
   fi
 }
@@ -72,28 +152,29 @@ update_alpine() {
     exit
   fi
 
-  RELEASE="ironclaw-v0.29.1"
-  if check_for_gh_release "ironclaw-bin" "nearai/ironclaw" "${RELEASE}" "IronClaw 1.0 (Reborn) is a ground-up rearchitecture with an incompatible CLI/config format; pinned until this script supports it"; then
+  RELEASE="ironclaw-v1.4.0"
+  if check_for_gh_release "ironclaw-bin" "nearai/ironclaw" "${RELEASE}" "verified against IronClaw 1.4 (Reborn); bump once a newer release is tested"; then
     msg_info "Stopping Service"
-    rc-service ironclaw stop 2>/dev/null || true
+    if ! stop_ironclaw_service; then
+      msg_error "An ${APP} process is still running and could not be stopped - update aborted"
+      exit 1
+    fi
     msg_ok "Stopped Service"
 
-    msg_info "Backing up Configuration"
-    cp /root/.ironclaw/.env /root/ironclaw.env.bak
-    msg_ok "Backed up Configuration"
+    back_up_ironclaw_configuration
 
     fetch_and_deploy_gh_release "ironclaw-bin" "nearai/ironclaw" "prebuild" "${RELEASE}" "/usr/local/bin" \
       "ironclaw-$(uname -m)-unknown-linux-musl.tar.gz"
     chmod +x /usr/local/bin/ironclaw
 
-    msg_info "Restoring Configuration"
-    cp /root/ironclaw.env.bak /root/.ironclaw/.env
-    rm -f /root/ironclaw.env.bak
-    msg_ok "Restored Configuration"
+    restore_ironclaw_configuration
 
     msg_info "Starting Service"
-    rc-service ironclaw start
-    msg_ok "Started Service"
+    if rc-service ironclaw start 2>/dev/null; then
+      msg_ok "Started Service"
+    else
+      msg_warn "No openrc service found. IronClaw 1.x has no openrc integration (its ${BGN}service${CL} command needs systemd/launchd) - supervise ${BGN}/usr/local/bin/ironclaw serve${CL} yourself"
+    fi
     msg_ok "Updated successfully!"
   fi
 }
@@ -111,12 +192,17 @@ description
 
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
-echo -e "${INFO}${YW} Next Steps:${CL}"
-echo -e "${TAB}1. Configure remaining settings:${CL}"
+echo -e "${INFO}${YW} Next Steps (inside the container):${CL}"
+echo -e "${TAB}1. Complete setup (config, LLM provider, WebUI token, OS service):${CL}"
 echo -e "${TAB}${TAB}${BGN}/usr/local/bin/ironclaw onboard${CL}"
-echo -e "${TAB}2. Start the service:${CL}"
-echo -e "${TAB}${TAB}${BGN}systemctl start ironclaw${CL}"
+echo -e "${TAB}${TAB}(non-interactive sessions skip service install - do it manually):${CL}"
+echo -e "${TAB}${TAB}${BGN}/usr/local/bin/ironclaw service install && /usr/local/bin/ironclaw service start${CL}"
+echo -e "${TAB}${TAB}${BGN}loginctl enable-linger root${CL}"
+echo -e "${TAB}2. To reach the WebUI from outside the container, bind it to all interfaces${CL}"
+echo -e "${TAB}${TAB}(append to /root/.ironclaw/reborn/config.toml, then ${BGN}ironclaw service restart${CL}):${CL}"
+echo -e "${TAB}${TAB}${TAB}${BGN}[webui]${CL}"
+echo -e "${TAB}${TAB}${TAB}${BGN}listen_host = \"0.0.0.0\"${CL}"
 echo -e "${TAB}3. Access the Web UI at:${CL}"
-echo -e "${GATEWAY}${BGN}http://${IP}:3000${CL}"
-echo -e "${INFO}${YW} Use Gateway Authentication Token to login:${CL}"
-echo -e "${TAB}${TAB}${BGN}cat /root/.ironclaw/gateway.creds${CL}"
+echo -e "${TAB}${TAB}${GATEWAY}${BGN}http://${IP}:3000${CL}"
+echo -e "${INFO}${YW} Log in with the WebUI token (URL: http://${IP}:3000/login?token=<token>):${CL}"
+echo -e "${TAB}${TAB}${BGN}cat /root/.ironclaw/reborn/webui-token${CL}"


### PR DESCRIPTION
IronClaw 1.0 ("Reborn") was a ground-up rearchitecture; the script was pinned to v0.29.1 until this update.

- Bump pin to ironclaw-v1.4.0 (asset naming unchanged)
- Service is now a systemd **user** unit (ironclaw-reborn.service) installed by the binary; new stop/start helpers handle user-unit, legacy system-unit and openrc fallbacks
- Config backup/restore for the new home /root/.ironclaw/reborn/ (tar) with legacy /root/.ironclaw/.env fallback
- Legacy pre-1.0 system unit (ironclaw.service) is disabled/removed on migration so it cannot keep failing at boot
- Update aborts (no partial state) if a live ironclaw process cannot be stopped - a running daemon blocks binary replacement with ETEXTBSY
- Next steps rewritten: onboard -> service install + loginctl enable-linger root -> [webui] listen_host = "0.0.0.0" -> login via /root/.ironclaw/reborn/webui-token
- Alpine: same flow with an honest note that 1.x has no openrc integration

Verified in a systemd Debian 13 container using the real core functions and GitHub release downloads:
1. legacy 0.29.1 -> 1.4.0 migration (env backup/restore, legacy unit removal)
2. 1.x -> 1.x update (reborn home backup/restore, service restart, WebUI serving on 0.0.0.0:3000)
3. failure path: stop not possible -> clean abort, version file untouched