### PR TITLE
feat(jitsi-meet): optional public setup (FQDN, Let's Encrypt, NAT, secure domain)

### DIFF
--- a/ct/jitsi-meet.sh
+++ b/ct/jitsi-meet.sh
@@ -17,6 +17,14 @@ var_version="${var_version:-13}"
 var_arm64="${var_arm64:-yes}"
 var_unprivileged="${var_unprivileged:-1}"
 
+# Optional public setup, read by the install script (all empty = LAN-only install as before).
+# Without the export they never reach the container.
+export var_jitsi_domain="${var_jitsi_domain:-}"
+export var_jitsi_le_email="${var_jitsi_le_email:-}"
+export var_jitsi_public_ip="${var_jitsi_public_ip:-}"
+export var_jitsi_admin_user="${var_jitsi_admin_user:-}"
+export var_jitsi_admin_pass="${var_jitsi_admin_pass:-}"
+
 header_info "$APP"
 variables
 color
@@ -50,4 +58,7 @@ description
 msg_ok "Completed Successfully!\n"
 echo -e "${CREATING}${GN}${APP} setup has been successfully initialized!${CL}"
 echo -e "${INFO}${YW}Access it using the following URL:${CL}"
-echo -e "${GATEWAY}${BGN}https://${IP}${CL}"
+echo -e "${GATEWAY}${BGN}https://${var_jitsi_domain:-$IP}${CL}"
+if [[ -n "${var_jitsi_domain}" ]]; then
+  echo -e "${INFO}${YW}Forward TCP 80/443 and UDP 10000 to the container. Secure-domain credentials (if enabled) are in ~/jitsi-meet.creds inside the container.${CL}"
+fi

--- a/install/jitsi-meet-install.sh
+++ b/install/jitsi-meet-install.sh
@@ -13,6 +13,29 @@ setting_up_container
 network_check
 update_os
 
+# Optional public setup. Leave the hostname empty for a LAN-only install
+# (container IP, self-signed certificate) - the previous default behaviour.
+if [[ -z "${var_jitsi_domain:-}" ]]; then
+  read -rp "${TAB3}Public hostname (FQDN, leave empty to use the container IP): " var_jitsi_domain || true
+fi
+var_jitsi_domain="${var_jitsi_domain:-$LOCAL_IP}"
+
+if [[ "$var_jitsi_domain" != "$LOCAL_IP" ]]; then
+  if [[ -z "${var_jitsi_le_email:-}" ]]; then
+    read -rp "${TAB3}E-mail for Let's Encrypt (leave empty for a self-signed certificate): " var_jitsi_le_email || true
+  fi
+  if [[ -z "${var_jitsi_public_ip:-}" ]]; then
+    read -rp "${TAB3}Public IP behind NAT (leave empty to detect via STUN): " var_jitsi_public_ip || true
+  fi
+  if [[ -z "${var_jitsi_admin_user:-}" ]]; then
+    read -rp "${TAB3}Admin user for secure domain (leave empty to let anyone create rooms): " var_jitsi_admin_user || true
+  fi
+  if [[ -n "${var_jitsi_admin_user:-}" && -z "${var_jitsi_admin_pass:-}" ]]; then
+    read -rsp "${TAB3}Admin password (leave empty to generate): " var_jitsi_admin_pass || true
+    echo
+  fi
+fi
+
 msg_info "Installing Dependencies"
 $STD apt install -y nginx
 msg_ok "Installed Dependencies"
@@ -25,10 +48,71 @@ setup_deb822_repo "jitsi" \
   ""
 
 msg_info "Installing Jitsi Meet"
-echo "jitsi-videobridge2 jitsi-videobridge/jvb-hostname string ${LOCAL_IP}" | debconf-set-selections
-echo "jitsi-meet-web-config jitsi-meet/cert-choice select Generate a new self-signed certificate" | debconf-set-selections
+echo "jitsi-videobridge2 jitsi-videobridge/jvb-hostname string ${var_jitsi_domain}" | debconf-set-selections
+if [[ -n "${var_jitsi_le_email:-}" ]]; then
+  # acme.sh (used by the packaged Let's Encrypt helper) refuses to install without cron
+  $STD apt install -y cron
+  echo "jitsi-meet-web-config jitsi-meet/cert-choice select Let's Encrypt certificates" | debconf-set-selections
+  echo "jitsi-meet-web-config jitsi-meet/email string ${var_jitsi_le_email}" | debconf-set-selections
+else
+  echo "jitsi-meet-web-config jitsi-meet/cert-choice select Generate a new self-signed certificate" | debconf-set-selections
+fi
+echo "jitsi-meet-web-config jitsi-meet/jaas-choice boolean false" | debconf-set-selections
 DEBIAN_FRONTEND=noninteractive $STD apt install -y jitsi-meet
 msg_ok "Installed Jitsi Meet"
+
+if [[ -n "${var_jitsi_public_ip:-}" ]]; then
+  msg_info "Configuring NAT mapping"
+  # JVB 2.3+ reads this from jvb.conf; sip-communicator.properties is no longer used
+  cat <<EOF >>/etc/jitsi/videobridge/jvb.conf
+ice4j {
+  harvest {
+    mapping {
+      static-mappings = [
+        { local-address = "${LOCAL_IP}", public-address = "${var_jitsi_public_ip}" }
+      ]
+    }
+  }
+}
+EOF
+  systemctl restart jitsi-videobridge2
+  msg_ok "Configured NAT mapping"
+fi
+
+if [[ -n "${var_jitsi_admin_user:-}" ]]; then
+  msg_info "Configuring Secure Domain"
+  # Only authenticated users may create rooms; guests join via the anonymous domain.
+  # https://jitsi.github.io/handbook/docs/devops-guide/secure-domain/
+  var_jitsi_admin_pass="${var_jitsi_admin_pass:-$(openssl rand -base64 18 | tr -dc 'a-zA-Z0-9' | cut -c1-16)}"
+  sed -i "0,/authentication = \"jitsi-anonymous\"/s//authentication = \"internal_hashed\"/" \
+    "/etc/prosody/conf.avail/${var_jitsi_domain}.cfg.lua"
+  cat <<EOF >>"/etc/prosody/conf.avail/${var_jitsi_domain}.cfg.lua"
+
+VirtualHost "guest.${var_jitsi_domain}"
+    authentication = "anonymous"
+    c2s_require_encryption = false
+EOF
+  cat <<EOF >>/etc/jitsi/jicofo/jicofo.conf
+jicofo {
+  authentication {
+    enabled = true
+    type = XMPP
+    login-url = "${var_jitsi_domain}"
+  }
+}
+EOF
+  sed -i "s|^\s*// anonymousdomain: 'guest.example.com',|    anonymousdomain: 'guest.${var_jitsi_domain}',|" \
+    "/etc/jitsi/meet/${var_jitsi_domain}-config.js"
+  $STD prosodyctl register "${var_jitsi_admin_user}" "${var_jitsi_domain}" "${var_jitsi_admin_pass}"
+  cat <<EOF >~/jitsi-meet.creds
+Jitsi Meet Secure Domain
+Admin User: ${var_jitsi_admin_user}
+Admin Password: ${var_jitsi_admin_pass}
+Add more users: prosodyctl register <name> ${var_jitsi_domain} <password>
+EOF
+  systemctl restart prosody jicofo jitsi-videobridge2
+  msg_ok "Configured Secure Domain"
+fi
 
 motd_ssh
 customize


### PR DESCRIPTION
## ✍️ Description

The current `jitsi-meet` script installs Jitsi with the container IP as hostname and a self-signed certificate. That is fine on a LAN, but anyone who wants a public server has to redo the hostname, certificate, NAT and access control by hand afterwards.

This PR adds five **optional** `var_jitsi_*` settings to the install script (read first, prompted only when unset, per the contribution guide). All of them default to empty, which keeps the previous LAN-only behaviour byte-for-byte:

| Variable | Effect |
|---|---|
| `var_jitsi_domain` | public hostname (FQDN) instead of the container IP |
| `var_jitsi_le_email` | Let's Encrypt via the debconf option shipped by the Jitsi package (`jitsi-meet/cert-choice` + `jitsi-meet/email`); installs `cron` because acme.sh refuses to install without it |
| `var_jitsi_public_ip` | static NAT mapping in `/etc/jitsi/videobridge/jvb.conf` (JVB 2.3+ no longer reads `sip-communicator.properties`) |
| `var_jitsi_admin_user` | secure domain: only authenticated users can create rooms, guests join via the anonymous domain ([Jitsi handbook](https://jitsi.github.io/handbook/docs/devops-guide/secure-domain/)) |
| `var_jitsi_admin_pass` | password for that user, generated when empty; written to `~/jitsi-meet.creds` because Jitsi has no `.env` to hold it |

The follow-up prompts only appear when a domain was entered, so the default interactive run gets exactly one extra question.

The `ct/` script exports the variables and prints the domain (plus a port-forwarding hint) in the footer. Prompts use `read … || true` so an unattended run with a closed stdin falls back to the defaults instead of tripping `catch_errors` (that is what happened in my first test).

**Testing** (Proxmox VE 9.2, unprivileged Debian 13 LXC, `mode=default` with `var_*` exported):

- All variables set (test domain, NAT IP, admin user; self-signed cert): prosody/jicofo/jvb/nginx/coturn active, HTTPS 200, JVB log shows `StaticMappingCandidateHarvester(face=<lan-ip>, mask=<public-ip>)`, jicofo logs `AuthConfig[enabled=true, type=XMPP, …]`, `anonymousdomain` set in config.js, prosody account created, creds file written.
- No variables set: identical to the current script — hostname is the container IP, no guest domain, no NAT block, no jicofo auth block, no creds file.
- Not exercised in the LXC test: the Let's Encrypt branch (needs a real DNS name). It only preseeds the package's own debconf choice; the same choice was used successfully on a VM with a real domain.

Website metadata: `app_vars` for the five variables should be added to the PocketBase record; I did not touch repo JSON per the contribution guide.

AI assistance: Claude Fable 5.1 via Claude Code, default reasoning level; the scripts were reviewed and tested by me as described above.

## 🔗 Related Issue

None

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [X] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VW4CxQz6dJqnTgj3RsKur
