### PR TITLE
fix(hermesagent): stop spurious root gateway after update

### DIFF
--- a/ct/hermesagent.sh
+++ b/ct/hermesagent.sh
@@ -52,6 +52,7 @@ function update_script() {
     set -a; source /etc/default/hermes; set +a
     /home/hermes/.local/bin/hermes update --yes
   '
+  # See https://github.com/community-scripts/ProxmoxVE/issues/17123
   mapfile -t root_gateway_pids < <(ps -eo user=,pid=,args= | awk '$1 == "root" && $0 ~ /\/home\/hermes\/\.hermes\/hermes-agent\/venv\/bin\/python -m hermes_cli\.main gateway run --replace$/ { print $2 }')
   if ((${#root_gateway_pids[@]})); then
     kill -TERM "${root_gateway_pids[@]}"

--- a/ct/hermesagent.sh
+++ b/ct/hermesagent.sh
@@ -52,6 +52,10 @@ function update_script() {
     set -a; source /etc/default/hermes; set +a
     /home/hermes/.local/bin/hermes update --yes
   '
+  mapfile -t root_gateway_pids < <(ps -eo user=,pid=,args= | awk '$1 == "root" && $0 ~ /\/home\/hermes\/\.hermes\/hermes-agent\/venv\/bin\/python -m hermes_cli\.main gateway run --replace$/ { print $2 }')
+  if ((${#root_gateway_pids[@]})); then
+    kill -TERM "${root_gateway_pids[@]}"
+  fi
   chown -R hermes:hermes /home/hermes
   msg_ok "Updated Hermes Agent"
 


### PR DESCRIPTION
## ✍️ Description

Stops the erroneous root-owned default gateway only when the root update path creates it. The existing `hermes` user service then recovers through its normal systemd restart policy.

## 🔗 Related Issue

Fixes #17123

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines. GPT-5.6, high reasoning.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.

## Verification

- Reproduced the root updater path locally with a mocked default gateway process and verified it receives `TERM`.
- Verified a root named-profile gateway is not matched.
- Verified the no-root-gateway case is a no-op.
- Ran `bash -n ct/hermesagent.sh`.
