### PR TITLE
fix(iventoy): preserve release data and migrate legacy service launchers

### DIFF
--- a/ct/iventoy.sh
+++ b/ct/iventoy.sh
@@ -33,15 +33,43 @@ function update_script() {
 
   if check_for_gh_release "iventoy" "ventoy/PXE"; then
     msg_info "Stopping iVentoy"
-    $STD /opt/iventoy/iventoy.sh stop
+    systemctl stop iventoy
     msg_ok "Stopped iVentoy"
 
-    create_backup /opt/iventoy/data /opt/iventoy/iso
+    # Only preserve user state; data/iventoy.dat must match the new executable.
+    create_backup /opt/iventoy/data/config.dat /opt/iventoy/iso /opt/iventoy/user
     CLEAN_INSTALL=1 fetch_and_deploy_gh_release "iventoy" "ventoy/PXE" "prebuild" "latest" "/opt/iventoy" "iventoy-*-linux-$(arch_resolve x86_64-free arm64-trial).tar.gz"
     restore_backup
 
+    # Migrate existing services that invoke the Bash launcher with sh.
+    mkdir -p /etc/systemd/system/iventoy.service.d
+    cat <<EOF >/etc/systemd/system/iventoy.service.d/launcher.conf
+[Service]
+ExecStart=
+ExecStart=/bin/bash /opt/iventoy/iventoy.sh -R start
+ExecStop=
+ExecStop=/bin/bash /opt/iventoy/iventoy.sh stop
+PIDFile=/run/iventoy.pid
+RestartSec=5
+EOF
+    systemctl daemon-reload
+
     msg_info "Starting iVentoy"
-    $STD /opt/iventoy/iventoy.sh -R start
+    systemctl reset-failed iventoy
+    systemctl start iventoy
+    # The launcher can return success before the daemon fails initialization.
+    local i ready=0
+    for ((i = 0; i < 90; i++)); do
+      if systemctl is-active --quiet iventoy && curl -fsS --max-time 2 "${IVENTOY_HEALTH_URL:-http://127.0.0.1:26000/}" >/dev/null 2>&1; then
+        ready=1
+        break
+      fi
+      sleep 2
+    done
+    if [[ "$ready" -ne 1 ]]; then
+      msg_error "iVentoy did not become ready; check journalctl -u iventoy and /opt/iventoy/log/log.txt"
+      exit 1
+    fi
     msg_ok "Started iVentoy"
     msg_ok "Updated Successfully"
   fi


### PR DESCRIPTION
## ✍️ Description

Updating iVentoy from 1.0.39 to 1.0.41 can leave the web interface unavailable even though the updater reports success. Restoring the entire old `data/` directory replaces the new `iventoy.dat` with the previous release's payload, and the new executable exits with a checksum mismatch. Older installations also retain a systemd service that invokes the Bash launcher with `sh`, causing `Bad substitution`.

Preserve only `data/config.dat`, ISOs, and the `user/` directory across deployment. Keep the new release's program data, stop/start the daemon through systemd, and migrate existing launchers with a drop-in that uses Bash and tracks the PID file. Wait for both an active service and a successful HTTP response before reporting success; `IVENTOY_HEALTH_URL` supports a non-default web address.

The current installer already uses Bash, so this change targets the update path only and retains other service overrides such as ISO mount dependencies.

Validation:
- `bash -n`, ShellCheck (excluding the existing dynamic-source/external-variable diagnostics), `shfmt`, and `git diff --check` pass.
- Isolated update-flow tests use the actual upstream `create_backup` and `restore_backup` helpers. They verify matching new program data, preserved configuration/user files/ISOs, absent initial configuration, service migration, and nonzero exit on HTTP startup failure.
- The underlying Bash-launcher and matching-release-data repair restored HTTP 200 in an affected x86_64 LXC. The complete revised community updater has not yet been run against a live upgrade; ARM validation is pending.

AI assistance: OpenAI Codex (GPT-6; reasoning level not reported by the session). Reviewed using the linked ProxmoxVED contribution guidance.

## 🔗 Related Issue

No linked issue; reproduced in an existing iVentoy LXC.

## ✅ Prerequisites

- [x] **Self-review completed** – Code follows project standards.
- [ ] **Tested thoroughly** – Isolated regression checks pass; full live-update and ARM validation remain pending.
- [x] **No security risks** – No hardcoded secrets or new privilege requirements.

## 🤖 AI Assistance

- [ ] **No AI used**
- [x] **AI was used** – Scripts were built using [`AGENTS.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/AGENTS.md) and [`.github/agents/pve-script-creator.agent.md`](https://github.com/community-scripts/ProxmoxVED/blob/main/.github/agents/pve-script-creator.agent.md) as guidance, and reviewed against those guidelines.

## 🛠️ Type of Change

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
