### PR TITLE
fix(hermesagent): wait for root gateway cleanup

### DIFF
--- a/ct/hermesagent.sh
+++ b/ct/hermesagent.sh
@@ -56,6 +56,11 @@ function update_script() {
   mapfile -t root_gateway_pids < <(ps -eo user=,pid=,args= | awk '$1 == "root" && $0 ~ /\/home\/hermes\/\.hermes\/hermes-agent\/venv\/bin\/python -m hermes_cli\.main gateway run --replace$/ { print $2 }')
   if ((${#root_gateway_pids[@]})); then
     kill -TERM "${root_gateway_pids[@]}"
+    for pid in "${root_gateway_pids[@]}"; do
+      while kill -0 "$pid" 2>/dev/null; do
+        sleep 0.1
+      done
+    done
   fi
   chown -R hermes:hermes /home/hermes
   msg_ok "Updated Hermes Agent"


### PR DESCRIPTION
## ✍️ Description

`#17126` terminates a root-owned Hermes gateway before restoring ownership of `/home/hermes`. The gateway removes `gateway.pid` during shutdown. If `chown -R` has already started walking that directory, GNU `chown` exits nonzero on the missing file and aborts an otherwise successful update.

This waits for each targeted root gateway PID to exit before starting `chown -R`. It keeps the existing ownership command strict, so unrelated ownership failures still stop the update.

AI assistance: GPT-5.6 Codex, high reasoning. I used it to investigate the race, prepare the five-line change, and verify the shell behavior. I reviewed the final diff and test output.

## 🔗 Related Issue

Fixes #17144

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – The change follows the existing Bash style and only changes `ct/hermesagent.sh`.
- [x] **Tested thoroughly** – `bash -n ct/hermesagent.sh` passes. A controlled root-gateway shutdown removed `gateway.pid`, then the same wait loop completed `chown -R` with clean ownership.
- [x] **No security risks** – The change only waits on PIDs that the existing root-gateway filter already selected. It does not add credentials, privilege escalation, or relaxed error handling.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [x] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
