### PR TITLE
fix(shlink): preserve servers.json across web-client updates

### DIFF
--- a/ct/shlink.sh
+++ b/ct/shlink.sh
@@ -61,7 +61,12 @@ function update_script() {
 
   if [[ -d /opt/shlink-web-client ]]; then
     if check_for_gh_release "shlink-web-client" "shlinkio/shlink-web-client"; then
+      create_backup /opt/shlink-web-client/servers.json
+
       CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shlink-web-client" "shlinkio/shlink-web-client" "prebuild" "latest" "/opt/shlink-web-client" "shlink-web-client_*_dist.zip"
+
+      restore_backup
+
       msg_ok "Updated Web Client"
     fi
   fi


### PR DESCRIPTION
## ✍️ Description

`update_script()` in `ct/shlink.sh` does a `CLEAN_INSTALL=1 fetch_and_deploy_gh_release` for `/opt/shlink-web-client` on every update, with no backup/restore step. `CLEAN_INSTALL` wipes the target directory before redeploying, so the Web Client's `servers.json` (the configured server URL + API key) is deleted on every update. The Web Client then reverts to the "Add a server" onboarding screen, even though the Shlink API/backend itself is completely unaffected.

This is inconsistent with how `/opt/shlink` is already handled a few lines above in the same function: it wraps its `CLEAN_INSTALL` with `create_backup /opt/shlink/.env /opt/shlink/data` and `restore_backup`.

**Fix:** reuse the existing `create_backup` / `restore_backup` helpers around the web-client's `CLEAN_INSTALL`, the same way it's already done for `/opt/shlink`:

```bash
if [[ -d /opt/shlink-web-client ]]; then
  if check_for_gh_release "shlink-web-client" "shlinkio/shlink-web-client"; then
    create_backup /opt/shlink-web-client/servers.json

    CLEAN_INSTALL=1 fetch_and_deploy_gh_release "shlink-web-client" "shlinkio/shlink-web-client" "prebuild" "latest" "/opt/shlink-web-client" "shlink-web-client_*_dist.zip"

    restore_backup

    msg_ok "Updated Web Client"
  fi
fi
```

No other behavior changes. Scope kept minimal (update path only), matching the reported issue and the maintainer's suggestion to reuse `create_backup`.

**Testing performed** on a live LXC (Debian 13, installed via `ct/shlink.sh`):
- Confirmed `/opt/shlink-web-client/servers.json` existed and was populated before an update.
- Ran `update`; confirmed the file was gone afterward and the Web Client showed the onboarding screen, while the Shlink API (`/rest/health`) stayed healthy the whole time.
- Applied the same `create_backup`/`restore_backup` pattern manually on that container and re-ran the equivalent update steps; `servers.json` survived as expected.
- No hardcoded secrets, credentials, or IPs are introduced by this change.

## 🔗 Related Issue

Fixes # (reported directly to @MickLesk, no separate GitHub issue was filed — see this PR's discussion for the original report/reproduction)

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

Model used: GitHub Copilot (Claude Sonnet 5). The change was reviewed against the running fix on a live Shlink LXC before opening this PR (see Testing above).

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

No breaking change — the `breaking-change` advisory block is intentionally omitted.