### PR TITLE
Fix Sonarqube update script to add +x on sonar.sh

### DIFF
--- a/ct/sonarqube.sh
+++ b/ct/sonarqube.sh
@@ -54,6 +54,7 @@ function update_script() {
     cp -rp ${BACKUP_DIR}/extensions/ /opt/sonarqube/extensions/
     cp -p ${BACKUP_DIR}/conf/sonar.properties /opt/sonarqube/conf/sonar.properties
     rm -rf ${BACKUP_DIR}
+    chmod +x /opt/sonarqube/bin/linux-x86-64/sonar.sh
     chown -R sonarqube:sonarqube /opt/sonarqube
     msg_ok "Restored Backup"
 


### PR DESCRIPTION
## ✍️ Description
Sonarqube fails to start during update process due to missing +x on sonar.sh. The fix is to add the +x to file during update process.

## 🔗 Related Issue

Fixes #17054 

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [X] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---
