### PR TITLE
vm: drop the discussions link from the summary

### DIFF
--- a/vm/debian-13-vm.sh
+++ b/vm/debian-13-vm.sh
@@ -675,4 +675,3 @@ if [ "$START_VM" == "yes" ]; then
 fi
 
 msg_ok "Completed successfully!\n"
-echo "More Info at https://github.com/community-scripts/ProxmoxVE/discussions/836"

--- a/vm/debian-vm.sh
+++ b/vm/debian-vm.sh
@@ -612,4 +612,3 @@ if [ "$START_VM" == "yes" ]; then
 fi
 
 msg_ok "Completed successfully!\n"
-echo "More Info at https://github.com/community-scripts/ProxmoxVE/discussions/836"


### PR DESCRIPTION
Moving to the script notes on the website, where it belongs. Two files, one line each.