### PR TITLE
fix(solidtime): prevent composer install from hanging on root prompt

### DIFF
--- a/ct/solidtime.sh
+++ b/ct/solidtime.sh
@@ -45,7 +45,7 @@ function update_script() {
 
     msg_info "Updating Application"
     cd /opt/solidtime
-    $STD composer install --no-dev --optimize-autoloader
+    COMPOSER_ALLOW_SUPERUSER=1 $STD composer install --no-dev --optimize-autoloader
     $STD npm install
     $STD npm run build
     $STD php artisan migrate --force


### PR DESCRIPTION
## ✍️ Description

`update_script` in `ct/solidtime.sh` runs `composer install` as root while the container's real stdin is still attached to the interactive terminal. Composer's built-in root-user safety check then prompts `Continue as root/super user [yes]?` and blocks indefinitely, since nothing is there to answer it — the update just hangs forever instead of failing or completing.

Fix: set `COMPOSER_ALLOW_SUPERUSER=1` before the `composer install` call, composer's documented env var for exactly this case (root/CI runs), which skips the prompt entirely.

Model: Claude Sonnet 5, via Claude Code (standard reasoning effort).

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [X] **AI was used** – I confirm the scripts were built using `AGENTS.md` and `.github/agents/pve-script-creator.agent.md` as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
