### PR TITLE
Pin Go to the version each project declares in go.mod

### DIFF
--- a/ct/authentik.sh
+++ b/ct/authentik.sh
@@ -44,7 +44,6 @@ function update_script() {
   msg_ok "Update dependencies"
 
   NODE_VERSION="26" NODE_MODULE=pnpm@11 setup_nodejs
-  setup_go
   $STD uv cache clean
   UV_PYTHON_INSTALL_DIR="/usr/local/bin" PYTHON_VERSION="3.14.7" setup_uv
   RUST_PROFILE="minimal" RUST_TOOLCHAIN="stable" setup_rust
@@ -86,6 +85,7 @@ function update_script() {
     msg_ok "Stopped Services"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "authentik" "goauthentik/authentik" "tarball" "${AUTHENTIK_VERSION}" "/opt/authentik"
+    GO_VERSION="$(grep -m1 '^go ' /opt/authentik/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Configuring rust"
     cd /opt/authentik

--- a/ct/bitmagnet.sh
+++ b/ct/bitmagnet.sh
@@ -71,6 +71,7 @@ update_deb_based() {
     msg_ok "Data backed up"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "bitmagnet" "bitmagnet-io/bitmagnet" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/bitmagnet/go.mod | awk '{print $2}')" setup_go
     restore_backup
 
     msg_info "Configuring Bitmagnet"

--- a/ct/cloudflare-ddns.sh
+++ b/ct/cloudflare-ddns.sh
@@ -37,8 +37,8 @@ function update_script() {
     systemctl stop cloudflare-ddns
     msg_ok "Stopped Service"
 
-    setup_go
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "cloudflare-ddns" "favonia/cloudflare-ddns" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/cloudflare-ddns/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Updating ${APP}"
     cd /opt/cloudflare-ddns

--- a/ct/databasus.sh
+++ b/ct/databasus.sh
@@ -70,6 +70,7 @@ function update_script() {
     msg_ok "Ensured Database Clients"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "databasus" "databasus/databasus" "tarball" "latest" "/opt/databasus"
+    GO_VERSION="$(grep -m1 '^go ' /opt/databasus/backend/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Updating Databasus"
     export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/ct/firecrawl.sh
+++ b/ct/firecrawl.sh
@@ -42,6 +42,7 @@ function update_script() {
     create_backup /opt/firecrawl/.env
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "firecrawl" "firecrawl/firecrawl" "tarball" "latest" "/opt/firecrawl"
+    GO_VERSION="$(grep -m1 '^go ' /opt/firecrawl/apps/api/sharedLibs/go-html-to-md/go.mod | awk '{print $2}')" setup_go
 
     restore_backup
 

--- a/ct/gluetun.sh
+++ b/ct/gluetun.sh
@@ -39,6 +39,7 @@ function update_script() {
     msg_ok "Stopped Service"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "gluetun" "qdm12/gluetun" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/gluetun/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Building Gluetun"
     cd /opt/gluetun

--- a/ct/koffan.sh
+++ b/ct/koffan.sh
@@ -40,6 +40,7 @@ function update_script() {
 
     create_backup /opt/koffan/data
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "koffan" "PanSalut/Koffan" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/koffan/go.mod | awk '{print $2}')" setup_go
     restore_backup
 
     msg_info "Rebuilding Koffan"

--- a/ct/localagi.sh
+++ b/ct/localagi.sh
@@ -40,6 +40,7 @@ function update_script() {
 
     create_backup /opt/localagi/.env
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "localagi" "mudler/LocalAGI" "tarball" "latest" "/opt/localagi"
+    GO_VERSION="$(grep -m1 '^go ' /opt/localagi/go.mod | awk '{print $2}')" setup_go
     restore_backup
 
     msg_info "Building LocalAGI"

--- a/ct/networkoptimizer.sh
+++ b/ct/networkoptimizer.sh
@@ -39,6 +39,7 @@ function update_script() {
 
     create_backup /opt/networkoptimizer/networkoptimizer.env
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "networkoptimizer" "Ozark-Connect/NetworkOptimizer" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/networkoptimizer/src/uwnspeedtest/go.mod | awk '{print $2}')" setup_go
     restore_backup
 
     msg_info "Rebuilding NetworkOptimizer"

--- a/ct/paperless-gpt.sh
+++ b/ct/paperless-gpt.sh
@@ -41,6 +41,7 @@ function update_script() {
     fi
 
     fetch_and_deploy_gh_release "paperless-gpt" "icereed/paperless-gpt" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/paperless-gpt/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Updating Paperless-GPT"
     cd /opt/paperless-gpt/web-app

--- a/ct/tor-snowflake.sh
+++ b/ct/tor-snowflake.sh
@@ -44,6 +44,7 @@ function update_script() {
     msg_ok "Stopped Service"
 
     CLEAN_INSTALL=1 GITLAB_URL="https://gitlab.torproject.org" fetch_and_deploy_gl_release "tor-snowflake" "tpo/anti-censorship/pluggable-transports/snowflake" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/tor-snowflake/proxy/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Building Snowflake"
     cd /opt/tor-snowflake/proxy

--- a/ct/watcharr.sh
+++ b/ct/watcharr.sh
@@ -40,6 +40,7 @@ function update_script() {
 
     create_backup /opt/watcharr/server/data
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "watcharr" "sbondCo/Watcharr" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/watcharr/server/go.mod | awk '{print $2}')" setup_go
     restore_backup
 
     msg_info "Updating Watcharr"

--- a/ct/yopass.sh
+++ b/ct/yopass.sh
@@ -38,6 +38,7 @@ function update_script() {
     msg_ok "Stopped Service"
 
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "yopass" "jhaals/yopass" "tarball"
+    GO_VERSION="$(grep -m1 '^go ' /opt/yopass/go.mod | awk '{print $2}')" setup_go
 
     msg_info "Building Yopass"
     cd /opt/yopass

--- a/install/authentik-install.sh
+++ b/install/authentik-install.sh
@@ -52,7 +52,6 @@ msg_ok "Installed Dependencies"
 
 NODE_VERSION="26" NODE_MODULE=pnpm@11 setup_nodejs
 setup_yq
-setup_go
 RUST_PROFILE="minimal" RUST_TOOLCHAIN="stable" setup_rust
 UV_PYTHON_INSTALL_DIR="/usr/local/bin" PYTHON_VERSION="3.14.7" setup_uv
 PG_VERSION="17" setup_postgresql
@@ -62,6 +61,7 @@ XMLSEC_VERSION="1.3.12"
 AUTHENTIK_VERSION="version/2026.8.0"
 fetch_and_deploy_gh_release "xmlsec" "lsh123/xmlsec" "tarball" "${XMLSEC_VERSION}" "/opt/xmlsec"
 fetch_and_deploy_gh_release "authentik" "goauthentik/authentik" "tarball" "${AUTHENTIK_VERSION}" "/opt/authentik"
+GO_VERSION="$(grep -m1 '^go ' /opt/authentik/go.mod | awk '{print $2}')" setup_go
 fetch_and_deploy_gh_release "geoipupdate" "maxmind/geoipupdate" "binary"
 
 msg_info "Setting up xmlsec"

--- a/install/bitmagnet-install.sh
+++ b/install/bitmagnet-install.sh
@@ -23,9 +23,9 @@ setup_deb_based() {
 
   PG_VERSION="16" setup_postgresql
   PG_DB_NAME="bitmagnet" PG_DB_USER="bitmagnet" setup_postgresql_db
-  setup_go
 
   fetch_and_deploy_gh_release "bitmagnet" "bitmagnet-io/bitmagnet" "tarball"
+  GO_VERSION="$(grep -m1 '^go ' /opt/bitmagnet/go.mod | awk '{print $2}')" setup_go
   RELEASE=$(cat ~/.bitmagnet)
 
   msg_info "Configuring bitmagnet"

--- a/install/cloudflare-ddns-install.sh
+++ b/install/cloudflare-ddns-install.sh
@@ -51,8 +51,8 @@ while true; do
 done
 msg_ok "Configured Application"
 
-setup_go
 fetch_and_deploy_gh_release "cloudflare-ddns" "favonia/cloudflare-ddns" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/cloudflare-ddns/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building ${APPLICATION}"
 cd /opt/cloudflare-ddns

--- a/install/databasus-install.sh
+++ b/install/databasus-install.sh
@@ -22,7 +22,6 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 PG_VERSION="17" setup_postgresql
-setup_go
 NODE_VERSION="24" NODE_MODULE="corepack" setup_nodejs
 
 msg_info "Installing Database Clients"
@@ -52,6 +51,7 @@ done
 msg_ok "Installed Database Clients"
 
 fetch_and_deploy_gh_release "databasus" "databasus/databasus" "tarball" "latest" "/opt/databasus"
+GO_VERSION="$(grep -m1 '^go ' /opt/databasus/backend/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building Databasus (Patience)"
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/install/firecrawl-install.sh
+++ b/install/firecrawl-install.sh
@@ -28,11 +28,11 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="22" NODE_MODULE="pnpm@11.4.0" setup_nodejs
-setup_go
 RUST_PROFILE="minimal" setup_rust
 PG_VERSION="17" PG_MODULES="cron" setup_postgresql
 
 fetch_and_deploy_gh_release "firecrawl" "firecrawl/firecrawl" "tarball" "latest" "/opt/firecrawl"
+GO_VERSION="$(grep -m1 '^go ' /opt/firecrawl/apps/api/sharedLibs/go-html-to-md/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Configuring FDB"
 FDB_VERSION="$(awk -F= '/^ARG FDB_VERSION=/{print $2; exit}' /opt/firecrawl/apps/api/Dockerfile)"

--- a/install/gluetun-install.sh
+++ b/install/gluetun-install.sh
@@ -26,9 +26,9 @@ $STD update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
 ln -sf /usr/sbin/openvpn /usr/sbin/openvpn2.6
 msg_ok "Configured iptables"
 
-setup_go
 
 fetch_and_deploy_gh_release "gluetun" "qdm12/gluetun" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/gluetun/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building Gluetun"
 cd /opt/gluetun

--- a/install/koffan-install.sh
+++ b/install/koffan-install.sh
@@ -17,8 +17,8 @@ msg_info "Installing Dependencies"
 $STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
-setup_go
 fetch_and_deploy_gh_release "koffan" "PanSalut/Koffan" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/koffan/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building Koffan"
 cd /opt/koffan

--- a/install/localagi-install.sh
+++ b/install/localagi-install.sh
@@ -19,7 +19,6 @@ $STD apt install -y build-essential
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-setup_go
 
 msg_info "Installing Bun"
 export BUN_INSTALL="/root/.bun"
@@ -29,6 +28,7 @@ ln -sf /root/.bun/bin/bunx /usr/local/bin/bunx
 msg_ok "Installed Bun"
 
 fetch_and_deploy_gh_release "localagi" "mudler/LocalAGI" "tarball" "latest" "/opt/localagi"
+GO_VERSION="$(grep -m1 '^go ' /opt/localagi/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Configuring LocalAGI"
 mkdir -p /opt/localagi/pool

--- a/install/neko-install.sh
+++ b/install/neko-install.sh
@@ -48,9 +48,9 @@ $STD apt install -y \
 msg_ok "Installed Build Dependencies"
 
 NODE_VERSION="22" setup_nodejs
-setup_go
 
 fetch_and_deploy_gh_release "neko" "m1k1o/neko" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/neko/server/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building Client"
 cd /opt/neko/client

--- a/install/networkoptimizer-install.sh
+++ b/install/networkoptimizer-install.sh
@@ -27,9 +27,9 @@ setup_deb822_repo \
 $STD apt install -y dotnet-sdk-10.0
 msg_ok "Installed Dependencies"
 
-setup_go
 
 fetch_and_deploy_gh_release "networkoptimizer" "Ozark-Connect/NetworkOptimizer" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/networkoptimizer/src/uwnspeedtest/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building NetworkOptimizer"
 RID="linux-x64"

--- a/install/paperless-gpt-install.sh
+++ b/install/paperless-gpt-install.sh
@@ -23,8 +23,8 @@ $STD apt install -y \
 msg_ok "Installed Dependencies"
 
 NODE_VERSION="24" setup_nodejs
-setup_go
 fetch_and_deploy_gh_release "paperless-gpt" "icereed/paperless-gpt" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/paperless-gpt/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Setup Paperless-GPT"
 cd /opt/paperless-gpt/web-app

--- a/install/seelf-install.sh
+++ b/install/seelf-install.sh
@@ -19,9 +19,9 @@ $STD apt install -y \
   gcc
 msg_ok "Installed Dependencies"
 
-setup_go
 NODE_VERSION="22" setup_nodejs
 fetch_and_deploy_gh_release "seelf" "YuukanOO/seelf" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/seelf/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Setting up seelf. Patience"
 cd /opt/seelf

--- a/install/tor-snowflake-install.sh
+++ b/install/tor-snowflake-install.sh
@@ -13,10 +13,10 @@ setting_up_container
 network_check
 update_os
 
-setup_go
 
 msg_info "Building Snowflake"
 GITLAB_URL="https://gitlab.torproject.org" fetch_and_deploy_gl_release "tor-snowflake" "tpo/anti-censorship/pluggable-transports/snowflake" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/tor-snowflake/proxy/go.mod | awk '{print $2}')" setup_go
 cd /opt/tor-snowflake/proxy
 $STD go build -o snowflake-proxy .
 msg_ok "Built Snowflake Proxy"

--- a/install/watcharr-install.sh
+++ b/install/watcharr-install.sh
@@ -17,9 +17,9 @@ msg_info "Installing Dependencies"
 $STD apt install -y gcc
 msg_ok "Installed Dependencies"
 
-setup_go
 NODE_VERSION="24" setup_nodejs
 fetch_and_deploy_gh_release "watcharr" "sbondCo/Watcharr" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/watcharr/server/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Setup Watcharr"
 cd /opt/watcharr

--- a/install/yopass-install.sh
+++ b/install/yopass-install.sh
@@ -18,10 +18,10 @@ $STD apt install -y redis-server
 systemctl enable -q --now redis-server
 msg_ok "Installed Dependencies"
 
-setup_go
 NODE_VERSION="22" NODE_MODULE="yarn" setup_nodejs
 
 fetch_and_deploy_gh_release "yopass" "jhaals/yopass" "tarball"
+GO_VERSION="$(grep -m1 '^go ' /opt/yopass/go.mod | awk '{print $2}')" setup_go
 
 msg_info "Building Yopass"
 cd /opt/yopass


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
`setup_go` without `GO_VERSION` resolves to whatever go.dev currently serves, so every Go app was built against a moving target. When 1.27 landed it broke wanderer outright (#16909): PocketBase pins `go 1.25.0` and stack-overflows at startup when built with anything newer.

**Two problems, both fixed here.**

`setup_go` ran **before** the source was fetched in all 15 install scripts, so the pin could not be read even if someone wanted one. It now runs after the fetch and reads the version out of `go.mod` — the pattern `gatus-install.sh` already used.

13 `ct/` scripts rebuild with go during update. **Eleven never called `setup_go` at all** and rebuilt with whatever the container happened to have; the other two called it before the fetch. All 13 now use the same call as their installer.

**Scope:** 28 files, 15 `install/` + 13 `ct/`. The go.mod path was resolved per script by walking back from each `go build` / `go mod` to its preceding `cd`, not guessed from the app name — several differ (`/opt/watcharr/server`, `/opt/neko/server`, `/opt/databasus/backend`, `/opt/firecrawl/apps/api/sharedLibs/go-html-to-md`, `/opt/networkoptimizer/src/uwnspeedtest`, `/opt/tor-snowflake/proxy`).

**Left alone:** `caddy` — `xcaddy build` fetches the Caddy source itself, so there is no local `go.mod` to read, and it already pins deliberately. `wanderer` is in #16976 to keep the branches disjoint.

**Verified:** `bash -n` clean on all 28; install and update calls compared string for string, 0 mismatches; no comments added.

**Worth knowing:** `go 1.25.0` in a go.mod is a *minimum*, not a maximum, and Go's compatibility promise means newer toolchains normally work. Pinning to it trades an unpredictable toolchain for a frozen one — apps will no longer pick up newer Go releases on their own. That is a deliberate choice for reproducibility.


## 🔗 Related Issue

Refs #16909

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – not run on a live container; static verification only, as described above.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
