### PR TITLE
omnitools: allow remote action while npm ci

### DIFF
--- a/ct/omnitools.sh
+++ b/ct/omnitools.sh
@@ -40,6 +40,7 @@ function update_script() {
     msg_info "Building OmniTools"
     cd /opt/omnitools
     export HUSKY=0
+    $STD npm pkg delete scripts.prepare
     $STD npm ci
     $STD npm run build
     msg_ok "Built OmniTools"

--- a/ct/omnitools.sh
+++ b/ct/omnitools.sh
@@ -40,7 +40,6 @@ function update_script() {
     msg_info "Building OmniTools"
     cd /opt/omnitools
     export HUSKY=0
-    $STD npm pkg delete scripts.prepare
     $STD npm ci --allow-remote=all
     $STD npm run build
     msg_ok "Built OmniTools"

--- a/ct/omnitools.sh
+++ b/ct/omnitools.sh
@@ -41,7 +41,7 @@ function update_script() {
     cd /opt/omnitools
     export HUSKY=0
     $STD npm pkg delete scripts.prepare
-    $STD npm ci
+    $STD npm ci --allow-remote=all
     $STD npm run build
     msg_ok "Built OmniTools"
 

--- a/install/omnitools-install.sh
+++ b/install/omnitools-install.sh
@@ -24,7 +24,7 @@ msg_info "Building OmniTools"
 cd /opt/omnitools
 export HUSKY=0
 $STD npm pkg delete scripts.prepare
-$STD npm ci
+$STD npm ci --allow-remote=all
 $STD npm run build
 msg_ok "Built OmniTools"
 

--- a/install/omnitools-install.sh
+++ b/install/omnitools-install.sh
@@ -23,6 +23,7 @@ fetch_and_deploy_gh_release "omnitools" "iib0011/omni-tools" "tarball"
 msg_info "Building OmniTools"
 cd /opt/omnitools
 export HUSKY=0
+$STD npm pkg delete scripts.prepare
 $STD npm ci
 $STD npm run build
 msg_ok "Built OmniTools"

--- a/install/omnitools-install.sh
+++ b/install/omnitools-install.sh
@@ -23,7 +23,6 @@ fetch_and_deploy_gh_release "omnitools" "iib0011/omni-tools" "tarball"
 msg_info "Building OmniTools"
 cd /opt/omnitools
 export HUSKY=0
-$STD npm pkg delete scripts.prepare
 $STD npm ci --allow-remote=all
 $STD npm run build
 msg_ok "Built OmniTools"


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
husky bugging, so remove the prehook before npm ci
add ci allow remote to build correctly (npm12)

## 🔗 Related Issue

Fixes #17055

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
