### PR TITLE
Fix npm v12 allow-git/allow-remote restrictions across affected scripts

### DIFF
--- a/ct/baserow.sh
+++ b/ct/baserow.sh
@@ -48,7 +48,7 @@ function update_script() {
 
     msg_info "Rebuilding Frontend"
     cd /opt/baserow/web-frontend
-    $STD npm install
+    $STD npm install --allow-remote=all
     $STD npm run build
     msg_ok "Rebuilt Frontend"
 

--- a/ct/bentopdf.sh
+++ b/ct/bentopdf.sh
@@ -44,7 +44,7 @@ function update_script() {
 
     msg_info "Configuring BentoPDF"
     cd /opt/bentopdf
-    $STD npm ci --no-audit --no-fund
+    $STD npm ci --no-audit --no-fund --allow-remote=all
     export NODE_OPTIONS="--max-old-space-size=3072"
     export SIMPLE_MODE=true
     export VITE_USE_CDN=true

--- a/ct/cryptpad.sh
+++ b/ct/cryptpad.sh
@@ -51,7 +51,7 @@ function update_script() {
 
     msg_info "Updating CryptPad"
     cd /opt/cryptpad
-    $STD npm ci
+    $STD npm ci --allow-git=all
     $STD npm run install:components
     if [ -f "/opt/cryptpad/install-onlyoffice.sh" ]; then
       $STD bash /opt/cryptpad/install-onlyoffice.sh --accept-license

--- a/ct/librechat.sh
+++ b/ct/librechat.sh
@@ -45,7 +45,7 @@ function update_script() {
 
     msg_info "Installing Dependencies"
     cd /opt/librechat
-    $STD npm ci
+    $STD npm ci --allow-remote=all
     msg_ok "Installed Dependencies"
 
     msg_info "Building Frontend"

--- a/ct/pangolin.sh
+++ b/ct/pangolin.sh
@@ -63,7 +63,7 @@ function update_script() {
 
     msg_info "Updating Pangolin"
     cd /opt/pangolin
-    $STD npm ci
+    $STD npm ci --allow-remote=all
     $STD npm run set:pg
     $STD npm run set:oss
     rm -rf server/private

--- a/install/baserow-install.sh
+++ b/install/baserow-install.sh
@@ -45,7 +45,7 @@ msg_ok "Installed Backend Dependencies"
 
 msg_info "Building Frontend"
 cd /opt/baserow/web-frontend
-NODE_OPTIONS="--max-old-space-size=4096" $STD npm install --legacy-peer-deps
+NODE_OPTIONS="--max-old-space-size=4096" $STD npm install --legacy-peer-deps --allow-remote=all
 NODE_OPTIONS="--max-old-space-size=4096" $STD npm run build
 msg_ok "Built Frontend"
 

--- a/install/bentopdf-install.sh
+++ b/install/bentopdf-install.sh
@@ -24,7 +24,7 @@ fetch_and_deploy_gh_release "bentopdf" "alam00000/bentopdf" "tarball" "latest" "
 
 msg_info "Setup BentoPDF"
 cd /opt/bentopdf
-$STD npm ci --no-audit --no-fund
+$STD npm ci --no-audit --no-fund --allow-remote=all
 cp ./.env.example ./.env.production
 export NODE_OPTIONS="--max-old-space-size=3072"
 export SIMPLE_MODE=true

--- a/install/cryptpad-install.sh
+++ b/install/cryptpad-install.sh
@@ -24,7 +24,7 @@ fetch_and_deploy_gh_release "cryptpad" "cryptpad/cryptpad" "tarball"
 
 msg_info "Setup CryptPad"
 cd /opt/cryptpad
-$STD npm ci
+$STD npm ci --allow-git=all
 $STD npm run install:components
 if [[ "$onlyoffice" =~ ^[Yy]$ ]]; then
   $STD bash -c "./install-onlyoffice.sh --accept-license"

--- a/install/librechat-install.sh
+++ b/install/librechat-install.sh
@@ -25,7 +25,7 @@ fetch_and_deploy_gh_release "rag-api" "danny-avila/rag_api" "tarball"
 
 msg_info "Installing LibreChat Dependencies"
 cd /opt/librechat
-$STD npm ci
+$STD npm ci --allow-remote=all
 msg_ok "Installed LibreChat Dependencies"
 
 msg_info "Building Frontend"

--- a/install/pangolin-install.sh
+++ b/install/pangolin-install.sh
@@ -45,7 +45,7 @@ SECRET_KEY=$(openssl rand -base64 48 | tr -dc 'A-Za-z0-9' | head -c 32)
 BADGER_VERSION=$(get_latest_github_release "fosrl/badger" "false")
 cd /opt/pangolin
 mkdir -p /opt/pangolin/config/{traefik,db,letsencrypt,logs}
-$STD npm ci
+$STD npm ci --allow-remote=all
 $STD npm run set:pg
 $STD npm run set:oss
 rm -rf server/private


### PR DESCRIPTION
## ✍️ Description

npm v12 disabled git/remote dependency fetching by default; bentopdf, librechat, pangolin, baserow, and cryptpad each pin a dependency that way and now fail with **EALLOWGIT or EALLOWREMOTE**

Added `--allow-git=all`/`--allow-remote=all` to their `npm ci`/`npm install` calls in both install and update paths.

## 🔗 Related Issue

Fixes #17006

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.