### PR TITLE
update-apps: rewrite the retired Gitea base in every container before updating it

### DIFF
--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -178,14 +178,9 @@ function resolve_service_script() {
   return 1
 }
 
-# git.community-scripts.org was a Gitea mirror of the same repositories and has
-# been shut down, but containers built against it still carry it in
-# /usr/bin/update. The newer entrypoint repairs itself through the update helper;
-# the older one pulls ct/<app>.sh from the dead host directly and never gets that
-# far, so it has to be rewritten from here. Two plain substitutions rather than
-# one with a backreference: the host, then the /raw/<kind>/ segment Gitea puts
-# before the ref. Owner, repo and ref are never touched, so a fork stays on its
-# own fork.
+# The retired Gitea mirror. The old entrypoint pulls ct/<app>.sh straight from
+# it and never reaches the update helper that would repair itself, so rewrite it
+# here. Only host and /raw/<kind>/ change; owner, repo and ref are kept.
 function repair_update_url() {
   local container="$1"
   pct exec "$container" -- sh -c '
@@ -512,8 +507,7 @@ for container in $CHOICE; do
     sleep 5
   fi
 
-  #0.5) Containers built against the retired Gitea mirror cannot update at all
-  #     until the base URL is rewritten, so do that before anything reads it.
+  #0.5) Rewrite a retired Gitea base before anything reads it.
   repair_update_url "$container"
 
   #1) Detect service using the service name in the update command

--- a/tools/pve/update-apps.sh
+++ b/tools/pve/update-apps.sh
@@ -178,6 +178,29 @@ function resolve_service_script() {
   return 1
 }
 
+# git.community-scripts.org was a Gitea mirror of the same repositories and has
+# been shut down, but containers built against it still carry it in
+# /usr/bin/update. The newer entrypoint repairs itself through the update helper;
+# the older one pulls ct/<app>.sh from the dead host directly and never gets that
+# far, so it has to be rewritten from here. Two plain substitutions rather than
+# one with a backreference: the host, then the /raw/<kind>/ segment Gitea puts
+# before the ref. Owner, repo and ref are never touched, so a fork stays on its
+# own fork.
+function repair_update_url() {
+  local container="$1"
+  pct exec "$container" -- sh -c '
+    [ -f /usr/bin/update ] || exit 1
+    grep -q git.community-scripts.org /usr/bin/update || exit 1
+    sed -i \
+      -e "s|https://git[.]community-scripts[.]org/|https://raw.githubusercontent.com/|g" \
+      -e "s|/raw/branch/|/|g" -e "s|/raw/tag/|/|g" -e "s|/raw/commit/|/|g" \
+      /usr/bin/update
+  ' >/dev/null 2>&1 || return 1
+
+  echo -e "${BL}[INFO]${CL} Repaired update URL (Gitea -> GitHub) in container $container"
+  log_write "Container $container: rewrote the retired Gitea base in /usr/bin/update"
+}
+
 function detect_service() {
   local container="$1"
   local tmpdir update_file
@@ -488,6 +511,10 @@ for container in $CHOICE; do
     echo -e "${BL}[Info]${GN} Waiting For${BL} $container${CL}${GN} To Start ${CL} \n"
     sleep 5
   fi
+
+  #0.5) Containers built against the retired Gitea mirror cannot update at all
+  #     until the base URL is rewritten, so do that before anything reads it.
+  repair_update_url "$container"
 
   #1) Detect service using the service name in the update command
   detect_service $container


### PR DESCRIPTION
## ✍️ Description

`git.community-scripts.org` was a Gitea mirror of the same repositories and is gone.aA container built against it cannot update: the older entrypoint pulls ct/<app>.sh straight from the dead host, so it never reaches the update helper that repairs itself ([core#33](https://github.com/community-scripts/core/pull/33)).

Rewriting it from the host is the one place that reaches those containers, and it is where people already sweep all of them at once. Only the host and Gitea's /raw/<kind>/ segment change, so a fork keeps its own owner, repo and ref, and a container already on GitHub is left untouched.

## 🔗 Related Issue

Fixes # Discord

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

- [ ] **No AI used** – Scripts were written without AI assistance.
- [X] **AI was used** – I confirm the scripts were built using `AGENTS.md` and `.github/agents/pve-script-creator.agent.md` as guidance, and the output has been reviewed and corrected to match those guidelines.

Claude Opus 5, high reasoning.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
