### PR TITLE
fix(paperless-ngx): add --no-sync to the ExecStartPre inserted on update

### DIFF
--- a/ct/paperless-ngx.sh
+++ b/ct/paperless-ngx.sh
@@ -169,7 +169,8 @@ function update_script() {
       if ((BRIDGE_UPDATE == 0)); then
         sed -i 's|^ExecStart=.*|ExecStart=uv run --no-sync -- granian --interface asginl --ws --loop uvloop "paperless.asgi:application"|' /etc/systemd/system/paperless-webserver.service
         grep -q "document_index reindex" /etc/systemd/system/paperless-webserver.service ||
-          sed -i '/^ExecStart=/i ExecStartPre=uv run -- python manage.py document_index reindex --if-needed --no-progress-bar' /etc/systemd/system/paperless-webserver.service
+          sed -i '/^ExecStart=/i ExecStartPre=uv run --no-sync -- python manage.py document_index reindex --if-needed --no-progress-bar' /etc/systemd/system/paperless-webserver.service
+        sed -i 's|^ExecStartPre=uv run -- python manage.py document_index reindex|ExecStartPre=uv run --no-sync -- python manage.py document_index reindex|' /etc/systemd/system/paperless-webserver.service
         $STD systemctl daemon-reload
       fi
       cd /opt/paperless


### PR DESCRIPTION
## ✍️ Description

The update path patches `ExecStart` with `--no-sync`, but the line right below inserts an `ExecStartPre` **without** it:

```bash
# line 170 — correct
sed -i 's|^ExecStart=.*|ExecStart=uv run --no-sync -- granian …|' …

# line 172 — no --no-sync
grep -q "document_index reindex" … ||
  sed -i '/^ExecStart=/i ExecStartPre=uv run -- python manage.py document_index reindex …' …
```

That re-introduces exactly the startup network dependency #16479 set out to remove. Without `--no-sync`, `uv run` resolves the lockfile, and entries using `source = { url = … }` carry no metadata — so uv downloads those wheels just to generate it, including wheels for platforms the host never uses. On a cold boot, where the container starts before the network path is usable, the webserver then fails:

```
uv: Failed to generate package metadata for psycopg-c==3.3.4
    @ direct+https://…/psycopg_c-3.3.4-cp312-cp312-linux_aarch64.whl
  Caused by: Request failed after 3 retries in 48.8s
  Caused by: operation timed out
paperless-webserver.service: Control process exited, code=exited, status=2
```

(That is the **aarch64/cp312** wheel on an amd64 host running Python 3.13 — never used here, uv only wants its metadata.)

This PR does two things:

1. Adds `--no-sync` to the inserted line, so new insertions are correct.
2. Adds one `sed` that rewrites an **already present** `ExecStartPre` that lacks the flag. This matters because the preceding `grep -q` guard skips insertion whenever the line exists — so every installation that already received the broken line would keep it forever, through any number of updates. The added `sed` is idempotent: once `--no-sync` is present the pattern no longer matches.

Note the same line is already commented out in `install/paperless-ngx-install.sh` (line 154), so fresh installs are unaffected until their first update.

Not addressed here, because it seems like a maintainer call: the `PATCHES` array that writes `--no-sync` into consumer, scheduler and task-queue lives in the `Migrating old Paperless-ngx installation to uv` block, which only runs once. Installations that migrated before #16479 was merged keep `uv run --` in those three units and no later update revisits them. Described in #17209.

## 🔗 Related Issue

Fixes #17209

## ✅ Prerequisites (**X** in brackets)

- [X] **Self-review completed** – Code follows project standards.
- [X] **Tested thoroughly** – Changes work as expected.
- [X] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.

**Tested on:** PVE 9.2.11 (kernel 7.0.14-14-pve), Debian 13 CT, paperless-ngx 3.1.3, amd64. Both `sed` expressions were verified in isolation — correct rewrite, and unchanged output on a second run (idempotent) — and `bash -n` passes. For full disclosure: the complete update path was not re-run with this patch applied. The container had already been updated to 3.1.3 when the cause was found, and re-running an update purely to exercise the patch was not worth the downtime on a production instance.

---

## 🛠️ Type of Change (**X** in brackets)

- [X] 🐞 **Bug fix** – Resolves an issue without breaking functionality.
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.
- [ ] 🆕 **New script** – A fully functional and tested script or script set.
- [ ] 🌍 **Website update** – Changes to script metadata (PocketBase/website data).
- [ ] 🔧 **Refactoring / Code Cleanup** – Improves readability or maintainability without changing functionality.
- [ ] 📝 **Documentation update** – Changes to `README`, `AppName.md`, `CONTRIBUTING.md`, or other docs.
