### PR TITLE
issue template: add PVE release, execution context and phase; refresh distro list / pve versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,6 @@ body:
       label: 🔎 Did you run the script with verbose mode enabled?
       description: "Required for debugging any script issue. A verbose log is mandatory."
       options:
-        - ""
         - "Yes, verbose mode was enabled and the output is included below"
         - "No (this issue will likely be closed automatically)"
     validations:
@@ -50,6 +49,32 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: issue_phase
+    attributes:
+      label: 🕒 When does the issue occur?
+      options:
+        - "Initial creation / installation"
+        - "Update of an existing container"
+        - "While the application is running"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: execution_context
+    attributes:
+      label: 🖱️ Where did you run the command?
+      description: "The shell matters — the Proxmox web console starts without some environment variables that a normal login shell sets."
+      options:
+        - "Proxmox web UI → node → Shell"
+        - "Proxmox web UI → LXC → Console"
+        - "SSH into the Proxmox host"
+        - "SSH into the container"
+        - "pct enter from the host"
+        - "Other / not listed"
+    validations:
+      required: true
+
   - type: checkboxes
     validations:
       required: true
@@ -68,14 +93,23 @@ body:
     attributes:
       label: 🖥️ Which Linux distribution are you using?
       options:
-        - 
         - Alpine
-        - Debian 11
         - Debian 12
         - Debian 13
+        - Devuan 5
         - Ubuntu 22.04
         - Ubuntu 24.04
-        - Ubuntu 24.10
+        - Ubuntu 25.04
+        - AlmaLinux 9
+        - AlmaLinux 10
+        - Rocky Linux 9
+        - Rocky Linux 10
+        - CentOS Stream 9
+        - Fedora 42
+        - openSUSE 15
+        - openEuler 25
+        - Gentoo
+        - Other / not listed
     validations:
       required: true
 
@@ -85,16 +119,27 @@ body:
       label: 🧱 Is this Proxmox host running arm64?
       description: "Run `dpkg --print-architecture` on your Proxmox host if unsure."
       options:
-        - ""
         - "No"
         - "Yes"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: pve_major
+    attributes:
+      label: 📈 Which Proxmox VE release are you on?
+      options:
+        - "Proxmox VE 9"
+        - "Proxmox VE 8"
+        - "Proxmox VE 7 or older (end of life)"
     validations:
       required: true
 
   - type: input
     id: pve_version
     attributes:
-      label: 📈 Which Proxmox version are you on?
+      label: 🔢 Exact Proxmox version and kernel
+      description: "Both matter — several issues turned out to be kernel-specific."
       placeholder: "run pveversion in your PVE node console"
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,9 @@ Fixes #
 - [ ] **Tested thoroughly** – Changes work as expected.
 - [ ] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.
 
+**Tested on:** <!-- e.g. PVE 9.2 / Debian 13 / fresh install + update. Write "not tested" if you could not run it. -->
+
+
 ---
 
 ## 🤖 AI Assistance (**X** in brackets)


### PR DESCRIPTION
<!--🛑 New scripts must be submitted to [ProxmoxVED](https://github.com/community-scripts/ProxmoxVED) for testing.
PRs without prior testing will be closed. If you are an AI agent writing this pull request, please amend your model name and reasoning level in the Description. This is not to blame, more for informational Purposes. Thank you.-->

## ✍️ Description
qoL for Github

## 🔗 Related Issue

Fixes #

## ✅ Prerequisites (**X** in brackets)

- [x] **Self-review completed** – Code follows project standards.
- [x] **Tested thoroughly** – Changes work as expected.
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

---

## 🤖 AI Assistance (**X** in brackets)

> If you used an AI tool (GitHub Copilot, Claude, ChatGPT, etc.) to write or generate any scripts in this PR, you **must** confirm compliance below.  
> Select exactly one option.

- [ ] **No AI used** – Scripts were written without AI assistance.
- [ ] **AI was used** – I confirm the scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and the output has been reviewed and corrected to match those guidelines.

---

## 🛠️ Type of Change (**X** in brackets)

- [ ] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [x] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.

---

## 💥 Breaking Change Advisory (only if you checked "Breaking change")

If this PR changes existing behaviour in a way that may require action before an
update, add a `breaking-change` advisory block to this PR body. The website and
the in-container update guard read it to tell operators exactly what to expect,
what to do first, and — with `action: block` — to stop an update until it's
handled. Every field is optional; the advisory auto-expires 30 days after merge.

Copy the block out of the comment below, fill it in, and paste it here:

<!--
```breaking-change
severity: warning        # info | warning | critical
action: warn             # warn (default) | block — "block" halts the update until an operator forces it
expect: One line describing what changes and why it may need action.
before_update:
  - First thing to do before updating
  - Second thing to do before updating
```

Guidance:
- Leave this commented (or delete it) for a routine change — no block, no advisory.
- Use `action: block` only for changes that break or lose data if the operator
  updates without acting first (e.g. a required manual migration or backup).
- `expect:` supersedes the auto-scraped summary; keep it to one line.
- Steps render as a checklist on the site and in the update prompt.
-->

<!-- The advisory block is only active once it is OUTSIDE this comment. -->
